### PR TITLE
Remove SimpleCov

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -41,7 +41,6 @@ group :test do
   gem 'formulaic'
   gem 'launchy'
   gem 'shoulda-matchers', require: false
-  gem 'simplecov', require: false
   gem 'timecop'
   gem 'webmock'
 end

--- a/templates/spec_helper.rb
+++ b/templates/spec_helper.rb
@@ -1,6 +1,3 @@
-require 'simplecov'
-SimpleCov.start 'rails'
-
 ENV['RAILS_ENV'] = 'test'
 
 require File.expand_path('../../config/environment', __FILE__)


### PR DESCRIPTION
- SimpleCov was returning zero status even when build failed.
- Remove SimpleCov so that we get real build results on Travis.
- The team was reporting not regularly reviewing the coverage stats.
