### PR TITLE
Remove Campfire in favor of Slack

### DIFF
--- a/templates/travis.yml.erb
+++ b/templates/travis.yml.erb
@@ -16,13 +16,6 @@ cache:
 language:
   - ruby
 notifications:
-  campfire:
-    on_failure:
-      - always
-    on_success:
-      - change
-    template:
-      - '(%{branch} - %{author}): %{message} - %{build_url}'
   email:
     - false
 rvm:


### PR DESCRIPTION
We don't need a placeholder for Slack because we'll typically add it using the 
CLI:

```
travis encrypt "thoughtbot:123abc" --add notifications.slack
```

http://blog.travis-ci.com/2014-03-13-slack-notifications/
