### PR TITLE
Only use rack-timeout in staging or production environments

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -222,7 +222,11 @@ end
     end
 
     def configure_rack_timeout
-      copy_file 'rack_timeout.rb', 'config/initializers/rack_timeout.rb'
+      rack_timeout_config = <<-RUBY
+Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i
+      RUBY
+
+      append_file "config/environments/production.rb", rack_timeout_config
     end
 
     def configure_simple_form

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -103,6 +103,7 @@ module Suspenders
       say 'Setting up the production environment'
       build :configure_newrelic
       build :configure_smtp
+      build :configure_rack_timeout
       build :enable_rack_deflater
       build :setup_asset_host
     end
@@ -130,7 +131,6 @@ module Suspenders
       build :configure_action_mailer
       build :configure_active_job
       build :configure_time_formats
-      build :configure_rack_timeout
       build :configure_simple_form
       build :disable_xml_params
       build :fix_i18n_deprecation_warning

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -15,7 +15,6 @@ gem "neat", "~> 1.7.0"
 gem "newrelic_rpm"
 gem "normalize-rails", "~> 3.0.0"
 gem "pg"
-gem "rack-timeout"
 gem "rails", "<%= Suspenders::RAILS_VERSION %>"
 gem "recipient_interceptor"
 gem "refills"
@@ -52,4 +51,5 @@ group :test do
 end
 
 group :staging, :production do
+  gem "rack-timeout"
 end

--- a/templates/rack_timeout.rb
+++ b/templates/rack_timeout.rb
@@ -1,1 +1,0 @@
-Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i


### PR DESCRIPTION
This causes intermittent failures in capybara test suites where js is enabled.

See https://github.com/heroku/rack-timeout/issues/55 for more information.