### PR TITLE
Set up staging and production for Cloudfront CDN

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -86,6 +86,20 @@ module Suspenders
         :after => "config.serve_static_assets = false\n"
     end
 
+    def setup_asset_host
+      replace_in_file 'config/environments/production.rb',
+        '# config.action_controller.asset_host = "http://assets.example.com"',
+        "config.action_controller.asset_host = ENV.fetch('ASSET_HOST')"
+
+      replace_in_file 'config/environments/production.rb',
+        "config.assets.version = '1.0'",
+        "config.assets.version = ENV.fetch('ASSETS_VERSION')"
+
+      replace_in_file 'config/environments/production.rb',
+        'config.serve_static_assets = false',
+        'config.static_cache_control = "public, max-age=#{1.year.to_i}"'
+    end
+
     def setup_staging_environment
       staging_file = 'config/environments/staging.rb'
       copy_file 'staging.rb', staging_file

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -90,6 +90,7 @@ module Suspenders
       build :configure_newrelic
       build :configure_smtp
       build :enable_rack_deflater
+      build :setup_asset_host
     end
 
     def setup_staging_environment


### PR DESCRIPTION
The value of `ASSET_HOST` will look like `//123abc.cloudfront.net`

In production every asset has a hash added to its name. Whenever the file
changes, the browser requests the latest version as the hash and therefore
the whole filename changes.

Putting the assets version in an environment variable makes it possible to
invalidate the cache without a re-deploy, if necessary. Simply re-set the
`ASSETS_VERSION` as a Heroku config variable to change the hash globally and
make the browser request every asset again.

Stuff we already have in Suspenders that makes this all work:

Gemfile:

   gem 'coffee-rails'
   gem 'sass-rails'
   gem 'uglifier'

config/environments/{staging,production}.rb:

   config.assets.compile = false
   config.assets.digest = true
   config.assets.js_compressor = :uglifier

We don't have to set `config.serve_static_assets = true` because the
`rails_12factor` gem does it for us.

We want the following settings in Cloudfront:
- "Download" Cloudfront distribution
- "Origin Domain Name" as www.example.com (our app's URL)
- "Origin Protocol Policy" to "Match VIewer"
- "Object Caching" to "Use Origin Cache Headers"
- "Forward Query Strings" to "No (Improves Caching)"
- "Distribution State" to "Enabled"
