### PR TITLE
Removes generated .rspec file

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -175,6 +175,7 @@ end
     end
 
     def configure_rspec
+      remove_file '.rspec'
       remove_file 'spec/spec_helper.rb'
       copy_file 'spec_helper.rb', 'spec/spec_helper.rb'
     end

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -84,6 +84,12 @@ feature 'Suspend a new project with default configuration' do
     expect(File).to exist("#{project_path}/config/i18n-tasks.yml")
   end
 
+  scenario "removes generated .rspec file" do
+    run_suspenders
+
+    expect(File).not_to exist("#{project_path}/.rspec")
+  end
+
   def analytics_partial
     IO.read("#{project_path}/app/views/application/_analytics.html.erb")
   end


### PR DESCRIPTION
This removes the .rspec file generated by rspec install, thus defferring
to the users ~/.rspec file.

Enforces the changes introduced in https://github.com/thoughtbot/suspenders/commit/66a26d39593da6ad9ea5ff129126e1e635a5ab38
