### PR TITLE
Add staging config variables to Heroku

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -225,6 +225,7 @@ module Suspenders
       path_addition = override_path_for_tests
       run "#{path_addition} heroku create #{app_name}-production --remote=production"
       run "#{path_addition} heroku create #{app_name}-staging --remote=staging"
+      run "#{path_addition} heroku config:add RACK_ENV=staging RAILS_ENV=staging --remote=staging"
     end
 
     def create_github_repo(repo_name)


### PR DESCRIPTION
These two variables are necessary to make the staging environment use staging
configuration.
