### PR TITLE
Update thoughtbot section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,16 +183,28 @@ If you have problems, please create a
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).
 
-## Credits
+Thank you, [contributors]!
 
-![thoughtbot](http://thoughtbot.com/images/tm/logo.png)
-
-Suspenders is maintained and funded by
-[thoughtbot, inc](http://thoughtbot.com/community).
-
-The names and logos for thoughtbot are trademarks of thoughtbot, inc.
+[contributors]: https://github.com/thoughtbot/suspenders/graphs/contributors
 
 ## License
 
-Suspenders is Copyright © 2008-2014 thoughtbot. It is free software, and may be
-redistributed under the terms specified in the LICENSE file.
+Suspenders is Copyright © 2008-2015 thoughtbot.
+It is free software,
+and may be redistributed under the terms specified in the [LICENSE] file.
+
+[LICENSE]: LICENSE
+
+## About thoughtbot
+
+![thoughtbot](https://thoughtbot.com/logo.png)
+
+Suspenders is maintained and funded by thoughtbot, inc.
+The names and logos for thoughtbot are trademarks of thoughtbot, inc.
+
+We love open source software!
+See [our other projects][community].
+We are [available for hire][hire].
+
+[community]: https://thoughtbot.com/community?utm_source=github
+[hire]: https://thoughtbot.com?utm_source=github


### PR DESCRIPTION
* Include 2015 in the copyright.
* Update logo to use new HTTPS version.
* Change header from "Credits" to "About thoughtbot".
* Move "thank you" to contributors section.
* Make "About thoughtbot" the last thing in the README,
  with the copyrights grouped closer to the LICENSE information.
* Link to LICENSE.
* Make the community link more obvious that we have other projects.
* Finish with a CTA to hire us.
* Include `utm_source` codes to improve tracking.