### PR TITLE
Remove git commit

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -134,8 +134,6 @@ module Suspenders
 
     def init_git
       run "git init"
-      run "git add -A ."
-      run "git commit -m 'Initial commit - suspended project'"
     end
 
     def create_heroku_apps

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -117,7 +117,7 @@ module Suspenders
     end
 
     def setup_git
-      say "Initializing git and initial commit"
+      say "Initializing git"
       invoke :setup_gitignore
       invoke :init_git
     end


### PR DESCRIPTION
- Most developers want to fiddle with the output of Suspenders
  before crafting their first commit. Weird to have to git commit
  --amend.
- The git commit also makes it more difficult to run Suspenders
  as an upgrade path.
