### PR TITLE
Bundler audit no required

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -25,13 +25,13 @@ gem "uglifier"
 gem "unicorn"
 
 group :development do
-  gem "bundler-audit", require: false
   gem "spring"
   gem "spring-commands-rspec"
 end
 
 group :development, :test do
   gem "awesome_print"
+  gem "bundler-audit", require: false
   gem "byebug"
   gem "dotenv-rails"
   gem "factory_girl_rails"

--- a/templates/bundler_audit.rake
+++ b/templates/bundler_audit.rake
@@ -1,4 +1,4 @@
-if Rails.env.development?
+if Rails.env.development? || Rails.env.test?
   require "bundler/audit/cli"
 
   namespace :bundler do


### PR DESCRIPTION
bundler-audit is not required in Gemfile

bundler-audit is not present in `test` group, so we can remove the 2nd || condition
