### PR TITLE
Distribute bin/suspenders, not bin/rspec, in gem

### DIFF
--- a/suspenders.gemspec
+++ b/suspenders.gemspec
@@ -19,7 +19,7 @@ rush to build something amazing; don't use it if you like missing deadlines.
   HERE
 
   s.email = 'support@thoughtbot.com'
-  s.executables = `git ls-files -- bin/*`.split("\n").map { |file| File.basename(file) }
+  s.executables = ['suspenders']
   s.extra_rdoc_files = %w[README.md LICENSE]
   s.files = `git ls-files`.split("\n")
   s.homepage = 'http://github.com/thoughtbot/suspenders'


### PR DESCRIPTION
While installing suspenders:

```
% gem install suspenders
```

   suspenders's executable "rspec" conflicts with rspec-core
   Overwrite the executable? [yN]

This is because we added an `rspec` binstub to `bin/` and automatically
distribute all files in `bin/` in the `.gemspec.`

Resolves https://github.com/thoughtbot/suspenders/issues/288
