### PR TITLE
Show exceptions during tests

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -318,6 +318,11 @@ git remote add production git@heroku.com:#{app_name}-production.git
       end
     end
 
+    def show_exceptions_in_tests
+      replace_in_file 'config/environments/test.rb',
+        'show_exceptions = false', 'show_exceptions = true'
+    end
+
     private
 
     def override_path_for_tests

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -73,6 +73,7 @@ module Suspenders
 
     def setup_test_environment
       say 'Setting up the test environment'
+      build :show_exceptions_in_tests
       build :enable_factory_girl_syntax
       build :test_factories_first
       build :generate_rspec


### PR DESCRIPTION
By default rails sets `config.action_dispatch.show_exceptions = true` in test
environment, which suppresses exceptions in test log. This change reverses it so
exceptions are easier to see, thus making debugging easier.

Before:
![screen shot 2014-03-31 at 10 28 57 pm](https://cloud.githubusercontent.com/assets/116327/2575842/8ce4326e-b95e-11e3-8275-f04ed7f394ff.png)

After:
![screen shot 2014-03-31 at 10 29 48 pm](https://cloud.githubusercontent.com/assets/116327/2575844/a85b879a-b95e-11e3-82c6-842d8e7ce449.png)
