### PR TITLE
Include `formulaic` gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ And testing gems like:
   [Capybara Webkit](https://github.com/thoughtbot/capybara-webkit) for
   integration testing
 * [Factory Girl](https://github.com/thoughtbot/factory_girl) for test data
+* [Formulaic](https://github.com/thoughtbot/formulaic) for integration testing
+  HTML forms
 * [RSpec](https://github.com/rspec/rspec) for unit testing
 * [RSpec Mocks](https://github.com/rspec/rspec-mocks) for stubbing and spying
 * [Shoulda Matchers](https://github.com/thoughtbot/shoulda-matchers) for common

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -38,6 +38,7 @@ end
 group :test do
   gem 'capybara-webkit', '>= 1.0.0'
   gem 'database_cleaner'
+  gem 'formulaic'
   gem 'launchy'
   gem 'shoulda-matchers', require: false
   gem 'simplecov', require: false

--- a/templates/spec_helper.rb
+++ b/templates/spec_helper.rb
@@ -21,6 +21,8 @@ RSpec.configure do |config|
   end
 
   config.include Features, type: :feature
+  config.include Formulaic::Dsl, type: :feature
+
   config.infer_base_class_for_anonymous_controllers = false
   config.order = 'random'
   config.treat_symbols_as_metadata_keys_with_true_values = true


### PR DESCRIPTION
Useful for outside-in integration testing
- integrates nicely with `simple_form`
- encourages `I18n` from the get-go
- encourages cleaner `capybara` specs
