### PR TITLE
Use New Relic RPM gem >= 3.5.7 for Heroku accuracy

### DIFF
--- a/templates/Gemfile_clean
+++ b/templates/Gemfile_clean
@@ -43,5 +43,5 @@ group :test do
 end
 
 group :staging, :production do
-  gem 'newrelic_rpm'
+  gem 'newrelic_rpm', '>= 3.5.7'
 end


### PR DESCRIPTION
http://blog.newrelic.com/2013/02/21/using-new-relic-on-heroku-read-how-our-new-ruby-agent-measures-queue-time/
