### PR TITLE
Set up Segment.io by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ It includes application gems like:
   avoid accidentally sending emails to real people from staging
 * [Simple Form](https://github.com/plataformatec/simple_form) for form markup
   and style
-* [Unicorn](https://github.com/defunkt/unicorn) to serve HTTP requests
 * [Title](https://github.com/calebthompson/title) for storing titles in
   translations
+* [Unicorn](https://github.com/defunkt/unicorn) to serve HTTP requests
 
 And gems only for staging and production like:
 
@@ -94,6 +94,8 @@ Suspenders also comes with:
 * An automatically-created `SECRET_KEY_BASE` environment variable in all
   environments.
 * Configuration for [Travis Pro][travis] continuous integration.
+* The analytics adapter [Segment.io][segment] (and therefore config for Google
+  Analytics, Intercom, Facebook Ads, Twitter Ads, etc.).
 
 [bin]: http://robots.thoughtbot.com/bin-setup
 [compress]: http://robots.thoughtbot.com/content-compression-with-rack-deflater/
@@ -102,6 +104,7 @@ Suspenders also comes with:
 [binstub]: https://github.com/thoughtbot/suspenders/pull/282
 [i18n]: https://github.com/thoughtbot/suspenders/pull/304
 [travis]: http://docs.travis-ci.com/user/travis-pro/
+[segment]: https://segment.io
 
 Heroku
 ------

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -286,6 +286,11 @@ heroku join --app #{app_name}-production
       run "#{path_addition} hub create #{repo_name}"
     end
 
+    def setup_segment_io
+      copy_file '_analytics.html.erb',
+        'app/views/application/_analytics.html.erb'
+    end
+
     def copy_miscellaneous_files
       copy_file 'errors.rb', 'config/initializers/errors.rb'
     end

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -38,6 +38,7 @@ module Suspenders
       invoke :setup_database
       invoke :create_heroku_apps
       invoke :create_github_repo
+      invoke :setup_segment_io
       invoke :outro
     end
 
@@ -154,6 +155,11 @@ module Suspenders
         say 'Creating Github repo'
         build :create_github_repo, options[:github]
       end
+    end
+
+    def setup_segment_io
+      say 'Setting up Segment.io'
+      build :setup_segment_io
     end
 
     def setup_gitignore

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -37,6 +37,7 @@ feature 'Suspend a new project with default configuration' do
     expect(secrets_file).to match(/secret_key_base: <%= ENV\['SECRET_KEY_BASE'\] %>/)
   end
 
+
   scenario 'action mailer support file is added' do
     run_suspenders
 
@@ -51,5 +52,18 @@ feature 'Suspend a new project with default configuration' do
     expect(newrelic_file).to match(
       /license_key: '<%= ENV\['NEW_RELIC_LICENSE_KEY'\] %>'/
     )
+  end
+
+  scenario 'records pageviews through Segment.io if ENV variable set' do
+    run_suspenders
+
+    expect(analytics_partial).
+      to include("<% if ENV['SEGMENT_IO_KEY'] %>")
+    expect(analytics_partial).
+      to include("window.analytics.load('<%= ENV['SEGMENT_IO_KEY'] %>');")
+  end
+
+  def analytics_partial
+    IO.read("#{project_path}/app/views/application/_analytics.html.erb")
   end
 end

--- a/templates/_analytics.html.erb
+++ b/templates/_analytics.html.erb
@@ -1,0 +1,7 @@
+<% if ENV['SEGMENT_IO_KEY'] %>
+  <script type="text/javascript">
+    window.analytics=window.analytics||[],window.analytics.methods=["identify","group","track","page","pageview","alias","ready","on","once","off","trackLink","trackForm","trackClick","trackSubmit"],window.analytics.factory=function(t){return function(){var a=Array.prototype.slice.call(arguments);return a.unshift(t),window.analytics.push(a),window.analytics}};for(var i=0;i<window.analytics.methods.length;i++){var key=window.analytics.methods[i];window.analytics[key]=window.analytics.factory(key)}window.analytics.load=function(t){if(!document.getElementById("analytics-js")){var a=document.createElement("script");a.type="text/javascript",a.id="analytics-js",a.async=!0,a.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.io/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(a,n)}},window.analytics.SNIPPET_VERSION="2.0.9",
+    window.analytics.load('<%= ENV['SEGMENT_IO_KEY'] %>');
+    window.analytics.page();
+  </script>
+<% end %>

--- a/templates/_javascript.html.erb
+++ b/templates/_javascript.html.erb
@@ -2,6 +2,8 @@
 
 <%= yield :javascript %>
 
+<%= render 'analytics' %>
+
 <% if Rails.env.test? %>
   <%= javascript_tag do %>
     $.fx.off = true;


### PR DESCRIPTION
In order to analyze metrics later, we need to instrument our app to log the
right metrics. The primary type of instrumentation we care about is called
"event tracking."

We ese Segment.io to capture events whenever possible. It is basically the
adapter pattern for analytics services.

Segment.io lets us drop one JS library into our web apps, or one Ruby library
into our server-side framework, or one iOS SDK into our mobile apps. Then, we
can toggle on and off different services such as Google Analytics, Intercom,
and others.

http://playbook.thoughtbot.com/#instrumentation

If we are working on an app that uses authentication through a library such as
Clearance, we should add the following to
`app/views/application/_analytics.html.erb`:

```
<% if signed_in? %>
  <%= render 'signed_in_analytics' %>
<% end %>
```

https://github.com/thoughtbot/clearance

At that time, we should also add
`app/views/application/_signed_in_analytics.html.erb`:

```
<script type="text/javascript">
  analytics.identify("#{current_user.id}", {
    created : "#{current_user.created_at}",
    email : "#{current_user.email}"
  }, {
    Intercom : {
      userHash : "#{OpenSSL::HMAC.hexdigest('sha256', ENV['INTERCOM_API_SECRET'], current_user.id.to_s)}"
    }
  });
</script>
```

The most likely first signed in service we'll want is Intercom. It plays two
important roles for an early stage product:
1. communication (and support) with customers and
2. measuring retention (such as Weekly Active Users)

https://intercom.io
