### PR TITLE
Avoid generation of extra _flashes view

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -274,10 +274,6 @@ end
       run "bitters install --path app/assets/stylesheets"
     end
 
-    def install_refills
-      run "rails generate refills:import flashes"
-    end
-
     def gitignore_files
       remove_file '.gitignore'
       copy_file 'suspenders_gitignore', '.gitignore'

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -40,7 +40,6 @@ module Suspenders
       invoke :configure_app
       invoke :setup_stylesheets
       invoke :install_bitters
-      invoke :install_refills
       invoke :copy_miscellaneous_files
       invoke :customize_error_pages
       invoke :remove_routes_comment_lines
@@ -147,11 +146,6 @@ module Suspenders
     def install_bitters
       say 'Install Bitters'
       build :install_bitters
-    end
-
-    def install_refills
-      say "Install Refills"
-      build :install_refills
     end
 
     def setup_git


### PR DESCRIPTION
This step generates an unneeded `app/views/refills/_flashes.html.erb`, but there's already `app/views/application/_flashes.html.erb`. Contents of the seemingly unneeded component:

```erb
<div class="flash-success">
  <span>This is a success message <a href="#">with a link</a></span>
</div>

<div class="flash-error">
  <span>This is an error message <a href="#">with a link</a></span>
</div>

<div class="flash-notice">
  <span>This is an notice message <a href="#">with a link</a></span>
</div>

<div class="flash-alert">
  <span>This is an alert message <a href="#">with a link</a></span>
</div>
```

Related: https://github.com/thoughtbot/suspenders/issues/537