### PR TITLE
Include missing word in the Flutie description.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ It includes application gems like:
   processing
 * [Email Validator](https://github.com/balexand/email_validator) for email
   validation
-* [Flutie](https://github.com/thoughtbot/flutie) for and `body_class` view
-  helper
+* [Flutie](https://github.com/thoughtbot/flutie) for `page_title` and `body_class` view
+  helpers
 * [High Voltage](https://github.com/thoughtbot/high_voltage) for static pages
 * [jQuery Rails](https://github.com/rails/jquery-rails) for jQuery
 * [Neat](https://github.com/thoughtbot/neat) for semantic grids


### PR DESCRIPTION
I had a hard time comprehending the Flutie gem's description before I realized it must be missing the `page_title` bit. 