### PR TITLE
Fix app name in staging config

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -88,7 +88,7 @@ module Suspenders
 
       config = <<-RUBY
 
-#{app_name.classify}::Application.configure do
+#{app_name.gsub('-', '_').classify}::Application.configure do
   # ...
 end
       RUBY


### PR DESCRIPTION
- ".classify" turns "app_name" -> "AppName" but "app-name" -> "App-name"
- Use gsub to turn dashes unto underscores before calling ".classify"
- This makes the app name consistent with how rails converts the app
  name in other config files

Example of what suspenders generated for a rails project named 'gratitude-ember':
![screen shot 2014-04-15 at 2 34 00 pm](https://cloud.githubusercontent.com/assets/601515/2713489/9e6998c8-c4e7-11e3-8cc6-62e77cc56ff1.png)
