### PR TITLE
Require mailer configuration on staging & production

### DIFF
--- a/templates/smtp.rb
+++ b/templates/smtp.rb
@@ -1,10 +1,10 @@
 if Rails.env.staging? || Rails.env.production?
   SMTP_SETTINGS = {
-    address: ENV['SMTP_ADDRESS'], # example: 'smtp.sendgrid.net'
+    address: ENV.fetch('SMTP_ADDRESS'), # example: 'smtp.sendgrid.net'
     authentication: :plain,
-    domain: ENV['SMTP_DOMAIN'], # example: 'this-app.com'
-    password: ENV['SMTP_PASSWORD'],
+    domain: ENV.fetch('SMTP_DOMAIN'), # example: 'this-app.com'
+    password: ENV.fetch('SMTP_PASSWORD'),
     port: '587',
-    user_name: ENV['SMTP_USERNAME']
+    user_name: ENV.fetch('SMTP_USERNAME')
   }
 end


### PR DESCRIPTION
If we have forgotten to give the smtp config options on staging or production, we should know at deploy time, and not have to waste time tracking down why emails aren't sending.
