### PR TITLE
Force rspec expect syntax

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -112,6 +112,13 @@ module Suspenders
         '# config.mock_with :mocha',
         'config.mock_with :mocha'
 
+      rspec_expect_syntax = <<-RUBY
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+      RUBY
+
       generators_config = <<-RUBY
     config.generators do |generate|
       generate.test_framework :rspec
@@ -122,6 +129,8 @@ module Suspenders
     end
       RUBY
 
+      inject_into_file 'spec/spec_helper.rb', rspec_expect_syntax,
+        :after => 'RSpec.configure do |config|'
       inject_into_class 'config/application.rb', 'Application', generators_config
     end
 

--- a/templates/factories_spec.rb
+++ b/templates/factories_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 FactoryGirl.factories.map(&:name).each do |factory_name|
   describe "the #{factory_name} factory" do
     it 'is valid' do
-      build(factory_name).should be_valid
+      expect(build(factory_name)).to be_valid
     end
   end
 end


### PR DESCRIPTION
Force the new rspec `expect` syntax. Using `.should` will raise an error.
