### PR TITLE
Use Travis container infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ install:
   - bundle install
 notifications:
   email: false
+sudo: false

--- a/templates/travis.yml.erb
+++ b/templates/travis.yml.erb
@@ -19,3 +19,4 @@ rvm:
   - <%= Suspenders::RUBY_VERSION %>
 addons:
   postgresql: "9.3"
+sudo: false


### PR DESCRIPTION
Builds start sooner and run faster. Open source builds on the container
infrastructure also get to use the bundle cache. See:
http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/

This has worked extremely well on all projects I've tried it on thus far.