### PR TITLE
use bundle exec

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -53,7 +53,7 @@ module Suspenders
     end
 
     def create_database
-      rake "db:create"
+      bundle_command('exec rake db:create')
     end
 
     def include_custom_gems


### PR DESCRIPTION
we should use bundle exec to avoid something like `You have already activated rake 0.9.3.beta.1, but your Gemfile requires rake 0.9.2.2. Using bundle exec may solve this.`
