### PR TITLE
Depend on therubyracer so this will work outside OS X

### DIFF
--- a/templates/Gemfile_additions
+++ b/templates/Gemfile_additions
@@ -5,6 +5,7 @@ gem 'formtastic'
 gem 'flutie'
 gem 'bourbon'
 gem 'airbrake'
+gem 'therubyracer'
 
 group :development do
   gem 'foreman'


### PR DESCRIPTION
OS X ships with a JavaScript runtime, but e.g. Debian does not. This commit adds `therubyracer` so we can all be on the same page.
