### PR TITLE
download_file method does not work for https uris

### DIFF
--- a/template/suspenders.rb
+++ b/template/suspenders.rb
@@ -33,7 +33,10 @@ end
 
 def download_file(uri_string, destination)
   uri = URI.parse(uri_string)
-  contents = Net::HTTP.get(uri)
+  http = Net::HTTP.new(uri.host, uri.port)
+  http.use_ssl = true if uri_string =~ /^https/
+  request = Net::HTTP::Get.new(uri.path)
+  contents = http.request(request).body
   path = File.join(destination_root, destination)
   File.open(path, "w") { |file| file.write(contents) }
 end


### PR DESCRIPTION
The download_file method did not support https uris so the result of 

```
download_file "https://github.com/rails/jquery-ujs/raw/master/src/rails.js",
      "public/javascripts/rails.js"
```

was this

```
<html>
<head><title>400 The plain HTTP request was sent to HTTPS port</title></head>
<body bgcolor="white">
<center><h1>400 Bad Request</h1></center>
<center>The plain HTTP request was sent to HTTPS port</center>
<hr><center>nginx/0.7.67</center>
</body>
</html>
```

I've updated the download_file method to handle both http and https uris
