### PR TITLE
Fix ActionMailer delivery method configuration

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -40,6 +40,7 @@ module Suspenders
         "require Rails.root.join('config/initializers/smtp')\n"
 
       config = <<-RUBY
+
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = SMTP_SETTINGS
       RUBY


### PR DESCRIPTION
The `delivery_method` configuration line was being appended to an
existing line (which was a comment, thus no error).

_Before_:

``` ruby
# config.action_mailer.raise_delivery_errors = false  config.action_mailer.delivery_method = :smtp
config.action_mailer.smtp_settings = SMTP_SETTINGS
```

_After_:

``` ruby
# config.action_mailer.raise_delivery_errors = false
config.action_mailer.delivery_method = :smtp
config.action_mailer.smtp_settings = SMTP_SETTINGS
```
