### PR TITLE
Configure Strong Parameters

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -116,7 +116,7 @@ module Suspenders
   end
       RUBY
 
-      generators_config = <<-RUBY
+      config = <<-RUBY
     config.generators do |generate|
       generate.test_framework :rspec
       generate.helper false
@@ -124,18 +124,32 @@ module Suspenders
       generate.javascript_engine false
       generate.view_specs false
     end
+
       RUBY
 
       inject_into_file 'spec/spec_helper.rb', rspec_expect_syntax,
         :after => 'RSpec.configure do |config|'
-      inject_into_class 'config/application.rb', 'Application', generators_config
+      inject_into_class 'config/application.rb', 'Application', config
+    end
+
+    def blacklist_active_record_attributes
+      config = <<-RUBY
+    config.active_record.whitelist_attributes = false
+
+      RUBY
+      inject_into_class 'config/application.rb', 'Application', config
+    end
+
+    def configure_strong_parameters
+      copy_file 'strong_parameters', 'config/initializers/strong_parameters.rb'
     end
 
     def configure_time_zone
-      time_zone_config = <<-RUBY
+      config = <<-RUBY
     config.active_record.default_timezone = :utc
+
       RUBY
-      inject_into_class "config/application.rb", "Application", time_zone_config
+      inject_into_class 'config/application.rb', 'Application', config
     end
 
     def configure_time_formats

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -107,6 +107,8 @@ module Suspenders
     def configure_app
       say 'Configuring app'
       build :configure_action_mailer
+      build :blacklist_active_record_attributes
+      build :configure_strong_parameters
       build :configure_time_zone
       build :configure_time_formats
       build :disable_xml_params

--- a/templates/strong_parameters.rb
+++ b/templates/strong_parameters.rb
@@ -1,0 +1,1 @@
+ActiveRecord::Base.send :include, ActiveModel::ForbiddenAttributesProtection


### PR DESCRIPTION
- Activate strong parameters in all ActiveRecord models.
- Blacklist ActiveRecord attributes to remove need for `attr_accessible`
  in models and allow mass assignment inside model code and specs.
