### PR TITLE
remove Foreman from Gemfile

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -22,7 +22,6 @@ gem 'uglifier'
 gem 'unicorn'
 
 group :development do
-  gem 'foreman'
   gem 'spring'
   gem 'spring-commands-rspec'
 end

--- a/templates/README.md.erb
+++ b/templates/README.md.erb
@@ -12,6 +12,8 @@ After setting up, you can run the application using [foreman]:
 
     % foreman start
 
+If you don't have [foreman], you can install it with `gem install foreman`. Note that it is not included in the `Gemfile` [nor should it be](https://github.com/ddollar/foreman/pull/437#issuecomment-41110407).
+
 [foreman]: http://ddollar.github.io/foreman/
 
 Guidelines


### PR DESCRIPTION
per @ddollar in https://github.com/ddollar/foreman/pull/437#issuecomment-41110407

> You should not put foreman into your Gemfile as the dependencies of a developer utility should not be able to interfere with the dependencies of your app.

later I told him I was using suspenders:

> Interesting I have always wondered where that trend got started. Having foreman be run inside the app using whatever random version of Ruby the user has installed is quite a pain point.
