### PR TITLE
Copy sample.env to .env

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -245,6 +245,7 @@ end
 
     def setup_foreman
       copy_file 'sample.env', '.sample.env'
+      copy_file 'sample.env', '.env'
       copy_file 'Procfile', 'Procfile'
     end
 


### PR DESCRIPTION
I have to copy by myself .sample.env to .env
I think this could be done automatically

Was there a good reason to do not copy sample.env to .env?
