### PR TITLE
Use RSpec 2.x until Travis/Capybara issues resolve

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -32,7 +32,7 @@ group :development, :test do
   gem 'dotenv-rails'
   gem 'factory_girl_rails'
   gem 'pry-rails'
-  gem 'rspec-rails', '>= 2.14'
+  gem 'rspec-rails', '~> 2.14.0'
 end
 
 group :test do


### PR DESCRIPTION
https://travis-ci.org/thoughtbot/suspenders/builds/26602519

```
rspec-support-3.0.0/lib/rspec/support/version_checker.rb:28:in
```

   `raise_too_low_error': You are using capybara 2.1.0. RSpec requires
   version >= 2.2.0. (RSpec::Support::LibraryVersionTooLowError)

https://rubygems.org/gems/capybara-webkit
