### PR TITLE
Use `rails server` to get console output for Thin.

### DIFF
--- a/templates/Procfile
+++ b/templates/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec thin start -p $PORT
+web: bundle exec rails server thin -p $PORT


### PR DESCRIPTION
This fixes the problem that `thin start` does not output to the console. `rails server` will detect that Thin is installed, and also outputs to the console.
