### PR TITLE
Remove better_errors

### DIFF
--- a/templates/Gemfile_clean
+++ b/templates/Gemfile_clean
@@ -20,8 +20,6 @@ gem 'uglifier'
 gem 'unicorn'
 
 group :development do
-  gem 'better_errors'
-  gem 'binding_of_caller'
   gem 'foreman'
   gem 'spring'
   gem 'spring-commands-rspec'


### PR DESCRIPTION
- We're using unicorn as our default server
- better_errors is not compatible with unicorn
- Instead of error context, you just see "Session expired"
- The default Rails behavior is more reliable

https://github.com/charliesome/better_errors/issues/40
