### PR TITLE
Improve and document TravisCI configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Suspenders also comes with:
 * [t() and l() in specs without prefixing with I18n][i18n]
 * An automatically-created `SECRET_KEY_BASE` environment variable in all
   environments.
+* Configuration for [Travis Pro][travis] continuous integration.
 
 [bin]: http://robots.thoughtbot.com/bin-setup
 [compress]: http://robots.thoughtbot.com/content-compression-with-rack-deflater/
@@ -98,6 +99,7 @@ Suspenders also comes with:
 [pool]: https://devcenter.heroku.com/articles/concurrency-and-database-connections
 [binstub]: https://github.com/thoughtbot/suspenders/pull/282
 [i18n]: https://github.com/thoughtbot/suspenders/pull/304
+[travis]: http://docs.travis-ci.com/user/travis-pro/
 
 Heroku
 ------

--- a/templates/travis.yml.erb
+++ b/templates/travis.yml.erb
@@ -1,13 +1,29 @@
+before_install:
+  - "echo '--colour' > ~/.rspec"
+  - "echo 'gem: --no-document' > ~/.gemrc"
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
 before_script:
-- cp .sample.env .env
+  - cp .sample.env .env
+  <% if options[:database] == 'postgresql' %>
+  - psql -c 'create database "<%= app_name %>_test";' -U postgres
+  <% end %>
 branches:
   only:
-  - master
-cache: bundler
-language: ruby
+    - master
+cache:
+  - bundler
+language:
+  - ruby
 notifications:
   campfire:
-    on_success: change
-    on_failure: always
-    template: '%{repository_name} build #%{build_number} on %{branch} by %{author} finished: %{message}: %{build_url}'
-rvm: ruby-<%= ruby_version_with_patch_level %>
+    on_failure:
+      - always
+    on_success:
+      - change
+    template:
+      - '(%{branch} - %{author}): %{message} - %{build_url}'
+  email:
+    - false
+rvm:
+  - <%= ruby_version_with_patch_level %>


### PR DESCRIPTION
- Add Travis to README.
- Color the RSpec output.
- Create Postgres database.
- Set up xvfb for Capybara Webkit.
- Turn off email notifications.
- Remove unnecessary `ruby-` prefix to Ruby version.
- Use consistent formatting.
