### PR TITLE
Turn off Travis email notifications

### DIFF
--- a/templates/travis.yml.erb
+++ b/templates/travis.yml.erb
@@ -13,8 +13,7 @@ cache:
 language:
   - ruby
 notifications:
-  email:
-    - false
+  email: false
 rvm:
   - <%= Suspenders::RUBY_VERSION %>
 addons:


### PR DESCRIPTION
The documentation gives this as the correct way to turn off build
notifications:

```yaml
notifications:
  email: false
```

This maps to `{ "notifications" => { "email" => false } }` in Ruby.

We currently set it to:

```yaml
notifications:
  email:
    - false
```

This maps to `{ "notifications" => { "email" => [false] } }` (note that
`false` is in an array). Because of this, Travis does not turn off email
notifications.

Docs: http://docs.travis-ci.com/user/notifications/