### PR TITLE
Remove Brewfile, document laptop setup

### DIFF
--- a/templates/Brewfile
+++ b/templates/Brewfile
@@ -1,2 +1,0 @@
-install postgres --no-python
-install qt imagemagick

--- a/templates/README.md.erb
+++ b/templates/README.md.erb
@@ -8,6 +8,11 @@ This repository comes equipped with a self-setup script:
 
     % ./bin/setup
 
+It assumes you have a machine equipped with Ruby, Postgres, etc. If not, set up
+your machine with [this script].
+
+[this script]: https://github.com/thoughtbot/laptop
+
 After setting up, you can run the application using [foreman]:
 
     % foreman start


### PR DESCRIPTION
There was a Brewfile template in the Suspenders source that was not being used
when generating an app. Rather than maintaining it, it might be better to
document for app developers that they should set up their machine using
something like thoughtbot/laptop.
