### PR TITLE
Tell Heroku to serve static files

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -300,9 +300,13 @@ end
     end
 
     def create_heroku_apps(flags)
+      rack_env = "RACK_ENV=staging RAILS_ENV=staging"
+      rails_serve_static_files = "RAILS_SERVE_STATIC_FILES=true"
+      staging_config = "#{rack_env} #{rails_serve_static_files}"
       run_heroku "create #{app_name}-production #{flags}", "production"
       run_heroku "create #{app_name}-staging #{flags}", "staging"
-      run_heroku "config:add RACK_ENV=staging RAILS_ENV=staging", "staging"
+      run_heroku "config:add #{staging_config}", "staging"
+      run_heroku "config:add #{rails_serve_static_files}", "production"
     end
 
     def set_heroku_remotes


### PR DESCRIPTION
By default, Rails 4 will not serve your assets:
https://devcenter.heroku.com/articles/rails-4-asset-pipeline#serve-assets

We use an environment variable to tell Rails to serve static files:

```ruby
config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
```

..but we were not automatically setting that environment variable on Heroku.
Now we are.