### PR TITLE
configure strong_parameters to raise in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ This has the same effect as running:
 Dependencies
 ------------
 
+Suspenders requires Ruby 1.9 or greater.
+
 Some gems included in Suspenders have native extensions. You should have GCC
 installed on your machine before generating an app with Suspenders.
 

--- a/lib/suspenders/actions.rb
+++ b/lib/suspenders/actions.rb
@@ -15,10 +15,15 @@ module Suspenders
     end
 
     def action_mailer_host(rails_env, host)
+      host_config = "config.action_mailer.default_url_option = { host: '#{host}' }"
+      configure_environment(rails_env, host_config)
+    end
+
+    def configure_environment(rails_env, config)
       inject_into_file(
         "config/environments/#{rails_env}.rb",
-        "\n\n  config.action_mailer.default_url_options = { :host => '#{host}' }",
-        :before => "\nend"
+        "\n\n  #{config}",
+        before: "\nend"
       )
     end
 

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -14,9 +14,14 @@ module Suspenders
       remove_file 'app/assets/images/rails.png'
     end
 
-    def raise_delivery_errors
+    def raise_on_delivery_errors
       replace_in_file 'config/environments/development.rb',
         'raise_delivery_errors = false', 'raise_delivery_errors = true'
+    end
+
+    def raise_on_unpermitted_parameters
+      configure_environment 'development',
+        'config.action_controller.action_on_unpermitted_parameters = :raise'
     end
 
     def provide_setup_script

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -65,7 +65,8 @@ module Suspenders
 
     def setup_development_environment
       say 'Setting up the development environment'
-      build :raise_delivery_errors
+      build :raise_on_delivery_errors
+      build :raise_on_unpermitted_parameters
       build :provide_setup_script
     end
 


### PR DESCRIPTION
This brings the behavior inline with the the attr_accessible mass
assignment protection behavior in rails 3.2 and can help save some serious
head scratching when an action isn't working as you'd expect.
