### PR TITLE
Add .rb extension to strong_parameters file copy.

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -141,7 +141,7 @@ module Suspenders
     end
 
     def configure_strong_parameters
-      copy_file 'strong_parameters', 'config/initializers/strong_parameters.rb'
+      copy_file 'strong_parameters.rb', 'config/initializers/strong_parameters.rb'
     end
 
     def configure_time_zone


### PR DESCRIPTION
The .rb extension was missing which would cause the copy to fail, and
the whole process to stop.
