### PR TITLE
Cache static assets, log to STDOUT in staging/prod

### DIFF
--- a/templates/Gemfile_clean
+++ b/templates/Gemfile_clean
@@ -44,4 +44,5 @@ end
 
 group :staging, :production do
   gem 'newrelic_rpm', '>= 3.5.7'
+  gem 'rails_12factor'
 end


### PR DESCRIPTION
The rails_12factor gem currently does two things in staging and production
environments:
- config.serve_static_assets = true
- Logger.new(STDOUT)

Rather than manage the intricacies of how these settings will change in
future versions of Rails, I think we should rely on the gem.

We are using this in staging and production on a current thoughtbot project.

https://devcenter.heroku.com/articles/rails-integration-gems
https://github.com/heroku/rails_12factor
https://github.com/heroku/rails_serve_static_assets
https://github.com/heroku/rails_stdout_logging
