### PR TITLE
Add `bin/deploy` script

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ Other goodies
 
 Suspenders also comes with:
 
-* The [`./bin/setup`][bin] convention for new developer setup
+* The [`./bin/setup`][setup] convention for new developer setup
+* The `./bin/deploy` convention for deploying to Heroku
 * Rails' flashes set up and in application layout
 * A few nice time formats set up for localization
 * `Rack::Deflater` to [compress responses with Gzip][compress]
@@ -96,7 +97,7 @@ Suspenders also comes with:
 * The analytics adapter [Segment][segment] (and therefore config for Google
   Analytics, Intercom, Facebook Ads, Twitter Ads, etc.)
 
-[bin]: http://robots.thoughtbot.com/bin-setup
+[setup]: http://robots.thoughtbot.com/bin-setup
 [compress]: http://robots.thoughtbot.com/content-compression-with-rack-deflater/
 [pool]: https://devcenter.heroku.com/articles/concurrency-and-database-connections
 [binstub]: https://github.com/thoughtbot/suspenders/pull/282

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -320,6 +320,22 @@ fi
       end
     end
 
+    def provide_deploy_script
+      copy_file "bin_deploy", "bin/deploy"
+
+      instructions = <<-MARKDOWN
+## Deploying
+
+If you have previously run the `./bin/setup` script,
+you can deploy to staging and production with:
+
+    $ ./bin/deploy staging
+    $ ./bin/deploy production
+      MARKDOWN
+
+      append_file "README.md", instructions
+    end
+
     def create_github_repo(repo_name)
       path_addition = override_path_for_tests
       run "#{path_addition} hub create #{repo_name}"

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -158,6 +158,7 @@ module Suspenders
         build :set_heroku_remotes
         build :set_heroku_rails_secrets
         build :set_memory_management_variable
+        build :provide_deploy_script
       end
     end
 

--- a/spec/features/heroku_spec.rb
+++ b/spec/features/heroku_spec.rb
@@ -15,5 +15,14 @@ feature 'Heroku' do
 
     expect(bin_setup).to include("heroku join --app #{app_name}-staging")
     expect(bin_setup).to include("heroku join --app #{app_name}-production")
+
+    bin_deploy = IO.read("#{project_path}/bin/deploy")
+
+    expect(bin_deploy).to include("heroku run rake db:migrate")
+
+    readme = IO.read("#{project_path}/README.md")
+
+    expect(readme).to include("./bin/deploy staging")
+    expect(readme).to include("./bin/deploy production")
   end
 end

--- a/templates/bin_deploy
+++ b/templates/bin_deploy
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Run this script to deploy the app to Heroku.
+
+set -e
+
+branch="$(git symbolic-ref HEAD --short)"
+target="${1:-staging}"
+
+git push "$target" "$branch:master"
+heroku run rake db:migrate --remote "$target"
+heroku restart --remote "$target"


### PR DESCRIPTION
- Help avoid forgetting to run `rake db:migrate`.
- Help avoid forgetting to run `restart` after migrate.
- Allow each app to edit these deploy instructions to fit their
  environments' needs (such as `run rake purge` to clear a cache)
  but maintain the same `./bin/deploy` interface and convention
  that is consistent with our many Middleman and Rails apps.
