### PR TITLE
Raise unpermitted parameters in test environment

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -12,17 +12,11 @@ module Suspenders
     end
 
     def raise_on_unpermitted_parameters
-      action_on_unpermitted_parameters = <<-RUBY
-
-  # Raise an ActionController::UnpermittedParameters exception when
-  # a parameter is not explicitly permitted but is passed anyway.
-  config.action_controller.action_on_unpermitted_parameters = :raise
+      config = <<-RUBY
+    config.action_controller.action_on_unpermitted_parameters = :raise
       RUBY
-      inject_into_file(
-        "config/environments/development.rb",
-        action_on_unpermitted_parameters,
-        before: "\nend"
-      )
+
+      inject_into_class "config/application.rb", "Application", config
     end
 
     def provide_setup_script
@@ -36,6 +30,7 @@ module Suspenders
 
     def configure_generators
       config = <<-RUBY
+
     config.generators do |generate|
       generate.helper false
       generate.javascript_engine false
@@ -208,8 +203,8 @@ end
     def configure_time_zone
       config = <<-RUBY
     config.active_record.default_timezone = :utc
-
       RUBY
+
       inject_into_class 'config/application.rb', 'Application', config
     end
 
@@ -232,8 +227,8 @@ end
     def fix_i18n_deprecation_warning
       config = <<-RUBY
     config.i18n.enforce_available_locales = true
-
       RUBY
+
       inject_into_class 'config/application.rb', 'Application', config
     end
 

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -68,6 +68,16 @@ feature 'Suspend a new project with default configuration' do
       to include(%{window.analytics.load("<%= ENV["SEGMENT_IO_KEY"] %>");})
   end
 
+  scenario "raises on unpermitted parameters in all environments" do
+    run_suspenders
+
+    result = IO.read("#{project_path}/config/application.rb")
+
+    expect(result).to match(
+      /^ +config.action_controller.action_on_unpermitted_parameters = :raise$/
+    )
+  end
+
   scenario "raises on missing translations in development" do
     run_suspenders
 


### PR DESCRIPTION
Unpermitted parameters are raised in the development environment but
ignored in the test environment. This can cause specs to pass even though
performing the same steps in development will fail.
- Inject config to raise unpermitted parameters in the test environment
