### PR TITLE
Upgrade RSpec to 3.1.0

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -38,7 +38,7 @@ group :development, :test do
   gem "dotenv-rails"
   gem "factory_girl_rails"
   gem "pry-rails"
-  gem "rspec-rails", "~> 3.0.0"
+  gem "rspec-rails", "~> 3.1.0"
 end
 
 group :test do


### PR DESCRIPTION
* Fixes Rails 4.2 named route deprecation warnings