### PR TITLE
Remove --drb from .rspec

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+master (unreleased)
+
+* Remove `--drb` now that we aren't using Spork.
+
 1.5.0 (August 3, 2013)
 
 * Add Neat.

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -79,7 +79,6 @@ module Suspenders
       build :configure_background_jobs_for_rspec
       build :enable_database_cleaner
       build :configure_capybara_webkit
-      build :setup_guard_spork
     end
 
     def setup_production_environment

--- a/templates/rspec
+++ b/templates/rspec
@@ -1,3 +1,2 @@
 --colour
---drb
 --profile


### PR DESCRIPTION
- We're no longer configuring spork and guard.
- This flag prints a warning on each spec run without spork.
