### PR TITLE
Set Heroku remotes without using concat_file

### DIFF
--- a/lib/suspenders/actions.rb
+++ b/lib/suspenders/actions.rb
@@ -1,10 +1,5 @@
 module Suspenders
   module Actions
-    def concat_file(source, destination)
-      contents = IO.read(find_in_source_paths(source))
-      append_file destination, contents
-    end
-
     def replace_in_file(relative_path, find, replace)
       path = File.join(destination_root, relative_path)
       contents = IO.read(path)

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -229,12 +229,14 @@ module Suspenders
     end
 
     def set_heroku_remotes
-      concat_file(
-        'templates/bin_setup',
-        "# Set up staging and production git remotes\r
-        git remote add staging git@heroku.com: #{app_name}-staging.git\r
-        git remote add production git@heroku.com: #{app_name}-production.git"
-      )
+      remotes = <<-RUBY
+
+# Set up staging and production git remotes
+git remote add staging git@heroku.com:#{app_name}-staging.git
+git remote add production git@heroku.com:#{app_name}-production.git
+      RUBY
+
+      append_file 'bin/setup', remotes
     end
 
     def create_github_repo(repo_name)


### PR DESCRIPTION
- Fix https://github.com/thoughtbot/suspenders/issues/227
- Fix space between git host and git repo name.
