### PR TITLE
Use Rails-recommended binstub for RSpec

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -134,6 +134,11 @@ module Suspenders
       copy_file 'spec_helper.rb', 'spec/spec_helper.rb'
     end
 
+    def use_rspec_binstub
+      run 'bundle binstub rspec-core'
+      run 'rm bin/autospec'
+    end
+
     def configure_background_jobs_for_rspec
       copy_file 'background_jobs_rspec.rb', 'spec/support/background_jobs.rb'
       run 'rails g delayed_job:active_record'

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -49,7 +49,7 @@ module Suspenders
     def customize_gemfile
       build :replace_gemfile
       build :set_ruby_to_version_being_used
-      bundle_command 'install --binstubs=bin/stubs'
+      bundle_command 'install'
     end
 
     def setup_database
@@ -76,6 +76,7 @@ module Suspenders
       build :test_factories_first
       build :generate_rspec
       build :configure_rspec
+      build :use_rspec_binstub
       build :configure_background_jobs_for_rspec
       build :enable_database_cleaner
       build :configure_capybara_webkit

--- a/templates/suspenders_gitignore
+++ b/templates/suspenders_gitignore
@@ -4,7 +4,6 @@
 *.swp
 .bundle
 .sass-cache/
-bin/stubs
 coverage/*
 db/*.sqlite3
 db/schema.rb


### PR DESCRIPTION
Some Ruby gems provide an executable to run its contained Ruby program. We
most commonly use `rails`, `rspec`, and `rake`.

When we type `rspec` within the root of our project, Rubygems will use the
latest version of the RSpec gem, not the version specified in the project's
`Gemfile`. That's a problem that Bundler's `bundle exec` solves.

It's tedious to type `bundle exec`, however. We previously solved that
problem via a directory convention for Bundler's binstubs and adding that
directory to our shell's `PATH`.

Running `bundle install --binstubs=bin/stubs` generates binstub files in the
`bin/stubs` directory for all the executables specified by gems in our
`Gemfile`. Running `./bin/stubs/rspec` is now the same thing as running
`bundle exec rspec`.

Adding `export PATH="./bin/stubs:$PATH"` lets us just type `rspec`, have the
binstub be invoked, and therefore the correct version of RSpec be used for
the project.

We previously used `./bin/stubs` as our binstubs directory convention and
ignored the directory in version control. We used that convention instead of
`./bin` because we didn't want to gitignore the already-existing `./bin`
directory and we didn't want to replace the critical `bin/rails`.

The community is moving towards a convention of using `./bin`:
- Rails is using `./bin` instead of `./script` starting with Rails 4.
- The default Bundler behavior is to use `./bin`.
