### PR TITLE
Make the .git/safe directory in bin/setup

### DIFF
--- a/templates/bin_setup
+++ b/templates/bin_setup
@@ -12,6 +12,9 @@ bundle install
 # Set up the database
 bundle exec rake db:setup
 
+# Add binstubs to PATH via export PATH=".git/safe/../../bin:$PATH" in ~/.zshenv
+mkdir -p .git/safe
+
 # Set up configurable environment variables
 if [ ! -f .env ]; then
   cp .sample.env .env


### PR DESCRIPTION
Our expected way of managing Rubies is with rbenv:

https://github.com/thoughtbot/laptop/blob/master/common-components/ruby-environment

We load rbenv and add `.git/safe/../../bin:$PATH` to our $PATH in:

https://github.com/thoughtbot/dotfiles/blob/master/zshrc

Loading rbenv in `zshrc` is recommended by the rbenv docs:

https://github.com/sstephenson/rbenv#basic-github-checkout

Assuming the binstubs for a project are in the local bin/ directory, we go a
step further to add the directory to shell $PATH so that rspec can be invoked
without the bin/ prefix:

<code>export PATH="./bin:$PATH"</code>

Doing so on a system that other people have write access to (such as a shared
host) is a security risk:

sstephenson/rbenv#309

The `.git/safe` convention addresses the security problem:

https://twitter.com/tpope/status/165631968996900865

This zsh fix may be necessary for OS users in order to fix a bug:

https://github.com/thoughtbot/laptop/blob/master/mac-components/zsh-fix
