### PR TITLE
Add option to skip bundle

### DIFF
--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -15,6 +15,9 @@ module Suspenders
     class_option :skip_test_unit, :type => :boolean, :aliases => '-T', :default => true,
       :desc => 'Skip Test::Unit files'
 
+    class_option :skip_bundle, type: :boolean, aliases: "-B", default: false,
+      desc: "Don't run bundle install"
+
     def finish_template
       invoke :suspenders_customization
       super
@@ -52,7 +55,7 @@ module Suspenders
         build :setup_heroku_specific_gems
       end
 
-      bundle_command 'install'
+      bundle_command "install" unless options[:skip_bundle]
     end
 
     def setup_database


### PR DESCRIPTION
I loath having all of my gems installed globally, I want to only have the
things I _really_ need being globally accessible and then modifying my
`GEM_HOME` and `GEM_PATH` depending on the project I'm in.

To make that work with setting up a new rails project,
I always run `--skip-bundle` and install my gems later on.

This patch just mimics this argument from rails itself: https://github.com/rails/rails/blob/ef99d4cd3ecc58a8c1484740b2fb5447dbda23ab/railties/lib/rails/generators/app_base.rb#L32-33
