### PR TITLE
Add better_errors gem to default set

### DIFF
--- a/templates/Gemfile_additions
+++ b/templates/Gemfile_additions
@@ -9,6 +9,7 @@ gem 'airbrake'
 group :development do
   gem 'foreman'
   gem 'better_errors'
+  gem 'binding_of_caller'
 end
 
 group :development, :test do


### PR DESCRIPTION
There is a beautiful gem [better_errors](https://github.com/charliesome/better_errors) which adds much more abilities to the default rails error screen.
