### PR TITLE
Opt in to the Rails differences

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -196,13 +196,11 @@ end
     end
 
     def configure_i18n_tasks
-      run "cp $(i18n-tasks gem-path)/templates/rspec/i18n_spec.rb spec/"
       copy_file "config_i18n_tasks.yml", "config/i18n-tasks.yml"
     end
 
     def configure_background_jobs_for_rspec
       copy_file 'background_jobs_rspec.rb', 'spec/support/background_jobs.rb'
-      run 'rails g delayed_job:active_record'
     end
 
     def configure_action_mailer_in_specs
@@ -216,10 +214,6 @@ end
 
     def configure_rack_timeout
       copy_file 'rack_timeout.rb', 'config/initializers/rack_timeout.rb'
-    end
-
-    def configure_simple_form
-      bundle_command "exec rails generate simple_form:install"
     end
 
     def configure_action_mailer
@@ -258,10 +252,6 @@ end
 
     def install_bitters
       run "bitters install --path app/assets/stylesheets"
-    end
-
-    def install_refills
-      run "rails generate refills:import flashes"
     end
 
     def gitignore_files

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -349,7 +349,7 @@ you can deploy to staging and production with:
 
     def setup_bundler_audit
       copy_file "bundler_audit.rake", "lib/tasks/bundler_audit.rake"
