### PR TITLE
Fix mailer configuration

### DIFF
--- a/lib/suspenders/actions.rb
+++ b/lib/suspenders/actions.rb
@@ -15,7 +15,7 @@ module Suspenders
     end
 
     def action_mailer_host(rails_env, host)
-      host_config = "config.action_mailer.default_url_option = { host: '#{host}' }"
+      host_config = "config.action_mailer.default_url_options = { host: '#{host}' }"
       configure_environment(rails_env, host_config)
     end
 


### PR DESCRIPTION
default_url_option should be plural, default_url_options

http://api.rubyonrails.org/classes/ActionMailer/Base.html#label-Generating+URLs

I can't find mention of a singular form of this setting/method in any 
version of rails.
