### PR TITLE
Create Hound-compliant config/unicorn.rb

### DIFF
--- a/templates/unicorn.rb
+++ b/templates/unicorn.rb
@@ -4,9 +4,9 @@ worker_processes (ENV["UNICORN_WORKERS"] || 3).to_i
 timeout (ENV["UNICORN_TIMEOUT"] || 15).to_i
 preload_app true
 
-before_fork do |server, worker|
+before_fork do |_server, _worker|
   Signal.trap "TERM" do
-    puts "Unicorn master intercepting TERM and sending myself QUIT instead"
+    puts "Unicorn master intercepting TERM, sending myself QUIT instead"
     Process.kill "QUIT", Process.pid
   end
 
@@ -15,9 +15,9 @@ before_fork do |server, worker|
   end
 end
 
-after_fork do |server, worker|
+after_fork do |_server, _worker|
   Signal.trap "TERM" do
-    puts "Unicorn worker intercepting TERM and doing nothing. Wait for master to send QUIT"
+    puts "Unicorn worker intercepting TERM, waiting for master to send QUIT"
   end
 
   if defined? ActiveRecord::Base


### PR DESCRIPTION
Fix:

> Line is too long. [91/80]

Fix:

> Unused block argument - server.
> Unused block argument - worker.
> You can omit all the arguments if you don't care about them.