### PR TITLE
Remove unnecessary FactoryGirl.find_definitions

### DIFF
--- a/templates/development_seeds.rb
+++ b/templates/development_seeds.rb
@@ -4,7 +4,6 @@ if Rails.env.development?
   namespace :dev do
     desc "Seed data for development environment"
     task prime: "db:setup" do
-      FactoryGirl.find_definitions
       include FactoryGirl::Syntax::Methods
 
       # create(:user, email: "user@example.com", password: "password")


### PR DESCRIPTION
This line causes a "duplicate factory definition" error when running `rake
db:setup`, which is run by `bin/setup`.
