### PR TITLE
Fix .ruby-version on Ruby 2.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
+  - 2.1.0
 before_install:
   - git config --global user.name 'Travis CI'
   - git config --global user.email 'travis-ci@example.com'

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -144,7 +144,7 @@ end
     def set_ruby_to_version_being_used
       inject_into_file 'Gemfile', "\n\nruby '#{RUBY_VERSION}'",
         after: /source 'https:\/\/rubygems.org'/
-      create_file '.ruby-version', "#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}\n"
+      create_file '.ruby-version', "#{RUBY_VERSION}#{patchlevel}\n"
     end
 
     def enable_database_cleaner
@@ -310,6 +310,14 @@ git remote add production git@heroku.com:#{app_name}-production.git
 
     def generate_secret
       SecureRandom.hex(64)
+    end
+
+    def patchlevel
+      if RUBY_PATCHLEVEL == 0 && RUBY_VERSION >= '2.1.0'
+        ''
+      else
+        "-p#{RUBY_PATCHLEVEL}"
+      end
     end
   end
 end

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -16,8 +16,23 @@ feature 'Suspend a new project with default configuration' do
 
     staging_file = IO.read("#{project_path}/config/environments/staging.rb")
     config_stub = "Dummy::Application.configure do"
-
     expect(staging_file).to match(/^require_relative 'production'/)
     expect(staging_file).to match(/#{config_stub}/), staging_file
+  end
+
+  if RUBY_PATCHLEVEL == 0 && RUBY_VERSION >= '2.1.0'
+    scenario '.ruby-version does not include patchlevel for Ruby 2.1.0' do
+      run_suspenders
+
+      ruby_version_file = IO.read("#{project_path}/.ruby-version")
+      expect(ruby_version_file).to eq "2.1.0\n"
+    end
+  else
+    scenario '.ruby-version includes patchlevel for all pre-Ruby 2.1.0 versions' do
+      run_suspenders
+
+      ruby_version_file = IO.read("#{project_path}/.ruby-version")
+      expect(ruby_version_file).to eq "#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}\n"
+    end
   end
 end


### PR DESCRIPTION
- Ruby 2.1.0 has no patchlevel number.
  https://twitter.com/hsbt/status/415887230318567424
- The .ruby-version was leaving a stray `-p` at the end of the number.
  #279
