### PR TITLE
Fix No route matches GET "/assets/application.css"

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -242,13 +242,9 @@ module Suspenders
   <meta charset='utf-8' />
   <meta name='ROBOTS' content='NOODP' />
       EOS
-      style_tags =<<-EOS
-<link href='/assets/application.css' media='all' rel='stylesheet' type='text/css' />
-      EOS
 
       %w(500 404 422).each do |page|
         inject_into_file "public/#{page}.html", meta_tags, :after => "<head>\n"
-        replace_in_file "public/#{page}.html", /<style.+>.+<\/style>/mi, style_tags.strip
         replace_in_file "public/#{page}.html", /<!--.+-->\n/, ''
       end
     end


### PR DESCRIPTION
We use Rails' asset pipeline's `config.assets.digest = true` setting to add a
hash to the name of the application.css file. This means it isn't available
using this path.