-      append_file "Rakefile", %{\ntask default: "bundler:audit"\n}
+      append_file "Rakefile", %{\n# task default: "bundler:audit"\n}
     end
 
     def copy_miscellaneous_files

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -37,7 +37,6 @@ module Suspenders
       invoke :configure_app
       invoke :setup_stylesheets
       invoke :install_bitters
-      invoke :install_refills
       invoke :copy_miscellaneous_files
       invoke :customize_error_pages
       invoke :remove_routes_comment_lines
@@ -126,7 +125,6 @@ module Suspenders
       build :configure_action_mailer
       build :configure_time_formats
       build :configure_rack_timeout
-      build :configure_simple_form
       build :disable_xml_params
       build :fix_i18n_deprecation_warning
       build :setup_default_rake_task
@@ -142,11 +140,6 @@ module Suspenders
     def install_bitters
       say 'Install Bitters'
       build :install_bitters
-    end
-
-    def install_refills
-      say "Install Refills"
-      build :install_refills
     end
 
     def setup_git

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -90,12 +90,6 @@ feature 'Suspend a new project with default configuration' do
     end
   end
 
-  scenario "specs for missing or unused translations" do
-    run_suspenders
-
-    expect(File).to exist("#{project_path}/spec/i18n_spec.rb")
-  end
-
   scenario "config file for i18n tasks" do
     run_suspenders
 
@@ -109,12 +103,6 @@ feature 'Suspend a new project with default configuration' do
     app_name = SuspendersTestHelpers::APP_NAME
 
     expect(locales_en_file).to match(/application: #{app_name.humanize}/)
-  end
-
-  scenario "config simple_form" do
-    run_suspenders
-
-    expect(File).to exist("#{project_path}/config/initializers/simple_form.rb")
   end
 
   def analytics_partial

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -4,8 +4,11 @@ ruby "<%= Suspenders::RUBY_VERSION %>"
 
 # gem "airbrake"
 
-gem "bourbon", "~> 4.1.0" ### TODO
-gem "coffee-rails", "~> 4.1.0" ### TODO
+# Enable and then edit:
+#   app/assets/application.css.scss
+# gem "bourbon", "~> 4.1.0"
+
+# gem "coffee-rails", "~> 4.1.0"
 
 # Enable and then run:
 #   rails generate delayed_job:active_record
@@ -23,13 +26,18 @@ gem "coffee-rails", "~> 4.1.0" ### TODO
 #   config/i18n-tasks.yml
 # gem "i18n-tasks"
 
-gem "jquery-rails" ### TODO
-gem "neat", "~> 1.7.0" ### TODO
+# gem "jquery-rails"
+
+# Enable and then edit:
+#   app/assets/application.css.scss
+# gem "neat", "~> 1.7.0"
 
 # Enable and then edit:
 #   config/newrelic.yml
 # gem "newrelic_rpm"
 
+# Enable and then edit:
+#   app/assets/application.css.scss
 # gem "normalize-rails", "~> 3.0.0"
 
 gem "pg"
@@ -42,11 +50,13 @@ gem "rails", "<%= Suspenders::RAILS_VERSION %>"
 
 # gem "recipient_interceptor"
 
-# Enable and then run:
+# Enable and then edit:
+#   app/assets/application.css.scss
+# And then run:
 #   rails generate refills:import flashes
 # gem "refills"
 
-gem "sass-rails", "~> 5.0" ### TODO?
+# gem "sass-rails", "~> 5.0"
 
 # Enable and then run:
 #   rails generate simple_form:install
@@ -54,7 +64,7 @@ gem "sass-rails", "~> 5.0" ### TODO?
 
 gem "title"
 
-gem "uglifier" ### TODO?
+# gem "uglifier"
 
 gem "unicorn"
 

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -4,8 +4,8 @@ ruby "<%= Suspenders::RUBY_VERSION %>"
 
 # gem "airbrake"
 
-gem "bourbon", "~> 4.1.0"
-gem "coffee-rails", "~> 4.1.0"
+gem "bourbon", "~> 4.1.0" ### TODO
+gem "coffee-rails", "~> 4.1.0" ### TODO
 
 # Enable and then run:
 #   rails generate delayed_job:active_record
@@ -23,8 +23,8 @@ gem "coffee-rails", "~> 4.1.0"
 #   config/i18n-tasks.yml
 # gem "i18n-tasks"
 
-gem "jquery-rails"
-gem "neat", "~> 1.7.0"
+gem "jquery-rails" ### TODO
+gem "neat", "~> 1.7.0" ### TODO
 
 # Enable and then edit:
 #   config/newrelic.yml
@@ -46,7 +46,7 @@ gem "rails", "<%= Suspenders::RAILS_VERSION %>"
 #   rails generate refills:import flashes
 # gem "refills"
 
-gem "sass-rails", "~> 5.0"
+gem "sass-rails", "~> 5.0" ### TODO?
 
 # Enable and then run:
 #   rails generate simple_form:install
@@ -54,7 +54,7 @@ gem "sass-rails", "~> 5.0"
 
 gem "title"
 
-gem "uglifier"
+gem "uglifier" ### TODO?
 
 gem "unicorn"
 
@@ -65,7 +65,7 @@ group :development do
 end
 
 group :development, :test do
-  gem "awesome_print"
+#  gem "awesome_print"
 
 #  Enable and then edit:
 #    lib/tasks/bundler_audit.rake
@@ -73,20 +73,23 @@ group :development, :test do
 #  gem "bundler-audit", require: false
 
 #  gem "byebug"
-  gem "dotenv-rails"
-  gem "factory_girl_rails" ### keep
-  gem "pry-rails"
-  gem "rspec-rails", "~> 3.1.0" ### keep
+#  gem "dotenv-rails"
+#  gem "pry-rails"
+  gem "factory_girl_rails"
+  gem "rspec-rails", "~> 3.1.0"
 end
 
 group :test do
-  gem "capybara-webkit", ">= 1.2.0"
-  gem "database_cleaner" ### keep
-  gem "formulaic"
-  gem "launchy"
-  gem "shoulda-matchers", require: false
-  gem "timecop"
-  gem "webmock"
+#  gem "capybara-webkit", ">= 1.2.0"
+  gem "database_cleaner"
+#  gem "formulaic"
+#  gem "launchy"
+#  gem "shoulda-matchers", require: false
+#  gem "timecop"
+
+#  Enable and then edit:
+#    spec/spec_helper.rb
+#  gem "webmock"
 end
 
 group :staging, :production do

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -59,24 +59,29 @@ gem "uglifier"
 gem "unicorn"
 
 group :development do
-#   gem "spring"
-#   gem "spring-commands-rspec"
-#   gem "web-console"
+  gem "spring" ### TODO
+#  gem "spring-commands-rspec"
+#  gem "web-console"
 end
 
 group :development, :test do
   gem "awesome_print"
-  gem "bundler-audit", require: false
-  gem "byebug"
+
+#  Enable and then edit:
+#    lib/tasks/bundler_audit.rake
+#    Rakefile
+#  gem "bundler-audit", require: false
+
+#  gem "byebug"
   gem "dotenv-rails"
-  gem "factory_girl_rails"
+  gem "factory_girl_rails" ### keep
   gem "pry-rails"
-  gem "rspec-rails", "~> 3.1.0"
+  gem "rspec-rails", "~> 3.1.0" ### keep
 end
 
 group :test do
   gem "capybara-webkit", ">= 1.2.0"
-  gem "database_cleaner"
+  gem "database_cleaner" ### keep
   gem "formulaic"
   gem "launchy"
   gem "shoulda-matchers", require: false

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -2,33 +2,66 @@ source "https://rubygems.org"
 
 ruby "<%= Suspenders::RUBY_VERSION %>"
 
-gem "airbrake"
+# gem "airbrake"
+
 gem "bourbon", "~> 4.1.0"
 gem "coffee-rails", "~> 4.1.0"
-gem "delayed_job_active_record"
-gem "email_validator"
-gem "flutie"
-gem "high_voltage"
-gem "i18n-tasks"
+
+# Enable and then run:
+#   rails generate delayed_job:active_record
+# gem "delayed_job_active_record"
+
+# gem "email_validator"
+
+# gem "flutie"
+
+# gem "high_voltage"
+
+# Enable and then run:
+#   cp $(i18n-tasks gem-path)/templates/rspec/i18n_spec.rb spec/
+# And then edit:
+#   config/i18n-tasks.yml
+# gem "i18n-tasks"
+
 gem "jquery-rails"
 gem "neat", "~> 1.7.0"
-gem "newrelic_rpm"
-gem "normalize-rails", "~> 3.0.0"
+
+# Enable and then edit:
+#   config/newrelic.yml
+# gem "newrelic_rpm"
+
+# gem "normalize-rails", "~> 3.0.0"
+
 gem "pg"
-gem "rack-timeout"
+
+# Enable and then uncomment:
+#   config/rack_timeout.rb
+# gem "rack-timeout"
+
 gem "rails", "<%= Suspenders::RAILS_VERSION %>"
-gem "recipient_interceptor"
-gem "refills"
+
+# gem "recipient_interceptor"
+
+# Enable and then run:
+#   rails generate refills:import flashes
+# gem "refills"
+
 gem "sass-rails", "~> 5.0"
-gem "simple_form"
+
+# Enable and then run:
+#   rails generate simple_form:install
+# gem "simple_form"
+
 gem "title"
+
 gem "uglifier"
+
 gem "unicorn"
 
 group :development do
-  gem "spring"
-  gem "spring-commands-rspec"
-  gem "web-console"
+#   gem "spring"
+#   gem "spring-commands-rspec"
+#   gem "web-console"
 end
 
 group :development, :test do

--- a/templates/application.css.scss
+++ b/templates/application.css.scss
@@ -1,8 +1,11 @@
 @charset "utf-8";
 
-@import "normalize-rails";
-@import "bourbon";
-@import "base/grid-settings";
-@import "neat";
-@import "base/base";
-@import "refills/flashes";
+// @import "normalize-rails";
+
+// @import "bourbon";
+
+// @import "base/grid-settings";
+// @import "neat";
+// @import "base/base";
+
+// @import "refills/flashes";

--- a/templates/bundler_audit.rake
+++ b/templates/bundler_audit.rake
@@ -1,12 +1,12 @@
-if Rails.env.development? || Rails.env.test?
-  require "bundler/audit/cli"
-
-  namespace :bundler do
-    desc "Updates the ruby-advisory-db and runs audit"
-    task :audit do
-      %w(update check).each do |command|
-        Bundler::Audit::CLI.start [command]
-      end
-    end
-  end
-end
+# if Rails.env.development? || Rails.env.test?
+#   require "bundler/audit/cli"
+#
+#   namespace :bundler do
+#     desc "Updates the ruby-advisory-db and runs audit"
+#     task :audit do
+#       %w(update check).each do |command|
+#         Bundler::Audit::CLI.start [command]
+#       end
+#     end
+#   end
+# end

--- a/templates/rack_timeout.rb
+++ b/templates/rack_timeout.rb
@@ -1,1 +1,1 @@
-Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i
+# Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i

--- a/templates/spec_helper.rb
+++ b/templates/spec_helper.rb
@@ -1,4 +1,5 @@
-require "webmock/rspec"
+# require "webmock/rspec"
+# WebMock.disable_net_connect!(allow_localhost: true)
 
 # http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
@@ -12,5 +13,3 @@ RSpec.configure do |config|
 
   config.order = :random
 end
-
-WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
This changes Suspenders to be an opt-in system instead of opt-out. That is, when you create a fresh Suspenders project, it is ready for you to uncomment and otherwise activate all the fancy Suspenders features -- but none of those features are active by default.

The idea in this branch is: if a gem can be unused, then it is.

This is a work in progress pull request, intended to get early discussion and some help.