### PR TITLE
Reduce ActiveRecord connection pool from 5 to 2

### DIFF
--- a/templates/postgresql_database.yml.erb
+++ b/templates/postgresql_database.yml.erb
@@ -3,7 +3,7 @@ development: &default
   database: <%= app_name %>_development
   encoding: utf8
   min_messages: warning
-  pool: 5
+  pool: 2
   timeout: 5000
 
 test:

--- a/templates/unicorn.rb
+++ b/templates/unicorn.rb
@@ -21,6 +21,9 @@ after_fork do |server, worker|
   end
 
   if defined? ActiveRecord::Base
-    ActiveRecord::Base.establish_connection
+    config = Rails.application.config.database_configuration[Rails.env]
+    config['reaping_frequency'] = (ENV['DB_REAPING_FREQUENCY'] || 10).to_i
+    config['pool'] = (ENV['DB_POOL'] || 2).to_i
+    ActiveRecord::Base.establish_connection(config)
   end
 end


### PR DESCRIPTION
When increasing concurrency by using a multi-process web server like Unicorn,
we must be aware of the number of connections our app holds to the database
and how many connections the database can accept. Each process requires a
different connection to the database. To accommodate this, ActiveRecord
provides a connection pool that can hold several connections at a time.

We are setting the pool to 2 connections or the value specified in the
`DB_POOL` environment varriable. We are also setting `reaping_frequency`
which is available in Rails 4.

Heroku provides managed Postgres databases. [Different tiered databases have
different connection limits](https://www.heroku.com/pricing), ranging from 20-500 connections.

Once our database has the maximum number of active connections, it will no
longer accept new connections. This will result in connection timeouts from
our application and will likely cause exceptions.

It is possible for a connection to get into a bad or unknown state. Due to
this, Heroku recommends setting the pool of our application to either 1 or 2
to avoid zombie connections from saturating our database.

With Unicorn, this could mean that over time a 3 worker dyno which normally
consumes 3 database connections could be holding as many as 15 connections (5
default connections per pool times 3 workers). To limit this threat, we lower
the connection pool to 2 and enable connection reaping.

`reaping_frequency` is telling ActiveRecord to check to see if connections
are hung or dead every 10 seconds. While it is likely that over time our
application may have a few connections that hang, if something in our code is
causing hung connections, the reaper will not be a permanent fix to the
problem.

https://devcenter.heroku.com/articles/concurrency-and-database-connections
