### PR TITLE
Removes duplicate maintain schema call

### DIFF
--- a/templates/spec_helper.rb
+++ b/templates/spec_helper.rb
@@ -25,6 +25,5 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = false
 end
 
-ActiveRecord::Migration.maintain_test_schema!
 Capybara.javascript_driver = :webkit
 WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
RSpec 3 adds `ActiveRecord::Migration.maintain_test_schema!` to
`rails_helper.rb` on install if the Rails version is >= 4.1, making it
unnecessary to add in the `spec_helper` template.
