### PR TITLE
Use PostgreSQL 9.3 on Travis CI

### DIFF
--- a/templates/travis.yml.erb
+++ b/templates/travis.yml.erb
@@ -27,3 +27,5 @@ notifications:
     - false
 rvm:
   - <%= Suspenders::RUBY_VERSION %>
+addons:
+  postgresql: "9.3"


### PR DESCRIPTION
[Heroku's default is Postgres 9.3](https://devcenter.heroku.com/articles/heroku-postgresql#version-support), but [Travis' default is Postgres 9.1](http://docs.travis-ci.com/user/using-postgresql/). This can occasionally cause problems which are difficult to debug.

For example, on Nyarp we had a problem with database cleaner's delete strategy behaving differently locally and on Travis.
