### PR TITLE
Fix Bundler installation code

### DIFF
--- a/templates/bin_setup.erb
+++ b/templates/bin_setup.erb
@@ -7,10 +7,7 @@
 set -e
 
 # Set up Ruby dependencies via Bundler
-if ! command -v bundle > /dev/null; then
-  gem install bundler --no-document
-fi
-
+bundle --version &> /dev/null || gem install bundler --no-document
 bundle install
 
 # Set up configurable environment variables


### PR DESCRIPTION
Our previous Bundler idempotency code did not work if you had a version of
Bundler installed on a different Ruby version.
