### PR TITLE
shoulda-matchers spring compatibility.

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -39,7 +39,7 @@ group :test do
   gem 'capybara-webkit', '>= 1.0.0'
   gem 'database_cleaner'
   gem 'launchy'
-  gem 'shoulda-matchers'
+  gem 'shoulda-matchers', require: false
   gem 'simplecov', require: false
   gem 'timecop'
   gem 'webmock'

--- a/templates/spec_helper.rb
+++ b/templates/spec_helper.rb
@@ -6,6 +6,7 @@ ENV['RAILS_ENV'] = 'test'
 require File.expand_path('../../config/environment', __FILE__)
 
 require 'rspec/rails'
+require 'shoulda/matchers'
 require 'webmock/rspec'
 
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |file| require file }


### PR DESCRIPTION
Changed Gemfile and spec_helper according to the shoulda-matchers
documentation:

Gemfile:

group :test do
  gem 'shoulda-matchers', require: false
end

spec_helper:

require 'rspec/rails'
require 'shoulda/matchers'u
