### PR TITLE
Set `en.titles.application` to App Name

### DIFF
--- a/templates/config_i18n_tasks.yml
+++ b/templates/config_i18n_tasks.yml
@@ -10,3 +10,4 @@ ignore_unused:
   - date.*
   - simple_form.*
   - time.*
+  - titles.*

--- a/templates/config_locales_en.yml
+++ b/templates/config_locales_en.yml
@@ -14,3 +14,6 @@ en:
         "%b %-d, %Y"
       short:
         "%B %d"
+
+  titles:
+    application: <%= app_name.humanize %>


### PR DESCRIPTION
- Gives developers that are unfamiliar with Caleb's `title` gem a nice hook to
  get started with
