### PR TITLE
Set `viewport` to `initial-scale=1`

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -325,6 +325,7 @@ fi
       meta_tags =<<-EOS
   <meta charset='utf-8' />
   <meta name='ROBOTS' content='NOODP' />
+  <meta name='viewport' content='initial-scale=1' />
       EOS
 
       %w(500 404 422).each do |page|

--- a/templates/suspenders_layout.html.erb.erb
+++ b/templates/suspenders_layout.html.erb.erb
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="ROBOTS" content="NOODP" />
+  <meta name="viewport" content="initial-scale=1" />
   <title><%%= title %></title>
   <%%= stylesheet_link_tag :application, :media => 'all' %>
   <%%= csrf_meta_tags %>


### PR DESCRIPTION
This sets the content's initial scale to 1 for mobile devices. Without
this tag, devices will load the page zoomed out to fit the entire
content on the screen. We need this when using a responsive grid
framework such as Bourbon Neat.

https://developer.apple.com/library/ios/documentation/appleapplications/reference/safariwebcontent/usingtheviewport/usingtheviewport.html
https://developer.mozilla.org/en-US/docs/Mozilla/Mobile/Viewport_meta_tag
