### PR TITLE
Fix i18n validation warning

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -199,6 +199,14 @@ end
       action_mailer_host 'production', "#{app_name}.com"
     end
 
+    def fix_i18n_deprecation_warning
+      config = <<-RUBY
+    config.i18n.enforce_available_locales = true
+
+      RUBY
+      inject_into_class 'config/application.rb', 'Application', config
+    end
+
     def generate_rspec
       generate 'rspec:install'
     end

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -118,6 +118,7 @@ module Suspenders
       build :configure_time_formats
       build :configure_rack_timeout
       build :disable_xml_params
+      build :fix_i18n_deprecation_warning
       build :setup_default_rake_task
       build :configure_unicorn
       build :setup_foreman


### PR DESCRIPTION
According to StackOverflow[1], we need to set this explicitly in order to
avoid this warning:

  [deprecated] I18n.enforce_available_locales will default to true in the
 future. If you really want to skip validation of your locale you can set
 I18n.enforce_available_locales = false to avoid this message.

We set it to `true` to future-proof our apps, since that's what the default
will be in the future.

1:
http://stackoverflow.com/questions/20361428/rails-i18n-validation-deprecation-warning
