### PR TITLE
Remove RSpec fast-failing

### DIFF
--- a/templates/spec_helper.rb
+++ b/templates/spec_helper.rb
@@ -19,7 +19,6 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
-  config.fail_fast = true
   config.include Features, type: :feature
   config.infer_base_class_for_anonymous_controllers = false
   config.order = 'random'


### PR DESCRIPTION
When this is turned on, I'll run `rspec` and see only one failure. After
fixing it, I'll see another, and so on. Turning this off lets people know how
many failures they actually have. Seeing every failure can also help users
with debugging, since one change may have caused many failures, and seeing
every failure can help track down the bug.
