### PR TITLE
Updated _flashes.html.erb with proper id

### DIFF
--- a/templates/_flashes.html.erb
+++ b/templates/_flashes.html.erb
@@ -1,7 +1,7 @@
 <% if flash.any? %>
   <div id="flash">
     <% flash.each do |key, value| -%>
-      <div id="flash_<%= key %>"><%= value %></div>
+      <div id="flash-<%= key %>"><%= value %></div>
     <% end -%>
   </div>
 <% end %>


### PR DESCRIPTION
In the generated _flashes.scss, the selectors use `flash-key` instead of `flash_key`, preventing it from working out of the box.
