### PR TITLE
Create the .env file before running rake tasks.

### DIFF
--- a/templates/bin_setup
+++ b/templates/bin_setup
@@ -9,16 +9,16 @@ set -e
 # Set up Ruby dependencies via Bundler
 bundle install
 
+# Set up configurable environment variables
+if [ ! -f .env ]; then
+  cp .sample.env .env
+fi
+
 # Set up database and add any development seed data
 bundle exec rake dev:prime
 
 # Add binstubs to PATH via export PATH=".git/safe/../../bin:$PATH" in ~/.zshenv
 mkdir -p .git/safe
-
-# Set up configurable environment variables
-if [ ! -f .env ]; then
-  cp .sample.env .env
-fi
 
 # Pick a port for Foreman
 echo "port: 7000" > .foreman


### PR DESCRIPTION
In Rails apps which require an environment variable to be set in an initializer, `rake dev:prime` will fail unless the `.env` file is put in place first.

This came up in both Koneksa and Nyarp, where we used `ENV.fetch` in an initializer to fail early if a required API key was missing.
