### PR TITLE
Start `xvfb` for headless JS tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: ruby
 rvm:
   - 2.1.2
+env:
+  - DISPLAY=:99.0
 before_install:
+  - sh -e /etc/init.d/xvfb start
   - "echo '--colour' > ~/.rspec"
   - git config --global user.name 'Travis CI'
   - git config --global user.email 'travis-ci@example.com'


### PR DESCRIPTION
Running `feature` specs with `js: true` will timeout on travis without
`xvfb` running.

See:
https://github.com/thoughtbot/skilledup-academy/commit/964ded18ec386d41c30b412ee3ccedf41ca42071
