### PR TITLE
Add SimpleCov

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    suspenders (1.25.0)
+    suspenders (1.26.0)
       bitters (~> 1.0.0)
       bundler (~> 1.3)
       rails (= 4.2.1)

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -47,6 +47,7 @@ group :test do
   gem "formulaic"
   gem "launchy"
   gem "shoulda-matchers", require: false
+  gem "simplecov", require: false
   gem "timecop"
   gem "webmock"
 end

--- a/templates/spec_helper.rb
+++ b/templates/spec_helper.rb
@@ -1,3 +1,8 @@
+if ENV.fetch("COVERAGE", false)
+  require "simplecov"
+  SimpleCov.start "rails"
+end
+
 require "webmock/rspec"
 
 # http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration


### PR DESCRIPTION
It was removed due to a return status bug which would mark failed builds as
successful, and is now fixed.

This reverts commit 6ece3c4bbea3825802e16c41724fa062b91b7c29.

Related with: https://github.com/thoughtbot/suspenders/issues/313