### PR TITLE
Don't set default_url_options to a string

### DIFF
--- a/lib/suspenders/actions.rb
+++ b/lib/suspenders/actions.rb
@@ -10,8 +10,8 @@ module Suspenders
     end
 
     def action_mailer_host(rails_env, host)
-      host_config = "config.action_mailer.default_url_options = { host: '#{host}' }"
-      configure_environment(rails_env, host_config)
+      config = "config.action_mailer.default_url_options = { host: #{host} }"
+      configure_environment(rails_env, config)
     end
 
     def configure_environment(rails_env, config)

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -237,8 +237,8 @@ end
     end
 
     def configure_action_mailer
-      action_mailer_host "development", "localhost:#{port}"
-      action_mailer_host "test", "www.example.com"
+      action_mailer_host "development", %{"localhost:#{port}"}
+      action_mailer_host "test", %{"www.example.com"}
       action_mailer_host "staging", %{ENV.fetch("HOST")}
       action_mailer_host "production", %{ENV.fetch("HOST")}
     end


### PR DESCRIPTION
Before:

```ruby
config.action_mailer.default_url_options = { host: 'ENV.fetch("HOST")' }
```

After:

```ruby
config.action_mailer.default_url_options = { host: ENV.fetch("HOST") }
```