### PR TITLE
Don't prepend factory specs if SPEC is set

### DIFF
--- a/templates/factories_spec_rake_task.rb
+++ b/templates/factories_spec_rake_task.rb
@@ -11,5 +11,5 @@ if defined?(RSpec)
     t.pattern = './spec/models/factories_spec.rb'
   end
 
-  task spec: :factory_specs
+  task(spec: :factory_specs) unless ENV['SPEC'].present?
 end


### PR DESCRIPTION
If you want to run **one** specific spec, you use something like:

``` console
$ SPEC=specs/path/to_spec.rb rake
```

Currently, doing this runs the specific spec _twice_, once during the `factory_specs` task and again during the `specs` task. This is because the `SPEC` environment variable is overriding `factory_specs`'s defined `pattern`.

This commit prevents Suspenders's `Rakefile` from adding `factory_specs` as a prereq task to `specs` when the `SPEC` environment variable is present.
