### PR TITLE
Corrects has_gem_included? test helper

### DIFF
--- a/spec/support/fake_heroku.rb
+++ b/spec/support/fake_heroku.rb
@@ -18,7 +18,9 @@ class FakeHeroku
   def self.has_gem_included?(project_path, gem_name)
     gemfile = File.open(File.join(project_path, 'Gemfile'), 'a')
 
-    File.foreach(gemfile).any? { |line| line.match(/#{Regexp.quote(gem_name)}/) }
+    File.foreach(gemfile).any? do |line|
+      line.match(/#{Regexp.quote(gem_name)}/)
+    end
   end
 
   def self.has_created_app_for?(remote_name)


### PR DESCRIPTION
It was always looking for rails_12factor, it now uses the actual gem
name that is passed in and makes sure it is usable in a Regex.
