### PR TITLE
Remove Unused Method

### DIFF
--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -175,10 +175,6 @@ module Suspenders
       say "Remember to run 'rails generate airbrake' with your API key."
     end
 
-    def run_bundle
-      # Let's not: We'll bundle manually at the right spot
-    end
-
     protected
 
     def get_builder_class


### PR DESCRIPTION
- While going through the source I noticed the method `run_bundle`
  was not being called and can be removed.
