### PR TITLE
Remove sample.env from generated apps

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -213,7 +213,6 @@ module Suspenders
     end
 
     def setup_foreman
-      copy_file 'sample.env', '.sample.env'
       copy_file 'Procfile', 'Procfile'
     end
 

--- a/templates/README.md.erb
+++ b/templates/README.md.erb
@@ -14,6 +14,11 @@ After setting up, you can run the application using [foreman]:
 
 [foreman]: http://ddollar.github.io/foreman/
 
+Check with your team to get the environment setup you may need - this shouldn't
+be stored in Git, so it might be in Basecamp or Google Docs.
+
+This should be stored in `.env` and not added to the repository.
+
 Guidelines
 ----------
 

--- a/templates/bin_setup
+++ b/templates/bin_setup
@@ -12,11 +12,6 @@ bundle install
 # Set up the database
 bundle exec rake db:setup
 
-# Set up configurable environment variables
-if [ ! -f .env ]; then
-  cp .sample.env .env
-fi
-
 # Pick a port for Foreman
 echo "port: 7000" > .foreman
 

--- a/templates/suspenders_gitignore
+++ b/templates/suspenders_gitignore
@@ -12,3 +12,4 @@ rerun.txt
 tags
 tmp/*
 tmp/**/*
+.env


### PR DESCRIPTION
Naming the file Git stores `.sample.env` saves you potentially adding 
malicious things into someone's foreman environment, but it doesn't prevent
you from storing things in your Git repo that shouldn't be, such as AWS keys.

Additionally, copying `.sample.env` to `.env` in `bin/setup` negates the 
benefit of not just storing .env in the repository.
