### PR TITLE
Heroku announced Cedar is default stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ You can optionally create Heroku staging and production apps:
 
 This has the same effect as running:
 
-    heroku create app-staging --remote staging --stack cedar
-    heroku create app-production --remote production --stack cedar
+    heroku create app-staging --remote staging
+    heroku create app-production --remote production
 
 Clearance
 ---------

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -142,8 +142,8 @@ module Suspenders
         support_bin = File.expand_path(File.join('..', '..', '..', 'features', 'support', 'bin'))
         path_addition = "PATH=#{support_bin}:$PATH"
       end
-      run "#{path_addition} heroku create #{app_name}-production --remote=production --stack=cedar"
-      run "#{path_addition} heroku create #{app_name}-staging    --remote=staging    --stack=cedar"
+      run "#{path_addition} heroku create #{app_name}-production --remote=production"
+      run "#{path_addition} heroku create #{app_name}-staging    --remote=staging"
     end
 
     def document_heroku


### PR DESCRIPTION
- no need to specify Cedar as stack anymore
