### PR TITLE
Move script/setup to bin/setup

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -20,8 +20,8 @@ module Suspenders
     end
 
     def provide_setup_script
-      copy_file 'script_setup', 'script/setup'
-      run 'chmod a+x script/setup'
+      copy_file 'bin_setup', 'bin/setup'
+      run 'chmod a+x bin/setup'
     end
 
     def enable_factory_girl_syntax
@@ -181,7 +181,7 @@ module Suspenders
     end
 
     def setup_foreman
-      copy_file 'sample.env', 'sample.env'
+      copy_file 'sample.env', '.sample.env'
       copy_file 'Procfile', 'Procfile'
     end
 

--- a/templates/Procfile
+++ b/templates/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec rails server thin -p $PORT
+web: bundle exec rails server thin -p $PORT -e $RACK_ENV

--- a/templates/bin_setup
+++ b/templates/bin_setup
@@ -5,4 +5,7 @@
 
 bundle install --binstubs=bin/stubs
 bundle exec rake db:setup
-cp sample.env .env
+
+if [ ! -f .env ]; then
+  cp .sample.env .env
+fi


### PR DESCRIPTION
- `bin/setup` is more in line with Rails 4.0 conventions.
- Include `-e $RACK_ENV` in `Procfile` per Heroku docs.
- Make bin/setup idempotent by only copying `.sample.env` to `.env`
  `.env` if file does not exist yet.
- Change `sample.env` to a `.sample.env` so it shows less often.
