### PR TITLE
Use only rails_stdout_logging, not rails_12factor

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,12 @@ This:
 * Sets them as `staging` and `production` Git remotes
 * Configures staging with `RACK_ENV` and `RAILS_ENV` environment variables set
   to `staging`
-* Adds the [Rails 12 Factor](https://github.com/heroku/rails_12factor) gem
-  to make running Rails 4 apps easier on Heroku
+* Adds the [Rails Stdout Logging][logging-gem] gem
+  to configure the app to log to standard out,
+  which is how [Heroku's logging][heroku-logging] works.
+
+[logging-gem]: https://github.com/heroku/rails_stdout_logging
+[heroku-logging]: https://devcenter.heroku.com/articles/logging#writing-to-your-log
 
 ## Git
 

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -77,8 +77,11 @@ module Suspenders
   config.middleware.use Rack::Deflater
       RUBY
 
-      inject_into_file 'config/environments/production.rb', config,
-        :after => "config.serve_static_assets = false\n"
+      inject_into_file(
+        "config/environments/production.rb",
+        config,
+        after: serve_static_files_line
+      )
     end
 
     def setup_asset_host
@@ -90,9 +93,11 @@ module Suspenders
         "config.assets.version = '1.0'",
         'config.assets.version = (ENV["ASSETS_VERSION"] || "1.0")'
 
-      replace_in_file 'config/environments/production.rb',
-        "config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?",
-        'config.static_cache_control = "public, max-age=#{1.year.to_i}"'
+      inject_into_file(
+        "config/environments/production.rb",
+        'config.static_cache_control = "public, max-age=#{1.year.to_i}"',
+        after: serve_static_files_line
+      )
     end
 
     def setup_staging_environment
@@ -156,8 +161,11 @@ end
     end
 
     def setup_heroku_specific_gems
-      inject_into_file 'Gemfile', "\n\s\sgem 'rails_12factor'",
+      inject_into_file(
+        "Gemfile",
+        %{\n\s\sgem "rails_stdout_logging"},
         after: /group :staging, :production do/
+      )
     end
 
     def enable_database_cleaner
@@ -429,6 +437,10 @@ end
 
     def port
       @port ||= [3000, 4000, 5000, 7000, 8000, 9000].sample
+    end
+
+    def serve_static_files_line
+      "config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?\n"
     end
   end
 end

--- a/spec/features/heroku_spec.rb
+++ b/spec/features/heroku_spec.rb
@@ -1,14 +1,15 @@
-require 'spec_helper'
+require "spec_helper"
 
-feature 'Heroku' do
-  scenario 'Suspend a project with --heroku=true' do
-    run_suspenders('--heroku=true')
+feature "Heroku" do
+  scenario "Suspend a project with --heroku=true" do
+    run_suspenders("--heroku=true")
 
-    expect(FakeHeroku).to have_gem_included(project_path, 'rails_12factor')
-    expect(FakeHeroku).to have_created_app_for('staging')
-    expect(FakeHeroku).to have_created_app_for('production')
-    expect(FakeHeroku).to have_configured_vars('staging', 'SECRET_KEY_BASE')
-    expect(FakeHeroku).to have_configured_vars('production', 'SECRET_KEY_BASE')
+    expect(FakeHeroku).
+      to have_gem_included(project_path, "rails_stdout_logging")
+    expect(FakeHeroku).to have_created_app_for("staging")
+    expect(FakeHeroku).to have_created_app_for("production")
+    expect(FakeHeroku).to have_configured_vars("staging", "SECRET_KEY_BASE")
+    expect(FakeHeroku).to have_configured_vars("production", "SECRET_KEY_BASE")
 
     bin_setup = IO.read("#{project_path}/bin/setup")
     app_name = SuspendersTestHelpers::APP_NAME


### PR DESCRIPTION
Rails 4.2.0 uses a `ENV['RAILS_SERVE_STATIC_FILES']` variable to determine by
default whether to server static files. We should use that community
convention rather than the `rails_serve_static_assets` gem, which is loaded by
`rails_12factor`. Removing that coupling also allows non-Heroku users to use
this convention.

When we remove our reliance on that gem, the remaining half of
`rails_12factor` that we still want to use in Heroku environments is the
`rails_stdout_logging` gem.

Extract a `serve_static_files_line` helper method as a way to reliably append
to the `config/environments/production.rb` file.

Use double quotes instead of single quotes on changed lines and the lines
around them.