### PR TITLE
Require spec/spec_helper by default.

### DIFF
--- a/templates/rspec
+++ b/templates/rspec
@@ -1,3 +1,4 @@
 --colour
 --drb
 --profile
+--require spec/spec_helper


### PR DESCRIPTION
This means that spec files (e.g. user_spec.rb) don't need `require
'spec_helper'` at the top.
