### PR TITLE
Require spec/spec_helper by default

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -175,6 +175,8 @@ end
     end
 
     def configure_rspec
+      remove_file '.rspec'
+      copy_file 'rspec', '.rspec'
       remove_file 'spec/spec_helper.rb'
       copy_file 'spec_helper.rb', 'spec/spec_helper.rb'
     end

--- a/templates/rspec
+++ b/templates/rspec
@@ -1,0 +1,1 @@
+--require spec/spec_helper


### PR DESCRIPTION
This means that spec files (e.g. user_spec.rb) don't need `require
'spec_helper'` at the top.

We removed this in 66a26d39593da6ad9ea5ff129126e1e635a5ab38 because the options
in `.rspec` were user-specific (e.g. `--color`). We are re-adding it because
requiring `spec_helper` is specific to the project.

Previous discussion: https://github.com/thoughtbot/suspenders/pull/214
