### PR TITLE
Update Unicorn config template

### DIFF
--- a/templates/unicorn.rb
+++ b/templates/unicorn.rb
@@ -21,7 +21,8 @@ after_fork do |server, worker|
   end
 
   if defined? ActiveRecord::Base
-    config = Rails.application.config.database_configuration[Rails.env]
+    config = ActiveRecord::Base.configurations[Rails.env] ||
+      Rails.application.config.database_configuration[Rails.env]
     config['reaping_frequency'] = (ENV['DB_REAPING_FREQUENCY'] || 10).to_i
     config['pool'] = (ENV['DB_POOL'] || 2).to_i
     ActiveRecord::Base.establish_connection(config)


### PR DESCRIPTION
- I recently ran into an issue after deploying to Heroku where
  `Rails.application.config.database_configuration[Rails.env]` was
  evaluating to `nil` in the staging environment. Updating
  config/unicorn.rb to the latest configuration recommended by Heroku
  fixed the problem.
- Reference:
  https://devcenter.heroku.com/articles/concurrency-and-database-connections#multi-process-servers
