### PR TITLE
Refer to Hound in addition to thoughtbot/guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,5 @@
 # Contributing
 
-We love pull requests. Here's a quick guide.
-
 Fork the repo:
 
     git clone git@github.com:thoughtbot/suspenders.git
@@ -14,23 +12,32 @@ Make sure the tests pass:
 
     rake
 
-Make your change. Add tests for your change. Make the tests pass:
+Make your change.
+Write tests.
+Follow our [style guide][style].
+Make the tests pass:
+
+[style]: https://github.com/thoughtbot/guides/tree/master/style
 
     rake
 
-Push to your fork and [submit a pull request][pr].
+Write a [good commit message][commit].
+Push to your fork.
+[Submit a pull request][pr].
 
+[commit]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 [pr]: https://github.com/thoughtbot/suspenders/compare/
 
-At this point you're waiting on us. We like to at least comment on pull requests
-within three business days (and, typically, one business day). We may suggest
-some changes or improvements or alternatives.
+If [Hound] catches style violations,
+fix them.
 
-Some things that will increase the chance that your pull request is accepted:
+[hound]: https://houndci.com
 
-* Write tests.
-* Follow our [style guide][style].
-* Write a [good commit message][commit].
+Wait for us.
+We try to at least comment on pull requests within one business day.
+We may suggest changes.
 
-[style]: https://github.com/thoughtbot/guides/tree/master/style
-[commit]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+## Versions
+
+To update the Ruby version,
+change `.ruby-version` and `.travis.yml`.

--- a/README.md
+++ b/README.md
@@ -181,9 +181,7 @@ If you have problems, please create a
 
 ## Contributing
 
-To update Suspenders' Ruby version, change `.ruby-version` and `.travis.yml`.
-
-Please see [CONTRIBUTING.md](CONTRIBUTING.md) for further details.
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Credits
 


### PR DESCRIPTION
* It's unreasonable to expect contributors to
  read and comprehend thoughtbot/guides.
* It's reasonable to expect they should fix Hound violations.
* Shorten a few other sentences.
* Delete unnecessary words.
* Move note about Ruby version inside `CONTRIBUTING.md` document.