### PR TITLE
Provide EXECJS_RUNTIME env variable

### DIFF
--- a/templates/sample.env
+++ b/templates/sample.env
@@ -3,3 +3,4 @@ ASSET_HOST=localhost:3000
 HOST=localhost:3000
 RACK_ENV=development
 SECRET_KEY_BASE=development_secret
+EXECJS_RUNTIME=Node


### PR DESCRIPTION
This is necessary for compiling assets (when needed to run with compiled assets
in dev).