### PR TITLE
Remove dependency on `hub` gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     suspenders (1.4.0)
       bundler (~> 1.3)
-      hub (~> 1.10)
       rails (= 4.0.0)
 
 GEM
@@ -57,7 +56,6 @@ GEM
     gherkin (2.12.0-x86-mingw32)
       multi_json (~> 1.3)
     hike (1.2.3)
-    hub (1.10.6)
     i18n (0.6.4)
     mail (2.5.4)
       mime-types (~> 1.16)
@@ -96,7 +94,7 @@ GEM
       activesupport (>= 3.0)
       sprockets (~> 2.8)
     thor (0.18.1)
-    thread_safe (0.1.0)
+    thread_safe (0.1.2)
       atomic
     tilt (1.4.1)
     treetop (1.4.14)

--- a/README.md
+++ b/README.md
@@ -91,8 +91,10 @@ This has the same effect as running:
 Github
 ------
 
-You can optionally create a Github repository:
+You can optionally create a Github repository for the suspended Rails app. It
+requires that you have [Hub](https://github.com/github/hub) on your system:
 
+    curl http://hub.github.com/standalone -sLo ~/bin/hub && chmod +x ~/bin/hub
     suspenders app --github organization/project
 
 This has the same effect as running:

--- a/suspenders.gemspec
+++ b/suspenders.gemspec
@@ -6,7 +6,6 @@ require 'date'
 Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.2'
   s.add_dependency 'bundler', '~> 1.3'
-  s.add_dependency 'hub', '~> 1.10'
   s.add_dependency 'rails', '4.0.0'
   s.add_development_dependency 'aruba', '~> 0.5.2'
   s.add_development_dependency 'cucumber', '~> 1.2'


### PR DESCRIPTION
Note in `--github` flag section of the README that the standalone version of
`hub` is required for it to work.
