### PR TITLE
Change `File.exists?` to `File.exist?`

### DIFF
--- a/spec/support/suspenders.rb
+++ b/spec/support/suspenders.rb
@@ -20,7 +20,7 @@ module SuspendersTestHelpers
   end
 
   def drop_dummy_database
-    if File.exists?(project_path)
+    if File.exist?(project_path)
       Dir.chdir(project_path) do
         Bundler.with_clean_env do
           `rake db:drop`


### PR DESCRIPTION
- `File.exists?` is deprecated in favor of `File.exist?`

https://github.com/ruby/ruby/blob/trunk/file.c#L1482
