### PR TITLE
Test Factory only if object respond_to :valid?

### DIFF
--- a/templates/factories_spec.rb
+++ b/templates/factories_spec.rb
@@ -3,7 +3,8 @@ require 'spec_helper'
 FactoryGirl.factories.map(&:name).each do |factory_name|
   describe "the #{factory_name} factory" do
     it 'is valid' do
-      expect(build(factory_name)).to be_valid
+      factory = build(factory_name)
+      expect(factory).to be_valid if factory.respond_to?(:valid?)
     end
   end
 end


### PR DESCRIPTION
If I use Factory Girl for non-AR objects, I Am get failed test, because this object does not have valid? method.

```
FactoryGirl.define do
  factory :bundle, class: Hash do
    initialize_with do
      { test: :fail }
    end
  end
end
```
