### PR TITLE
Remove Turbolinks

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -96,6 +96,12 @@ module Suspenders
         :force => true
     end
 
+    def remove_turbolinks
+      replace_in_file 'app/assets/javascripts/application.js',
+        /\/\/= require turbolinks\n/,
+        ''
+    end
+
     def create_common_javascripts
       directory 'javascripts', 'app/assets/javascripts'
     end

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -29,7 +29,7 @@ module Suspenders
       invoke :setup_production_environment
       invoke :setup_staging_environment
       invoke :create_suspenders_views
-      invoke :create_common_javascripts
+      invoke :setup_coffeescript
       invoke :configure_app
       invoke :setup_stylesheets
       invoke :copy_miscellaneous_files
@@ -99,8 +99,9 @@ module Suspenders
       build :create_application_layout
     end
 
-    def create_common_javascripts
-      say 'Pulling in some common javascripts'
+    def setup_coffeescript
+      say 'Setting up CoffeeScript defaults'
+      build :remove_turbolinks
       build :create_common_javascripts
     end
 


### PR DESCRIPTION
The line `//= require turbolinks` in `application.js` is causing Suspenders
to throw a `Sprockets::FileNotFound couldn't find file
'turbolinks'` error.

This most likely happened when Suspenders was upgraded to support Rails 4
where Turbolinks are the default. There are two possible solutions to the
problem: either to remove this line or to install the
`turbolinks` gem.

We're choosing the former for now until we've fully evaluated Turbolinks on
real projects.
