### PR TITLE
Set bin/deploy script as executable

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -353,6 +353,7 @@ you can deploy to staging and production with:
       MARKDOWN
 
       append_file "README.md", instructions
+      run "chmod a+x bin/deploy"
     end
 
     def create_github_repo(repo_name)

--- a/spec/features/heroku_spec.rb
+++ b/spec/features/heroku_spec.rb
@@ -11,15 +11,19 @@ feature "Heroku" do
     expect(FakeHeroku).to have_configured_vars("staging", "SECRET_KEY_BASE")
     expect(FakeHeroku).to have_configured_vars("production", "SECRET_KEY_BASE")
 
-    bin_setup = IO.read("#{project_path}/bin/setup")
+    bin_setup_path = "#{project_path}/bin/setup"
+    bin_setup = IO.read(bin_setup_path)
     app_name = SuspendersTestHelpers::APP_NAME
 
     expect(bin_setup).to include("heroku join --app #{app_name}-staging")
     expect(bin_setup).to include("heroku join --app #{app_name}-production")
+    expect(File.stat(bin_setup_path)).to be_executable
 
-    bin_deploy = IO.read("#{project_path}/bin/deploy")
+    bin_deploy_path = "#{project_path}/bin/deploy"
+    bin_deploy = IO.read(bin_deploy_path)
 
     expect(bin_deploy).to include("heroku run rake db:migrate")
+    expect(File.stat(bin_deploy_path)).to be_executable
 
     readme = IO.read("#{project_path}/README.md")
 


### PR DESCRIPTION
At the moment, in order to use the deploy script, an user must set it as
executable.

This sets the file as executable after creating it, following the logic
employed for the `bin/setup` script. It also adds tests for both of
the files, in order to prevent regression