### PR TITLE
Remove Pow in bin/setup

### DIFF
--- a/templates/bin_setup
+++ b/templates/bin_setup
@@ -22,11 +22,3 @@ mkdir -p .git/safe
 
 # Pick a port for Foreman
 echo "port: 7000" > .foreman
-
-# Set up DNS via Pow
-if [ -d ~/.pow ]
-then
-  echo 7000 > ~/.pow/`basename $PWD`
-else
-  echo "Pow not set up but the team uses it for this project. Setup: http://goo.gl/RaDPO"
-fi


### PR DESCRIPTION
Our primary issue is that we do not have development/staging/production parity
when using Pow locally. Pow doesn't use event machine or a forking model, so:
- Projects using Thin will work locally but not work in production if they use
  threads or gems with eventmachine incorrectly
- Projects using Unicorn will work locally but not in production if process
  spawning is not managed correctly

Using Pow in development and something else in production would be like using
single threaded code in development but multiple threads in production; we'll
end up with race conditions eventually.

Pow is more different from production than Foreman is (at least Foreman uses
the same web server), and it's likely to be different from other members of
the team.

We'd prefer to have only one way of running the app within a project and we'd
prefer to have that way be as close to production as possible.

Keeping it the same reduces the likelihood that somebody breaks the app for
everybody else because of a "works on my machine" scenario. It also reduces
the number of onboarding questions, because everybody sets up and runs the app
the same way: `bin/setup` and `foreman start`.
