### PR TITLE
Remove old Rails 3 asset precompilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ Suspenders also comes with:
 * Override recipient emails in staging environment.
 * Rails' flashes set up and in application layout.
 * A few nice time formats set up for localization.
-* [Heroku-recommended asset pipeline
-  settings](https://devcenter.heroku.com/articles/rails3x-asset-pipeline-cedar/).
+* [Heroku-recommended
+  settings](https://devcenter.heroku.com/articles/rails4-getting-started).
 
 Heroku
 ------

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -78,12 +78,6 @@ module Suspenders
         "Mail.register_interceptor RecipientInterceptor.new(ENV['EMAIL_RECIPIENTS'])\n"
     end
 
-    def initialize_on_precompile
-      inject_into_file 'config/application.rb',
-        "\n    config.assets.initialize_on_precompile = false",
-        :after => 'config.assets.enabled = true'
-    end
-
     def create_partials_directory
       empty_directory 'app/views/application'
     end

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -90,7 +90,6 @@ module Suspenders
     def setup_staging_environment
       say 'Setting up the staging environment'
       build :setup_staging_environment
-      build :initialize_on_precompile
     end
 
     def create_suspenders_views


### PR DESCRIPTION
Now unnecessary in Rails 4.

https://devcenter.heroku.com/articles/rails-asset-pipeline#troubleshooting
