### PR TITLE
Faster, more correct bundler gem and Gemfile install

### DIFF
--- a/templates/bin_setup.erb
+++ b/templates/bin_setup.erb
@@ -7,8 +7,8 @@
 set -e
 
 # Set up Ruby dependencies via Bundler
-gem list bundler --installed > /dev/null || gem install bundler
-bundle install
+gem install bundler --conservative
+bundle check || bundle install
 
 # Set up configurable environment variables
 if [ ! -f .env ]; then


### PR DESCRIPTION
- About 3x faster when gems are available
- Does not return false positive when other gems on system have 'bundler' in name

**Updated**: [per discussion](https://github.com/thoughtbot/suspenders/pull/497#discussion-diff-23411299), to use `gem install bundler --conservative` as it works with rbenv and will only install the gem if not installed.
Tested on my 2015 macbook pro, Mavericks, with RVM and Ruby 2.1.5 running via bash

Regarding the `gem uninstall -aIx gem_name` command used below

```plain
 -a  Uninstall all matching versions
 -I  Ignore dependency requirements while uninstalling.
 -x  Uninstall applicable executables without confirmation.
```
## Bundler not installed

###  gem list bundler --installed, _0.619_*

```bash
gem uninstall -aIx bundler
time gem list bundler --installed; echo $?
```

```plain
true

real    0m0.619s
user    0m0.538s
sys     0m0.077s
0
```

*but note it is falsely returning 'true' because I have other gems on the system with 'bundler' in the name*

### gem list ^bundler$ --installed, _0.604_

```bash
time gem list ^bundler$ --installed; echo $?
```

```plain
false

real    0m0.604s
user    0m0.525s
sys     0m0.075s
1
```

### command -v bundle, _0.000_

```bash
time command -v bundle; echo $?
```

```plain
real    0m0.000s
user    0m0.000s
sys     0m0.000s
1
```

## Bundler not installed, installing bundler

### gem list bundler --installed || gem install bundler, _0.621_*

```bash
gem uninstall -aIx bundler
time eval "gem list bundler --installed || gem install bundler"; echo $?
```

```plain
true

real    0m0.621s
user    0m0.539s
sys     0m0.076s
0
```

*again, it is falsely only executing the LHS because I have other gems on the system with 'bundler' in the name*

### gem list ^bundler$ --installed || gem install bundler, _4.695_

```bash
gem uninstall -aIx bundler
time eval "gem list ^bundler$ --installed || gem install bundler"; echo $?
```

```plain
false
Fetching: bundler-1.7.12.gem (100%)
Successfully installed bundler-1.7.12
Parsing documentation for bundler-1.7.12
Installing ri documentation for bundler-1.7.12
Done installing documentation for bundler after 1 seconds
1 gem installed

real    0m4.695s
user    0m2.983s
sys     0m0.348s
0
```

### command -v bundle || gem install bundler, _4.051_

```bash
gem uninstall -aIx bundler
time eval "command -v bundle || gem install bundler"; echo $?
```

```plain
Fetching: bundler-1.7.12.gem (100%)
Successfully installed bundler-1.7.12
Parsing documentation for bundler-1.7.12
Installing ri documentation for bundler-1.7.12
Done installing documentation for bundler after 1 seconds
1 gem installed

real    0m4.051s
user    0m2.459s
sys     0m0.269s
0
```

## Bundler installed, Gemfile containing "gem 'dotenv-rails', '1.0.2'"

### Gems Not Installed

#### Without Gemfile.lock

##### bundle, _2.706_

```bash
rm Gemfile.lock; gem uninstall -aIx dotenv-rails dotenv
time bundle; echo $?
```

```plain
Fetching gem metadata from https://rubygems.org/....
Resolving dependencies...
Installing dotenv 1.0.2
Installing dotenv-rails 1.0.2
Using bundler 1.7.12
Your bundle is complete!
Use `bundle show [gemname]` to see where a bundled gem is installed.

real    0m2.706s
user    0m0.739s
sys     0m0.103s
0
```

##### bundle check || bundle install, _2.423_

```bash
rm Gemfile.lock; gem uninstall -aIx dotenv-rails dotenv
time eval "bundle check || bundle install"; echo $?
```

```plain
Resolving dependencies...
Bundler can't satisfy your Gemfile's dependencies.
Install missing gems with `bundle install`.
Fetching gem metadata from https://rubygems.org/....
Resolving dependencies...
Installing dotenv 1.0.2
Installing dotenv-rails 1.0.2
Using bundler 1.7.12
Your bundle is complete!
Use `bundle show [gemname]` to see where a bundled gem is installed.

real    0m2.423s
user    0m1.264s
sys     0m0.171s
0
```

#### With Gemfile.lock

##### bundle, _3.176_

```bash
bundle; gem uninstall -aIx dotenv-rails dotenv
time bundle; echo $?
```

```plain
Fetching gem metadata from https://rubygems.org/...
Installing dotenv 1.0.2
Installing dotenv-rails 1.0.2
Using bundler 1.7.12
Your bundle is complete!
Use `bundle show [gemname]` to see where a bundled gem is installed.

real    0m3.176s
user    0m0.755s
sys     0m0.105s
0
```

##### bundle check || bundle install, _2.880_

```bash
bundle; gem uninstall -aIx dotenv-rails dotenv
time eval "bundle check || bundle install"; echo $?
```

```plain
The following gems are missing
 * dotenv (1.0.2)
  * dotenv-rails (1.0.2)
  Install missing gems with `bundle install`
  Fetching gem metadata from https://rubygems.org/...
  Installing dotenv 1.0.2
  Installing dotenv-rails 1.0.2
  Using bundler 1.7.12
  Your bundle is complete!
  Use `bundle show [gemname]` to see where a bundled gem is installed.

  real    0m2.880s
  user    0m1.277s
  sys     0m0.178s
  0
  ```

### Gems Installed

As the time to resolve and install gems increases, `bundle check || bundle`'s speed
advantage becomes more impressive. As a bonus, `bundle check` will update the `Gemfile.lock`
per changes in the Gemfile and all dependent gem versions are available locally.

#### Without Gemfile.lock

##### bundle, _1.519_

```bash
bundle; rm Gemfile.lock
time bundle; echo $?
```

```plain
Fetching gem metadata from https://rubygems.org/....
Resolving dependencies...
Using dotenv 1.0.2
Using dotenv-rails 1.0.2
Using bundler 1.7.12
Your bundle is complete!
Use `bundle show [gemname]` to see where a bundled gem is installed.

real    0m1.519s
user    0m0.651s
sys     0m0.092s
0
```

##### bundle check || bundle install, _0.612_

```bash
bundle; rm Gemfile.lock
time eval "bundle check || bundle install"; echo $?
```

```plain
Resolving dependencies...
The Gemfile's dependencies are satisfied

real    0m0.612s
user    0m0.535s
sys     0m0.073s
0
```

#### With Gemfile.lock

#### bundle, _0.669_

``bash
bundle
time bundle; echo $?
```

```plain
Using dotenv 1.0.2
Using dotenv-rails 1.0.2
Using bundler 1.7.12
Your bundle is complete!
Use `bundle show [gemname]` to see where a bundled gem is installed.

real    0m0.669s
user    0m0.582s
sys     0m0.086s
0
```

#### bundle check || bundle install, _0.596_

```bash
bundle
time eval "bundle check || bundle install"; echo $?
```

```plain
The Gemfile's dependencies are satisfied

real    0m0.596s
user    0m0.521s
sys     0m0.071s
0
```