### PR TITLE
We still need to import refills scss

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -293,6 +293,12 @@ Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i
                 "app/assets/stylesheets/application.scss"
     end
 
+    def install_refills
+      run "rails generate refills:import flashes"
+      run "rm app/views/refills/_flashes.html.erb"
+      run "rmdir app/views/refills"
+    end
+
     def install_bitters
       run "bitters install --path app/assets/stylesheets"
     end

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -40,6 +40,7 @@ module Suspenders
       invoke :configure_app
       invoke :setup_stylesheets
       invoke :install_bitters
+      invoke :install_refills
       invoke :copy_miscellaneous_files
       invoke :customize_error_pages
       invoke :remove_routes_comment_lines
@@ -149,6 +150,11 @@ module Suspenders
     def install_bitters
       say 'Install Bitters'
       build :install_bitters
+    end
+
+    def install_refills
+      say "Install Refills"
+      build :install_refills
     end
 
     def setup_git


### PR DESCRIPTION
* refills/flashes does not exist and fails import
* As per issue #537 and PR #546

I recognize that this is not the ultimate solution, this is still broken but this could be a possible solution and would have to change the refills gem.

We may want to consider scrapping the current flashes partial in favor of the refills defined ones instead.