### PR TITLE
Fail bin/setup if subcommands fail

### DIFF
--- a/templates/bin_setup
+++ b/templates/bin_setup
@@ -3,6 +3,9 @@
 # Set up Rails app. Run this script immediately after cloning the codebase.
 # https://github.com/thoughtbot/guides/tree/master/protocol
 
+# Exit if any subcommand fails
+set -e
+
 # Set up Ruby dependencies via Bundler
 bundle install
 


### PR DESCRIPTION
- Fail tests if bin/setup doesn't work
- Allow chaining bin/setup with &&
- Don't attempt subsequent setup steps if prerequisites fail
