### PR TITLE
Mb document action on unpermitted parameters

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -20,8 +20,17 @@ module Suspenders
     end
 
     def raise_on_unpermitted_parameters
-      configure_environment 'development',
-        'config.action_controller.action_on_unpermitted_parameters = :raise'
+      action_on_unpermitted_parameters = <<-RUBY
+
+  # Raise an ActionController::UnpermittedParameters exception when
+  # a parameter is not explcitly permitted but is passed anyway.
+  config.action_controller.action_on_unpermitted_parameters = :raise
+      RUBY
+      inject_into_file(
+        "config/environments/development.rb",
+        action_on_unpermitted_parameters,
+        before: "\nend"
+      )
     end
 
     def provide_setup_script
@@ -31,15 +40,15 @@ module Suspenders
 
     def configure_generators
       config = <<-RUBY
-  config.generators do |generate|
-    generate.helper false
-    generate.javascript_engine false
-    generate.request_specs false
-    generate.routing_specs false
-    generate.stylesheets false
-    generate.test_framework :rspec
-    generate.view_specs false
-  end
+    config.generators do |generate|
+      generate.helper false
+      generate.javascript_engine false
+      generate.request_specs false
+      generate.routing_specs false
+      generate.stylesheets false
+      generate.test_framework :rspec
+      generate.view_specs false
+    end
 
       RUBY
 


### PR DESCRIPTION
The `config/environments/development.rb` file has comments before each
of its settings, but a comment is missing when we insert
`action_on_unpermitted_parameters`. The lack of symmetry made me sad,
and the fact that we may hand the project off to another dev team makes
me think we should document it.
