### PR TITLE
Add mention of Autoprefixer Rails gem to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ generated projectname/Gemfile.
 It includes application gems like:
 
 * [Airbrake](https://github.com/airbrake/airbrake) for exception notification
+* [Autoprefixer Rails](https://github.com/ai/autoprefixer-rails) for CSS vendor prefixes
 * [Bourbon](https://github.com/thoughtbot/bourbon) for Sass mixins
 * [Bitters](https://github.com/thoughtbot/bitters) for scaffold application styles
 * [Delayed Job](https://github.com/collectiveidea/delayed_job) for background


### PR DESCRIPTION
We recently added Autoprefixer Rails to Suspenders (https://github.com/thoughtbot/suspenders/commit/7df323348714f7495bd296d8f3ae18baf89d8852), but forgot to add it to the gem list in the readme :smile: 