### PR TITLE
Configure RSpec

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -102,6 +102,11 @@ module Suspenders
     end
 
     def configure_rspec
+      remove_file '.rspec'
+      copy_file 'rspec', '.rspec'
+      replace_in_file 'spec/spec_helper.rb',
+        '# config.mock_with :mocha', 'config.mock_with :mocha'
+
       generators_config = <<-RUBY
     config.generators do |generate|
       generate.test_framework :rspec
@@ -111,6 +116,7 @@ module Suspenders
       generate.view_specs false
     end
       RUBY
+
       inject_into_class 'config/application.rb', 'Application', generators_config
     end
 
@@ -135,9 +141,6 @@ module Suspenders
 
     def generate_rspec
       generate 'rspec:install'
-      inject_into_file '.rspec', " --drb", :after => '--color'
-      replace_in_file 'spec/spec_helper.rb',
-        '# config.mock_with :mocha', 'config.mock_with :mocha'
     end
 
     def configure_capybara_webkit

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -28,13 +28,13 @@ module Suspenders
 
     def suspenders_customization
       invoke :remove_files_we_dont_need
+      invoke :customize_gemfile
       invoke :setup_development_environment
       invoke :setup_test_environment
       invoke :setup_staging_environment
       invoke :create_suspenders_views
       invoke :create_common_javascripts
       invoke :add_jquery_ui
-      invoke :customize_gemfile
       invoke :setup_database
       invoke :configure_app
       invoke :setup_stylesheets
@@ -62,6 +62,14 @@ module Suspenders
       say 'Setting up the test environment'
       build :enable_factory_girl_syntax
       build :test_factories_first
+      build :generate_rspec
+      build :configure_rspec
+
+      if options[:webkit]
+        build :configure_capybara_webkit
+      end
+
+      build :setup_guard_spork
     end
 
     def setup_staging_environment
@@ -115,17 +123,10 @@ module Suspenders
 
     def configure_app
       say 'Configuring app'
-      build :configure_rspec
       build :configure_action_mailer
-      build :generate_rspec
       build :configure_time_zone
       build :configure_time_formats
 
-      if options[:webkit]
-        build :configure_capybara_webkit
-      end
-
-      build :setup_guard_spork
       build :add_email_validator
       build :setup_default_rake_task
       build :setup_clearance

--- a/templates/rspec
+++ b/templates/rspec
@@ -1,0 +1,3 @@
+--colour
+--format documentation
+--profile


### PR DESCRIPTION
- Use `--profile` flag to display slowest-running specs.
- Use `--format documentation` flag to confirm specs are readable.
- Remove `--drb` flag because Spork should be replaced by Zeus.
- Re-organize methods so `generate_rspec` only generates RSpec and
  `configure_rspec` only configures RSpec.
