### PR TITLE
Remove .sass-cache from gitignore

### DIFF
--- a/templates/suspenders_gitignore
+++ b/templates/suspenders_gitignore
@@ -3,7 +3,6 @@
 *.swo
 *.swp
 .bundle
-.sass-cache/
 coverage/*
 db/*.sqlite3
 log/*


### PR DESCRIPTION
- rails puts cached sass files in `tmp/sass-cache`
  *
  http://stackoverflow.com/questions/14934800/why-does-sass-cache-folder-get-created
