### PR TITLE
Connect to Postgres on localhost

### DIFF
--- a/templates/postgresql_database.yml.erb
+++ b/templates/postgresql_database.yml.erb
@@ -2,6 +2,7 @@ development: &default
   adapter: postgresql
   database: <%= app_name %>_development
   encoding: utf8
+  host: localhost
   min_messages: warning
   pool: 2
   timeout: 5000


### PR DESCRIPTION
- Most installs listen on localhost
- Many installs do not listen on a socket
- This fixes connection errors for many users
