### PR TITLE
Do not automatically trust repo binstubs

### DIFF
--- a/templates/bin_setup.erb
+++ b/templates/bin_setup.erb
@@ -18,9 +18,6 @@ fi
 # Set up database and add any development seed data
 bundle exec rake db:setup dev:prime
 
-# Add binstubs to PATH via export PATH=".git/safe/../../bin:$PATH" in ~/.zshenv
-mkdir -p .git/safe
-
 # Pick a port for Foreman
 if ! grep --quiet --no-messages --fixed-strings 'port' .foreman; then
   printf 'port: <%= config[:port_number] %>\n' >> .foreman


### PR DESCRIPTION
The idea behind requring explicit permission to add `./bin` to your path is
that the developer has considered the code and the potential risks and make a
concious decision to trust the binstubs.

This shouldn't be something that's required in order to have the project setup
script run.
