### PR TITLE
Add bundler-audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ And development gems like:
   objects
 * [ByeBug](https://github.com/deivid-rodriguez/byebug) for interactively
   debugging behavior
+* [Bundler Audit](https://github.com/rubysec/bundler-audit) for scanning the
+  Gemfile for insecure dependencies based on published CVEs
 * [Spring](https://github.com/rails/spring) for fast Rails actions via
   pre-loading
 
@@ -89,10 +91,10 @@ Suspenders also comes with:
 * [Safe binstubs][binstub]
 * [t() and l() in specs without prefixing with I18n][i18n]
 * An automatically-created `SECRET_KEY_BASE` environment variable in all
-  environments.
-* Configuration for [Travis Pro][travis] continuous integration.
-* The analytics adapter [Segment.io][segment] (and therefore config for Google
-  Analytics, Intercom, Facebook Ads, Twitter Ads, etc.).
+  environments
+* Configuration for [Travis Pro][travis] continuous integration
+* The analytics adapter [Segment][segment] (and therefore config for Google
+  Analytics, Intercom, Facebook Ads, Twitter Ads, etc.)
 
 [bin]: http://robots.thoughtbot.com/bin-setup
 [compress]: http://robots.thoughtbot.com/content-compression-with-rack-deflater/

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -330,6 +330,11 @@ fi
         'app/views/application/_analytics.html.erb'
     end
 
+    def setup_bundler_audit
+      copy_file "bundler_audit.rake", "lib/tasks/bundler_audit.rake"
+      append_file "Rakefile", %{\ntask default: "bundler:audit"\n}
+    end
+
     def copy_miscellaneous_files
       copy_file 'errors.rb', 'config/initializers/errors.rb'
     end

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -40,6 +40,7 @@ module Suspenders
       invoke :create_heroku_apps
       invoke :create_github_repo
       invoke :setup_segment_io
+      invoke :setup_bundler_audit
       invoke :outro
     end
 
@@ -174,6 +175,11 @@ module Suspenders
 
     def setup_gitignore
       build :gitignore_files
+    end
+
+    def setup_bundler_audit
+      say "Setting up bundler-audit"
+      build :setup_bundler_audit
     end
 
     def init_git

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -25,6 +25,7 @@ gem "uglifier"
 gem "unicorn"
 
 group :development do
+  gem "bundler-audit"
   gem "spring"
   gem "spring-commands-rspec"
 end

--- a/templates/bundler_audit.rake
+++ b/templates/bundler_audit.rake
@@ -1,0 +1,11 @@
+if Rails.env.development? || Rails.env.test?
+  require "bundler/audit/cli"
+
+  namespace :bundler do
+    task :audit do
+      %w(update check).each do |command|
+        Bundler::Audit::CLI.start [command]
+      end
+    end
+  end
+end


### PR DESCRIPTION
We've used this on a couple projects. Here's what it does:
- Scans your Gemfile for insecure dependencies.
- Uses publishd CVEs to find vulnerabilities.

To get set up with bundler-audit, this commit:
- Adds it to the development dependencies.
- Adds a rake task to invoke the CLI.
- Adds it to your default `rake` run.

https://trello.com/c/PltmBueK/210
