### PR TITLE
rails_12factor gem only required on heroku

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -147,6 +147,11 @@ end
       create_file '.ruby-version', "#{RUBY_VERSION}#{patchlevel}\n"
     end
 
+    def setup_heroku_specific_gems
+      inject_into_file 'Gemfile', "\n\s\sgem 'rails_12factor'",
+        after: /group :staging, :production do/
+    end
+
     def enable_database_cleaner
       copy_file 'database_cleaner_rspec.rb', 'spec/support/database_cleaner.rb'
     end

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -44,6 +44,11 @@ module Suspenders
     def customize_gemfile
       build :replace_gemfile
       build :set_ruby_to_version_being_used
+
+      if options[:heroku]
+        build :setup_heroku_specific_gems
+      end
+
       bundle_command 'install'
     end
 

--- a/spec/features/heroku_spec.rb
+++ b/spec/features/heroku_spec.rb
@@ -4,6 +4,7 @@ feature 'Heroku' do
   scenario 'Suspend a project with --heroku=true' do
     run_suspenders('--heroku=true')
 
+    expect(FakeHeroku).to have_gem_included(project_path, 'rails_12factor')
     expect(FakeHeroku).to have_created_app_for('staging')
     expect(FakeHeroku).to have_created_app_for('production')
     expect(FakeHeroku).to have_configured_vars('staging', 'SECRET_KEY_BASE')

--- a/spec/support/fake_heroku.rb
+++ b/spec/support/fake_heroku.rb
@@ -15,6 +15,12 @@ class FakeHeroku
     FileUtils.rm_rf RECORDER
   end
 
+  def self.has_gem_included?(project_path, gem_name)
+    gemfile = File.open(File.join(project_path, 'Gemfile'), 'a')
+
+    File.foreach(gemfile).any?{ |line| line.match(/rails_12factor/) }
+  end
+
   def self.has_created_app_for?(remote_name)
     app_name = "#{SuspendersTestHelpers::APP_NAME}-#{remote_name}"
     expected_line = "create #{app_name} --remote=#{remote_name}\n"

--- a/templates/Gemfile_clean
+++ b/templates/Gemfile_clean
@@ -46,5 +46,4 @@ end
 
 group :staging, :production do
   gem 'newrelic_rpm', '>= 3.6.7'
-  gem 'rails_12factor'
 end


### PR DESCRIPTION
We have found this problem with non-heroku environments. 

Because of this `rails_12factor` gem production/staging logs are not being generated
