### PR TITLE
Generate spec/support/i18n.rb file

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -183,6 +183,10 @@ end
       template 'travis.yml.erb', '.travis.yml'
     end
 
+    def configure_i18n_for_test_environment
+      copy_file "i18n.rb", "spec/support/i18n.rb"
+    end
+
     def configure_i18n_for_development_environment
       raise_on_missing_translations_in("development")
     end

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -83,6 +83,7 @@ module Suspenders
       build :enable_database_cleaner
       build :configure_spec_support_features
       build :configure_travis
+      build :configure_i18n_for_test_environment
       build :configure_i18n_tasks
       build :configure_action_mailer_in_specs
     end

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -43,6 +43,12 @@ feature 'Suspend a new project with default configuration' do
     expect(File).to exist("#{project_path}/spec/support/action_mailer.rb")
   end
 
+  scenario "i18n support file is added" do
+    run_suspenders
+
+    expect(File).to exist("#{project_path}/spec/support/i18n.rb")
+  end
+
   scenario 'newrelic.yml reads NewRelic license from env' do
     run_suspenders
 


### PR DESCRIPTION
- Enable using just `t` (not `I18n.t`) in specs which was introduced in
  7ea5176 and removed in eaf7de1
- Add spec to ensure i18n support file is added
