### PR TITLE
Allow --heroku-region to override default US region

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ This:
 * Adds the [Rails 12 Factor](https://github.com/heroku/rails_12factor) gem
   to make running Rails 4 apps easier on Heroku
 
+If you want to specify a different region from US:
+
+    suspenders app --heroku true --heroku-region eu
+
 Git
 ---
 

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -279,9 +279,9 @@ end
       run 'git init'
     end
 
-    def create_heroku_apps
-      run_heroku "create #{app_name}-production", "production"
-      run_heroku "create #{app_name}-staging", "staging"
+    def create_heroku_apps(region)
+      run_heroku "create #{app_name}-production --region #{region}", "production"
+      run_heroku "create #{app_name}-staging --region #{region}", "staging"
       run_heroku "config:add RACK_ENV=staging RAILS_ENV=staging", "staging"
     end
 

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -9,6 +9,9 @@ module Suspenders
     class_option :heroku, :type => :boolean, :aliases => '-H', :default => false,
       :desc => 'Create staging and production Heroku apps'
 
+    class_option :heroku_region, :type => :string, :default => "us",
+      :desc => 'Set Heroku region'
+
     class_option :github, :type => :string, :aliases => '-G', :default => nil,
       :desc => 'Create Github repository and add remote origin pointed to repo'
 
@@ -154,7 +157,7 @@ module Suspenders
     def create_heroku_apps
       if options[:heroku]
         say 'Creating Heroku apps'
-        build :create_heroku_apps
+        build :create_heroku_apps, options[:heroku_region]
         build :set_heroku_remotes
         build :set_heroku_rails_secrets
         build :set_memory_management_variable

--- a/spec/features/heroku_spec.rb
+++ b/spec/features/heroku_spec.rb
@@ -5,8 +5,8 @@ feature 'Heroku' do
     run_suspenders('--heroku=true')
 
     expect(FakeHeroku).to have_gem_included(project_path, 'rails_12factor')
-    expect(FakeHeroku).to have_created_app_for('staging')
-    expect(FakeHeroku).to have_created_app_for('production')
+    expect(FakeHeroku).to have_created_app_for('staging', region: 'us')
+    expect(FakeHeroku).to have_created_app_for('production', region: 'us')
     expect(FakeHeroku).to have_configured_vars('staging', 'SECRET_KEY_BASE')
     expect(FakeHeroku).to have_configured_vars('production', 'SECRET_KEY_BASE')
 
@@ -15,5 +15,12 @@ feature 'Heroku' do
 
     expect(bin_setup).to include("heroku join --app #{app_name}-staging")
     expect(bin_setup).to include("heroku join --app #{app_name}-production")
+  end
+
+  scenario 'Suspend a project with --heroku=true --heroku-region=eu' do
+    run_suspenders('--heroku=true --heroku-region=eu')
+
+    expect(FakeHeroku).to have_created_app_for('staging', region: 'eu')
+    expect(FakeHeroku).to have_created_app_for('production', region: 'eu')
   end
 end

--- a/spec/support/fake_heroku.rb
+++ b/spec/support/fake_heroku.rb
@@ -23,9 +23,9 @@ class FakeHeroku
     end
   end
 
-  def self.has_created_app_for?(remote_name)
+  def self.has_created_app_for?(remote_name, options)
     app_name = "#{SuspendersTestHelpers::APP_NAME}-#{remote_name}"
-    expected_line = "create #{app_name} --remote #{remote_name}\n"
+    expected_line = "create #{app_name} --region #{options[:region]} --remote #{remote_name}\n"
 
     File.foreach(RECORDER).any? { |line| line == expected_line }
   end


### PR DESCRIPTION
I left US as default region. This could be useful for european suspender's users :)

Related Issue:
https://github.com/thoughtbot/suspenders/issues/427