### PR TITLE
Document how to use the #title helper

### DIFF
--- a/templates/suspenders_layout.html.erb.erb
+++ b/templates/suspenders_layout.html.erb.erb
@@ -4,6 +4,11 @@
   <meta charset="utf-8" />
   <meta name="ROBOTS" content="NOODP" />
   <meta name="viewport" content="initial-scale=1" />
+  <%%#
+    Configure default and controller-, and view-specific titles in
+    config/locales/en.yml. For more see:
+    https://github.com/calebthompson/title#usage
+  %>
   <title><%%= title %></title>
   <%%= stylesheet_link_tag :application, media: "all" %>
   <%%= csrf_meta_tags %>


### PR DESCRIPTION
When opening layout.html.erb to change the title, if can be off-putting
to traverse down a nest of discovery in order to know that one should
change the title in config/locales/*.yml. Add a note right there so that
people don't have to hunt.