### PR TITLE
Add rspec config to treat symbols as metadata keys with true values

### DIFF
--- a/templates/spec_helper.rb
+++ b/templates/spec_helper.rb
@@ -22,6 +22,7 @@ RSpec.configure do |config|
   config.include Features, type: :feature
   config.infer_base_class_for_anonymous_controllers = false
   config.order = 'random'
+  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.use_transactional_fixtures = false
 end
 


### PR DESCRIPTION
RSpec output contained a warning when I ran the factories spec because
of the `:factory` tag; RSpec 2 expects a hash instead of a symbol. Adding
this line to the config quiets the warning, and allows behavior that
will be default in RSpec 3.
