### PR TITLE
Move SMTP varibale settings out of initializer

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -56,10 +56,10 @@ module Suspenders
     end
 
     def configure_smtp
-      copy_file 'smtp.rb', 'config/initializers/smtp.rb'
+      copy_file 'smtp.rb', 'config/smtp.rb'
 
       prepend_file 'config/environments/production.rb',
-        "require Rails.root.join('config/initializers/smtp')\n"
+        "require Rails.root.join('config/smtp')\n"
 
       config = <<-RUBY
 

--- a/templates/smtp.rb
+++ b/templates/smtp.rb
@@ -1,11 +1,9 @@
-if Rails.env.staging? || Rails.env.production?
-  SMTP_SETTINGS = {
-    address: ENV.fetch('SMTP_ADDRESS'), # example: 'smtp.sendgrid.net'
-    authentication: :plain,
-    domain: ENV.fetch('SMTP_DOMAIN'), # example: 'this-app.com'
-    enable_starttls_auto: true,
-    password: ENV.fetch('SMTP_PASSWORD'),
-    port: '587',
-    user_name: ENV.fetch('SMTP_USERNAME')
-  }
-end
+SMTP_SETTINGS = {
+  address: ENV.fetch('SMTP_ADDRESS'), # example: 'smtp.sendgrid.net'
+  authentication: :plain,
+  domain: ENV.fetch('SMTP_DOMAIN'), # example: 'this-app.com'
+  enable_starttls_auto: true,
+  password: ENV.fetch('SMTP_PASSWORD'),
+  port: '587',
+  user_name: ENV.fetch('SMTP_USERNAME')
+}


### PR DESCRIPTION
Since we require the `smtp.rb` file in the environment files, and Rails loads it
as part of its boot process, this file was loaded twice. Which causes a constant
reinitialization warning message.

Also, to remove the duplicaton, there is no need to check the environments,
since we require the files from the appropriate environment files.

Fixes #335
