### PR TITLE
Replace Bourne with RSpec Mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,12 @@ And gems only for staging and production like:
 
 And testing gems like:
 
-* [Bourne](https://github.com/thoughtbot/bourne) and
-  [Mocha](https://github.com/freerange/mocha) for stubbing and spying
 * [Capybara](https://github.com/jnicklas/capybara) and
   [Capybara Webkit](https://github.com/thoughtbot/capybara-webkit) for
   integration testing
 * [Factory Girl](https://github.com/thoughtbot/factory_girl) for test data
 * [RSpec](https://github.com/rspec/rspec) for unit testing
+* [RSpec Mocks](https://github.com/rspec/rspec-mocks) for stubbing and spying
 * [Shoulda Matchers](https://github.com/thoughtbot/shoulda-matchers) for common
   RSpec matchers
 * [Timecop](https://github.com/jtrupiano/timecop-console) for testing time

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -138,10 +138,6 @@ module Suspenders
       copy_file 'rspec', '.rspec'
       prepend_file 'spec/spec_helper.rb', simplecov_init
 
-      replace_in_file 'spec/spec_helper.rb',
-        '# config.mock_with :mocha',
-        'config.mock_with :mocha'
-
       config = <<-RUBY
   config.expect_with :rspec do |expect|
     expect.syntax = :expect

--- a/templates/Gemfile_clean
+++ b/templates/Gemfile_clean
@@ -26,12 +26,11 @@ end
 
 group :development, :test do
   gem 'factory_girl_rails'
-  gem 'rspec-rails'
+  gem 'rspec-rails', '>= 2.14'
   gem 'sham_rack'
 end
 
 group :test do
-  gem 'bourne', require: false
   gem 'capybara-webkit', '>= 0.14.1'
   gem 'database_cleaner'
   gem 'launchy'


### PR DESCRIPTION
We explicitly request RSpec Rails >= 2.14 in order to get the stubbing
and spying features of RSpec Mocks:

https://github.com/rspec/rspec-mocks/commit/e8cae54c46f20128ec16c4355f5898c48a8d2d91#commitcomment-3240149

We don't need to include the `rspec-mocks` gem directly in the `Gemfile`
or directly configure it in `spec/spec_helper.rb` because `rspec-rails`
includes it as a dependency and defaults the `mock_with` configuration
to it.

Benefits:
- Officially supported by RSpec team.
- Compact.
- Good failure messages.
