### PR TITLE
Add a --skip-git option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,10 @@ Then run:
 
     suspenders projectname
 
-This will create a Rails 4.0 app in `projectname`. This script creates a
-new git repository. It is not meant to be used against an existing repo.
+This will create a Rails 4.0 app in `projectname`.
+
+By default this script creates a new git repository. See below if you
+want to use it against an existing repo.
 
 Gemfile
 -------
@@ -87,6 +89,14 @@ This has the same effect as running:
 
     heroku create app-staging --remote staging
     heroku create app-production --remote production
+
+Git
+---
+
+This will initialize a new git repository for your Rails app. You can
+bypass this with the `--skip-git` option:
+
+    suspenders app --skip-git true
 
 Github
 ------

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -126,9 +126,11 @@ module Suspenders
     end
 
     def setup_git
-      say 'Initializing git'
-      invoke :setup_gitignore
-      invoke :init_git
+      if !options[:skip_git]
+        say 'Initializing git'
+        invoke :setup_gitignore
+        invoke :init_git
+      end
     end
 
     def create_heroku_apps
@@ -140,7 +142,7 @@ module Suspenders
     end
 
     def create_github_repo
-      if options[:github]
+      if !options[:skip_git] && options[:github]
         say 'Creating Github repo'
         build :create_github_repo, options[:github]
       end


### PR DESCRIPTION
The only reason suspenders should not be run against an existing
directory is because it initializes a git repo. Allow for that to be
skipped.

Suspenders isn't ready to handle upgrading an existing app, but it can
now handle this situation:

```
% git checkout --orphan rewrite-the-spike
% cd ..
% suspenders appt --skip-git true
```
