### PR TITLE
Fix staging and production env

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -37,7 +37,7 @@ module Suspenders
       copy_file 'smtp.rb', 'config/initializers/smtp.rb'
 
       prepend_file 'config/environments/production.rb',
-        "require Rails.root.join('config/initializers/smtp')"
+        "require Rails.root.join('config/initializers/smtp')\n"
 
       config = <<-RUBY
   config.action_mailer.delivery_method = :smtp
@@ -52,7 +52,7 @@ module Suspenders
       run 'cp config/environments/production.rb config/environments/staging.rb'
 
       prepend_file 'config/environments/staging.rb',
-        "Mail.register_interceptor RecipientInterceptor.new(ENV['EMAIL_RECIPIENTS'])"
+        "Mail.register_interceptor RecipientInterceptor.new(ENV['EMAIL_RECIPIENTS'])\n"
     end
 
     def initialize_on_precompile


### PR DESCRIPTION
Fixed problems with Staging and Production environment

I got this error: 

```
/app/config/environments/staging.rb:1: syntax error, unexpected tIDENTIFIER, expecting $end
...ENV['EMAIL_RECIPIENTS'])require Rails.root.join('config/init..
```
