### PR TITLE
Remove unnecessary deletions of files for Rails 4

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -6,14 +6,6 @@ module Suspenders
       template 'README.md.erb', 'README.md'
     end
 
-    def remove_public_index
-      remove_file 'public/index.html'
-    end
-
-    def remove_rails_logo_image
-      remove_file 'app/assets/images/rails.png'
-    end
-
     def raise_on_delivery_errors
       replace_in_file 'config/environments/development.rb',
         'raise_delivery_errors = false', 'raise_delivery_errors = true'

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -21,7 +21,6 @@ module Suspenders
     end
 
     def suspenders_customization
-      invoke :remove_files_we_dont_need
       invoke :customize_gemfile
       invoke :setup_development_environment
       invoke :setup_test_environment
@@ -40,11 +39,6 @@ module Suspenders
       invoke :create_heroku_apps
       invoke :create_github_repo
       invoke :outro
-    end
-
-    def remove_files_we_dont_need
-      build :remove_public_index
-      build :remove_rails_logo_image
     end
 
     def customize_gemfile


### PR DESCRIPTION
No need for Rails 4 to manually remove `public/index.html` and rails logo ;-)
