### PR TITLE
Use fewer customizations to RSpec configuration

### DIFF
--- a/templates/spec_helper.rb
+++ b/templates/spec_helper.rb
@@ -19,9 +19,7 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
-  config.fail_fast = true
   config.include Features, type: :feature
-  config.infer_base_class_for_anonymous_controllers = false
   config.order = 'random'
   config.use_transactional_fixtures = false
 end


### PR DESCRIPTION
- These were tangentially introduced in 8718a47 while adding WebMock.
- `fail_fast` is a personal preference which should live in `~/.rspec`.
- `infer_base_class_for_anonymous_controllers` is true in RSpec 3.

This came up while discussing thoughtbot/learn#615.

https://github.com/thoughtbot/learn/pull/615#discussion_r9708534
