### PR TITLE
Remove jQuery UI

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -104,11 +104,6 @@ module Suspenders
       directory 'javascripts', 'app/assets/javascripts'
     end
 
-    def add_jquery_ui
-      inject_into_file 'app/assets/javascripts/application.js',
-        "//= require jquery-ui\n", :before => '//= require_tree .'
-    end
-
     def use_postgres_config_template
       template 'postgresql_database.yml.erb', 'config/database.yml',
         :force => true

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -30,7 +30,6 @@ module Suspenders
       invoke :setup_staging_environment
       invoke :create_suspenders_views
       invoke :create_common_javascripts
-      invoke :add_jquery_ui
       invoke :configure_app
       invoke :setup_stylesheets
       invoke :copy_miscellaneous_files
@@ -105,11 +104,6 @@ module Suspenders
     def create_common_javascripts
       say 'Pulling in some common javascripts'
       build :create_common_javascripts
-    end
-
-    def add_jquery_ui
-      say 'Add jQuery ui to the standard application.js'
-      build :add_jquery_ui
     end
 
     def configure_app


### PR DESCRIPTION
Only 40% of our recent projects have been including jQuery UI.

The intention of Suspenders is that we're including dependencies only if we
find ourselves using it on just about every thoughtbot project.
