### PR TITLE
Remove SMTP assumption

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -66,12 +66,14 @@ module Suspenders
       copy_file 'smtp.rb', 'config/smtp.rb'
 
       prepend_file 'config/environments/production.rb',
-        %{require Rails.root.join("config/smtp")\n}
+        %{require Rails.root.join("config/smtp") if ENV["SMTP_ADDRESS"].present?\n}
 
       config = <<-RUBY
 
-  config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = SMTP_SETTINGS
+  if ENV["SMTP_ADDRESS"].present?
+    config.action_mailer.delivery_method = :smtp
+    config.action_mailer.smtp_settings = SMTP_SETTINGS
+  end
       RUBY
 
       inject_into_file 'config/environments/production.rb', config,


### PR DESCRIPTION
The production config assumes that the SMTP environment variables will be present, but many apps don't need to send mail.

I'd welcome any suggestions for a more elegant way of handling this. There are four env vars related to SMTP, so `SMTP_ADDRESS` is an arbitrary choice.