### PR TITLE
Force `bundle install` instead of Travis default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,7 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
+install:
+  - bundle install
 notifications:
   email: false


### PR DESCRIPTION
Travis CI runs `bundle install --deployment` by default and will install
the gems into `vendor/bundle`, thus making `bundler` gem unavailable
during the tests.
