### PR TITLE
Enable SMTP/TLS in SMTP settings

### DIFF
--- a/templates/smtp.rb
+++ b/templates/smtp.rb
@@ -3,6 +3,7 @@ if Rails.env.staging? || Rails.env.production?
     address: ENV.fetch('SMTP_ADDRESS'), # example: 'smtp.sendgrid.net'
     authentication: :plain,
     domain: ENV.fetch('SMTP_DOMAIN'), # example: 'this-app.com'
+    enable_starttls_auto: true,
     password: ENV.fetch('SMTP_PASSWORD'),
     port: '587',
     user_name: ENV.fetch('SMTP_USERNAME')


### PR DESCRIPTION
Be more secure by default.

https://en.wikipedia.org/wiki/STARTTLS
