### PR TITLE
Enable verify_partial_doubles for RSpec

### DIFF
--- a/templates/spec_helper.rb
+++ b/templates/spec_helper.rb
@@ -8,6 +8,7 @@ RSpec.configure do |config|
 
   config.mock_with :rspec do |mocks|
     mocks.syntax = :expect
+    mocks.verify_partial_doubles = true
   end
 
   config.order = :random


### PR DESCRIPTION
https://relishapp.com/rspec/rspec-mocks/v/3-0/docs/verifying-doubles/partial-doubles

"When the verify_partial_doubles configuration option is set, the same
argument and method existence checks that are performed for
object_double are also performed on partial doubles. You should set
this unless you have a good reason not to. It defaults to off only for
backwards compatibility."