### PR TITLE
travis_retry the bin/setup script

### DIFF
--- a/templates/travis.yml.erb
+++ b/templates/travis.yml.erb
@@ -4,7 +4,7 @@ before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 install:
-  - bin/setup
+  - travis_retry bin/setup
 branches:
   only:
     - master


### PR DESCRIPTION
The `bundle install` command has possibilities facing network timeouts, causing build failures. By default, Travis will retry install commands three times if it fails. 

However, this behavior isn't enabled while using a custom setup script, only through running `travis_retry bin/setup` instead of `bin/setup` manually tells Travis use this functionality.

http://blog.travis-ci.com/2013-05-20-network-timeouts-build-retries/