### PR TITLE
Turn off parameter wrapping

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -118,6 +118,10 @@ end
       template 'secrets.yml', 'config/secrets.yml', force: true
     end
 
+    def disallow_wrapping_parameters
+      remove_file "config/initializers/wrap_parameters.rb"
+    end
+
     def create_partials_directory
       empty_directory 'app/views/application'
     end


### PR DESCRIPTION
With this setting on, Rails will happily turn a POST to the UsersController 
from this:

    { name: "Ralph" }

Into this:

    { users: { name: "Ralph" }, name: "Ralph" }

This means that `params.require(:user).permit(:name)` will not raise an error,
even if the developer forgets to nest their parameters inside a top-level
`user` key.

It is enabled for JSON by default. This change turns it off for every format.