### PR TITLE
Require the spec_helper file within rails_helper

### DIFF
--- a/templates/rails_helper.rb
+++ b/templates/rails_helper.rb
@@ -1,5 +1,7 @@
 ENV["RAILS_ENV"] = "test"
 
+require "spec_helper"
+
 require File.expand_path("../../config/environment", __FILE__)
 
 require "rspec/rails"


### PR DESCRIPTION
With the switch over to a rails_helper file in RSpec 3.x, the
spec_helper file should be required from within the rails_helper as
well.