### PR TITLE
Removed `timecop` gem in favor of `travel_to`

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ And testing gems like:
 * [RSpec Mocks](https://github.com/rspec/rspec-mocks) for stubbing and spying
 * [Shoulda Matchers](https://github.com/thoughtbot/shoulda-matchers) for common
   RSpec matchers
-* [Timecop](https://github.com/travisjeffery/timecop) for testing time
 
 ## Other goodies
 

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -42,7 +42,6 @@ end
 group :test do
   gem "formulaic"
   gem "launchy"
-  gem "timecop"
   gem "webmock"
 end
 


### PR DESCRIPTION
With the release of `rails` 4.1, `Timecop.freeze` can be replaced with `travel_to`

``` ruby

Timecop.freeze 1.week.ago do
  # time sensitive code
end

travel_to 1.week.ago do
  # time sensitive code
end
```

Read more in the [TimeHelpers](https://github.com/rails/rails/blob/a6f55fe257512731d7f3f41976648d99e9ec95be/activesupport/lib/active_support/testing/time_helpers.rb#L43) module

inspired by  http://brandonhilkert.com/blog/rails-4-1-travel-to-test-helper
