### PR TITLE
Set email deliver method to :test for development

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -11,6 +11,14 @@ module Suspenders
         'raise_delivery_errors = false', 'raise_delivery_errors = true'
     end
 
+    def set_test_delivery_method
+      inject_into_file(
+        "config/environments/development.rb",
+        "\n  config.action_mailer.delivery_method = :test",
+        after: "config.action_mailer.raise_delivery_errors = true",
+      )
+    end
+
     def raise_on_unpermitted_parameters
       config = <<-RUBY
     config.action_controller.action_on_unpermitted_parameters = :raise

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -77,6 +77,7 @@ module Suspenders
     def setup_development_environment
       say 'Setting up the development environment'
       build :raise_on_delivery_errors
+      build :set_test_delivery_method
       build :raise_on_unpermitted_parameters
       build :provide_setup_script
       build :provide_dev_prime_task

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -117,6 +117,14 @@ feature 'Suspend a new project with default configuration' do
     expect(File).to exist("#{project_path}/config/initializers/simple_form.rb")
   end
 
+  scenario "config :test email delivery method for development" do
+    run_suspenders
+
+    dev_env_file = IO.read("#{project_path}/config/environments/development.rb")
+    expect(dev_env_file).
+      to match(/^ +config.action_mailer.delivery_method = :test$/)
+  end
+
   def analytics_partial
     IO.read("#{project_path}/app/views/application/_analytics.html.erb")
   end


### PR DESCRIPTION
`:test` method will not send the email, but instead print it to the logs. This 
will allow faster development cycle, since there is no need to setup 
smtp/sendmail when email is involved.

Closes #516