### PR TITLE
Upgrade Capybara

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -37,7 +37,7 @@ group :development, :test do
 end
 
 group :test do
-  gem 'capybara-webkit', '>= 1.0.0'
+  gem 'capybara-webkit', '>= 1.2.0'
   gem 'database_cleaner'
   gem 'formulaic'
   gem 'launchy'


### PR DESCRIPTION
The previous stable release of capybara-webkit didn't support Capybara 2.3. We 
just released capybara-webkit 1.2, with support for the latest version.
