### PR TITLE
Use new --skip-turbolinks flag

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -140,12 +140,6 @@ end
         force: true
     end
 
-    def remove_turbolinks
-      replace_in_file 'app/assets/javascripts/application.js',
-        /\/\/= require turbolinks\n/,
-        ''
-    end
-
     def use_postgres_config_template
       template 'postgresql_database.yml.erb', 'config/database.yml',
         force: true

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -18,6 +18,9 @@ module Suspenders
     class_option :skip_test_unit, type: :boolean, aliases: "-T", default: true,
       desc: "Skip Test::Unit files"
 
+    class_option :skip_turbolinks, type: :boolean, default: true,
+      desc: "Skip turbolinks gem"
+
     def finish_template
       invoke :suspenders_customization
       super
@@ -31,7 +34,6 @@ module Suspenders
       invoke :setup_staging_environment
       invoke :setup_secret_token
       invoke :create_suspenders_views
-      invoke :setup_coffeescript
       invoke :configure_app
       invoke :setup_stylesheets
       invoke :install_bitters
@@ -117,11 +119,6 @@ module Suspenders
       build :create_shared_flashes
       build :create_shared_javascripts
       build :create_application_layout
-    end
-
-    def setup_coffeescript
-      say 'Setting up CoffeeScript defaults'
-      build :remove_turbolinks
     end
 
     def configure_app


### PR DESCRIPTION
Rails 4.2 introduced -skip-turbolinks flag. We can remove some code and use that flag instead. What do you think?