### PR TITLE
Updated template for newest versions of Clearance and Capybara

### DIFF
--- a/template/suspenders.rb
+++ b/template/suspenders.rb
@@ -112,8 +112,8 @@ action_mailer_host "production",  "#{app_name}.com"
 
 generate "rspec:install"
 generate "cucumber:install", "--rspec --capybara"
-generate "clearance"
-generate "clearance_features"
+generate "clearance:install"
+generate "clearance:features"
 
 create_file "public/stylesheets/sass/screen.scss"
 create_file "public/stylesheets/screen.css"
@@ -126,9 +126,6 @@ inject_into_file "features/support/env.rb",
                  %{Capybara.save_and_open_page_path = 'tmp'\n} +
                  %{Capybara.javascript_driver = :akephalos\n},
                  :before => %{Capybara.default_selector = :css}
-replace_in_file "features/support/env.rb",
-                %r{require .*capybara_javascript_emulation.*},
-                ''
 
 rake "flutie:install"
 


### PR DESCRIPTION
When installing a new site using suspenders this past weekend, I ran into three errors:

First, as mentioned in https://github.com/thoughtbot/suspenders/issues#issue/29 the require .*capybara_javascript_emulation line could not be found to be found to be replaced in features/support/env.rb.  It appears this line has been removed from the newest version of capybara.

Also, the generators for clearance have been changed from 

rails generate clearance and rails generate clearance_views

to

rails generate clearance:install and rails generate clearance:views

I changed these as well.
