### PR TITLE
Run Rails app on random, not static, port number

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -26,7 +26,7 @@ module Suspenders
     end
 
     def provide_setup_script
-      copy_file 'bin_setup', 'bin/setup'
+      template 'bin_setup.erb', 'bin/setup', port_number: port_number
       run 'chmod a+x bin/setup'
     end
 
@@ -219,7 +219,7 @@ end
     end
 
     def configure_action_mailer
-      action_mailer_host 'development', "#{app_name}.local"
+      action_mailer_host 'development', "localhost:#{port_number}"
       action_mailer_host 'test', 'www.example.com'
       action_mailer_host 'staging', "staging.#{app_name}.com"
       action_mailer_host 'production', "#{app_name}.com"
@@ -380,6 +380,10 @@ fi
 
     def generate_secret
       SecureRandom.hex(64)
+    end
+
+    def port_number
+      @port_number ||= [3000, 4000, 5000, 6000, 7000, 8000, 9000].sample
     end
   end
 end

--- a/templates/bin_setup.erb
+++ b/templates/bin_setup.erb
@@ -21,7 +21,7 @@ bundle exec rake dev:prime
 mkdir -p .git/safe
 
 # Pick a port for Foreman
-echo "port: 7000" > .foreman
+echo "port: <%= config[:port_number] %>" > .foreman
 
 # Print warning if Foreman is not installed
 if ! command -v foreman &>/dev/null; then


### PR DESCRIPTION
We have lots of Suspenders-generated apps. We run them using Foreman.
Randomizing the port number can help us run multiple apps locally while
avoiding conflicts.
