### PR TITLE
Generate .travis.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Gemfile
 -------
 
 To see the latest and greatest gems, look at Suspenders'
-[templates/Gemfile_clean](templates/Gemfile_clean),
+[Gemfile](templates/Gemfile.erb),
 which will be appended to the default generated projectname/Gemfile.
 
 It includes application gems like:

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -142,13 +142,11 @@ end
 
     def replace_gemfile
       remove_file 'Gemfile'
-      copy_file 'Gemfile_clean', 'Gemfile'
+      template 'Gemfile.erb', 'Gemfile'
     end
 
     def set_ruby_to_version_being_used
-      inject_into_file 'Gemfile', "\n\nruby '#{RUBY_VERSION}'",
-        after: /source 'https:\/\/rubygems.org'/
-      create_file '.ruby-version', "#{RUBY_VERSION}#{patchlevel}\n"
+      template 'ruby-version.erb', '.ruby-version'
     end
 
     def setup_heroku_specific_gems
@@ -168,6 +166,10 @@ end
     def configure_rspec
       remove_file 'spec/spec_helper.rb'
       copy_file 'spec_helper.rb', 'spec/spec_helper.rb'
+    end
+
+    def configure_travis
+      template 'travis.yml.erb', '.travis.yml'
     end
 
     def use_spring_binstubs
@@ -327,14 +329,6 @@ git remote add production git@heroku.com:#{app_name}-production.git
 
     def generate_secret
       SecureRandom.hex(64)
-    end
-
-    def patchlevel
-      if RUBY_PATCHLEVEL == 0 && RUBY_VERSION >= '2.1.0'
-        ''
-      else
-        "-p#{RUBY_PATCHLEVEL}"
-      end
     end
   end
 end

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -81,6 +81,7 @@ module Suspenders
       build :configure_background_jobs_for_rspec
       build :enable_database_cleaner
       build :configure_spec_support_features
+      build :configure_travis
     end
 
     def setup_production_environment
@@ -185,6 +186,10 @@ module Suspenders
       # Let's not: We'll bundle manually at the right spot
     end
 
+    def ruby_version_with_patch_level
+      "#{RUBY_VERSION}#{patch_level}"
+    end
+
     protected
 
     def get_builder_class
@@ -193,6 +198,14 @@ module Suspenders
 
     def using_active_record?
       !options[:skip_active_record]
+    end
+
+    def patch_level
+      if RUBY_PATCHLEVEL == 0 && RUBY_VERSION >= '2.1.0'
+        ''
+      else
+        "-p#{RUBY_PATCHLEVEL}"
+      end
     end
   end
 end

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby '<%= RUBY_VERSION %>'
+
 gem 'airbrake'
 gem 'bourbon'
 gem 'coffee-rails'

--- a/templates/ruby-version.erb
+++ b/templates/ruby-version.erb
@@ -1,0 +1,1 @@
+<%= ruby_version_with_patch_level %>

--- a/templates/travis.yml.erb
+++ b/templates/travis.yml.erb
@@ -1,0 +1,13 @@
+before_script:
+- cp .sample.env .env
+branches:
+  only:
+  - master
+cache: bundler
+language: ruby
+notifications:
+  campfire:
+    on_success: change
+    on_failure: always
+    template: '%{repository_name} build #%{build_number} on %{branch} by %{author} finished: %{message}: %{build_url}'
+rvm: ruby-<%= ruby_version_with_patch_level %>


### PR DESCRIPTION
We want to generate this file because:
- We're using Travis on a lot of projects
- It requires configuration to run builds and notify us
- We can skip some boilerplate by starting out with a sane config

The generated config makes sense because:
- It can run Ruby builds out of the box with our Ruby version
- It reduces noise for Campfire notifications
- It reduces volume in the queue by avoiding unnecessary branch builds

This also refactors handling of Ruby versions to move interpolation into 
templates where possible.
