### PR TITLE
Add Flutie to Gemfile

### DIFF
--- a/templates/Gemfile_clean
+++ b/templates/Gemfile_clean
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'airbrake'
 gem 'bourbon'
+gem 'flutie'
 gem 'high_voltage'
 gem 'jquery-rails'
 gem 'pg'
@@ -13,8 +14,8 @@ gem 'strong_parameters'
 gem 'thin'
 
 group :assets do
-  gem 'sass-rails'
   gem 'coffee-rails'
+  gem 'sass-rails'
   gem 'uglifier'
 end
 


### PR DESCRIPTION
- We use `body_class` and `page_title` view helpers in the application
  layout, which come from Flutie.
- We had previously removed Flutie because Flutie 1.x included lots of
  styles which have been superceded by Bourbon/Neat/Smash.
- Flutie 2.x is just the view helpers and we think `body_class` and
  `page_title` are valuable.
