### PR TITLE
Configure simple_form

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -220,6 +220,10 @@ end
       copy_file 'rack_timeout.rb', 'config/initializers/rack_timeout.rb'
     end
 
+    def configure_simple_form
+      bundle_command 'exec rails generate simple_form:install'
+    end
+
     def configure_action_mailer
       action_mailer_host 'development', "localhost:#{port_number}"
       action_mailer_host 'test', 'www.example.com'

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -126,6 +126,7 @@ module Suspenders
       build :configure_time_zone
       build :configure_time_formats
       build :configure_rack_timeout
+      build :configure_simple_form
       build :disable_xml_params
       build :fix_i18n_deprecation_warning
       build :setup_default_rake_task

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -111,6 +111,12 @@ feature 'Suspend a new project with default configuration' do
     expect(locales_en_file).to match(/application: #{app_name.humanize}/)
   end
 
+  scenario "config simple_form" do
+    run_suspenders
+
+    expect(File).to exist("#{project_path}/config/initializers/simple_form.rb")
+  end
+
   def analytics_partial
     IO.read("#{project_path}/app/views/application/_analytics.html.erb")
   end


### PR DESCRIPTION
This change removes the warning:

```
[Simple Form] Simple Form is not configured in the application and will use the default values. Use `rails generate simple_form:install` to generate the Simple Form configuration.
```

when starting rails.

This PR does not support `--bootstrap` / `--foundation` options.
