### PR TITLE
Use Heroku-recommended timeout numbers

### DIFF
--- a/templates/rack_timeout.rb
+++ b/templates/rack_timeout.rb
@@ -1,1 +1,1 @@
-Rack::Timeout.timeout = (ENV["TIMEOUT_IN_SECONDS"] || 5).to_i
+Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i

--- a/templates/unicorn.rb
+++ b/templates/unicorn.rb
@@ -1,7 +1,7 @@
 # https://devcenter.heroku.com/articles/rails-unicorn
 
-worker_processes (ENV["WEB_CONCURRENCY"] || 3).to_i
-timeout (ENV["WEB_TIMEOUT"] || 5).to_i
+worker_processes (ENV["UNICORN_WORKERS"] || 3).to_i
+timeout (ENV["UNICORN_TIMEOUT"] || 15).to_i
 preload_app true
 
 before_fork do |server, worker|


### PR DESCRIPTION
Rename ENV variables to be very explicit. Couples their names to their
libraries.
