### PR TITLE
Clean up .env and Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: bundle exec thin start -p $PORT -e $RACK_ENV

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -226,7 +226,6 @@ module Suspenders
 
     def copy_miscellaneous_files
       copy_file 'errors.rb', 'config/initializers/errors.rb'
-      copy_file 'Procfile'
     end
 
     def customize_error_pages

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -130,7 +130,6 @@ module Suspenders
       build :add_email_validator
       build :setup_default_rake_task
       build :setup_clearance
-      say 'Adding sample Procfile. Copy sample.env to .env'
       build :setup_foreman
     end
 

--- a/templates/sample.env
+++ b/templates/sample.env
@@ -1,14 +1,2 @@
-# Foreman reads environment variables from a .env file. For more info, see
-# http://blog.akash.im/per-project-environment-variables-with-forema
-
-# To use foreman:
-# - Copy this file to `.env` on your local machine
-# - Add `.env` to your `.gitignore` file
-# - On Heroku, do `heroku config:add RACK_ENV=(staging|production)
-
-
-# Needed for thin.
+# http://ddollar.github.com/foreman/
 RACK_ENV=development
-
-# Set as appropriate for environment.
-HOSTNAME=localhost:3000


### PR DESCRIPTION
- Remove duplicate Procfile added in 6b48ec6d29. The new duplicate was
  not being used in the script. The older templates/Procfile was used.
- Remove duplicate `copy_file 'Procfile'` command. Keep new version so
  there are fewer commands in non-intention-revealing method,
  `copy_miscellaneous_files`.
- Remove output instructing user to copy sample.env to .env. This output
  is likely to get lost in the rest of the ouput. We also want to
  automate that step in #120.
- Remove unnecessary comments: 1) No need to instruct user to copy file
  because they should use script/setup. 2) Do not need to add .env to
  .gitignore because Suspenders already ignores it. 3) Do not instruct
  all developers to add Heroku config variables. That is a process
  outside the scope of this file, better documented in
  https://github.com/thoughtbot/guides/tree/master/protocol.
- Link to official documentation in sample.env.
- Remove HOSTNAME from sample.env. Developers should be able to override
  the port from the command line.
