### PR TITLE
Remove FactoryGirl.lint in before(:suite)

### DIFF
--- a/templates/factory_girl_rspec.rb
+++ b/templates/factory_girl_rspec.rb
@@ -1,11 +1,3 @@
 RSpec.configure do |config|
-  config.before(:suite) do
-    begin
-      DatabaseCleaner.start
-    ensure
-      DatabaseCleaner.clean
-    end
-  end
-
   config.include FactoryGirl::Syntax::Methods
 end


### PR DESCRIPTION
We estimate that `lint`ing adds an extra ~300ms on a typical app we work on
for every `rspec` run, even a focused test that only runs one spec. Until we
can find a way to avoid paying that penalty, the discussion below has landed
at not putting it in Suspenders:

https://github.com/thoughtbot/suspenders/pull/299/files#r10642936
