### PR TITLE
Raise on missing translations in test

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -182,8 +182,9 @@ end
       copy_file "i18n.rb", "spec/support/i18n.rb"
     end
 
-    def configure_i18n_for_development_environment
+    def configure_i18n_for_missing_translations
       raise_on_missing_translations_in("development")
+      raise_on_missing_translations_in("test")
     end
 
     def configure_i18n_tasks

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -71,7 +71,7 @@ module Suspenders
       build :provide_setup_script
       build :provide_dev_prime_task
       build :configure_generators
-      build :configure_i18n_for_development_environment
+      build :configure_i18n_for_missing_translations
     end
 
     def setup_test_environment

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -78,14 +78,16 @@ feature 'Suspend a new project with default configuration' do
     )
   end
 
-  scenario "raises on missing translations in development" do
+  scenario "raises on missing translations in development and test" do
     run_suspenders
 
-    environment_file =
-      IO.read("#{project_path}/config/environments/development.rb")
-    expect(environment_file).to match(
-      /^ +config.action_view.raise_on_missing_translations = true$/
-    )
+    %w[development test].each do |environment|
+      environment_file =
+        IO.read("#{project_path}/config/environments/#{environment}.rb")
+      expect(environment_file).to match(
+        /^ +config.action_view.raise_on_missing_translations = true$/
+      )
+    end
   end
 
   scenario "specs for missing or unused translations" do


### PR DESCRIPTION
Although we're generating a separate `spec/support/i18n.rb` file for i18n (4d30479c3750ad5ce708cbf03ab8a58d484f2e8a), we're
once again **not** failing specs when a translation is missing.
