### PR TITLE
Use Sendgrid for SMTP mail delivery by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,14 @@ Suspenders also comes with:
 * [Fast-failing factories][fast]
 * A [low database connection pool limit][pool]
 * [Safe binstubs][binstub]
+* Sendgrid[sendgrid] configured to work with the Heroku plugin
 
 [bin]: http://robots.thoughtbot.com/bin-setup
 [compress]: http://robots.thoughtbot.com/content-compression-with-rack-deflater/
 [fast]: http://robots.thoughtbot.com/testing-your-factories-first
 [pool]: https://devcenter.heroku.com/articles/concurrency-and-database-connections
 [binstub]: https://github.com/thoughtbot/suspenders/pull/282
+[sendgrid]: http://sendgrid.com/
 
 Suspenders fixes several of Rails' [insecure defaults]:
 

--- a/templates/smtp.rb
+++ b/templates/smtp.rb
@@ -1,10 +1,10 @@
 if Rails.env.staging? || Rails.env.production?
   SMTP_SETTINGS = {
-    address: ENV.fetch('SMTP_ADDRESS'), # example: 'smtp.sendgrid.net'
+    address: 'smtp.sendgrid.net',
     authentication: :plain,
     domain: ENV.fetch('SMTP_DOMAIN'), # example: 'this-app.com'
-    password: ENV.fetch('SMTP_PASSWORD'),
+    password: ENV.fetch('SENDGRID_PASSWORD'),
     port: '587',
-    user_name: ENV.fetch('SMTP_USERNAME')
+    user_name: ENV.fetch('SENDGRID_USERNAME')
   }
 end


### PR DESCRIPTION
When deploying to Heroku I was getting

`KeyError: key not found`

which wasn't immediately clear.

Do we use anything other than sendgrid for mail delivery in production?
