### PR TITLE
Enforce Ruby version

### DIFF
--- a/suspenders.gemspec
+++ b/suspenders.gemspec
@@ -4,7 +4,7 @@ require 'suspenders/version'
 require 'date'
 
 Gem::Specification.new do |s|
-  s.required_ruby_version = "~> #{Suspenders::RUBY_VERSION}"
+  s.required_ruby_version = Suspenders::RUBY_VERSION
   s.add_dependency 'bundler', '~> 1.3'
   s.add_dependency 'rails', '~> 4.1.0'
   s.add_development_dependency 'aruba', '~> 0.5.2'


### PR DESCRIPTION
The pessimistic operator makes it possible to install Suspenders on Ruby 2.1.2
but then run Suspenders and have it not bundle because the Gemfile is
restricted to Ruby 2.1.1. This change enforces an exact Ruby version.
