### PR TITLE
Do run `rake dev:prime` on CI

### DIFF
--- a/templates/development_seeds.rb
+++ b/templates/development_seeds.rb
@@ -1,4 +1,4 @@
-if Rails.env.development?
+if Rails.env.development? || Rails.env.test?
   require "factory_girl"
 
   namespace :dev do


### PR DESCRIPTION
We wrap the `dev:prime` task in `if Rails.env.development?`. CI runs in the test environment. Because the environments don't match, the `dev:prime` task is never defined in CI, and CI crashes.