### PR TITLE
Improve SMTP_DOMAIN comment

### DIFF
--- a/templates/smtp.rb
+++ b/templates/smtp.rb
@@ -1,7 +1,7 @@
 SMTP_SETTINGS = {
   address: ENV.fetch("SMTP_ADDRESS"), # example: "smtp.sendgrid.net"
   authentication: :plain,
-  domain: ENV.fetch("SMTP_DOMAIN"), # example: "this-app.com"
+  domain: ENV.fetch("SMTP_DOMAIN"), # example: "heroku.com"
   enable_starttls_auto: true,
   password: ENV.fetch("SMTP_PASSWORD"),
   port: "587",


### PR DESCRIPTION
In Heroku's docs for
[Mandrill](https://devcenter.heroku.com/articles/mandrill) and
[SendGrid](https://devcenter.heroku.com/articles/sendgrid#ruby-rails), they
suggest using `heroku.com`.

Make this clearer for implementers.