### PR TITLE
Add Autoprefixer

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -388,6 +388,7 @@ you can deploy to staging and production with:
     end
 
     def copy_miscellaneous_files
+      copy_file "browserslist", "browserslist"
       copy_file "errors.rb", "config/initializers/errors.rb"
       copy_file "json_encoding.rb", "config/initializers/json_encoding.rb"
     end

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 ruby "<%= Suspenders::RUBY_VERSION %>"
 
 gem "airbrake"
+gem "autoprefixer-rails"
 gem "bourbon", "~> 4.2.0"
 gem "coffee-rails", "~> 4.1.0"
 gem "delayed_job_active_record"

--- a/templates/browserslist
+++ b/templates/browserslist
@@ -1,0 +1,4 @@
+Last 2 versions
+Explorer >= 9
+iOS >= 7.1
+Android >= 4.4


### PR DESCRIPTION
Should we add a default config file, as well? It would allow us to [define which browser versions](https://github.com/ai/autoprefixer-rails#ruby-on-rails) we want to support…where would I put that `browserslist` here in Suspenders?