### PR TITLE
Swap flash id for a class

### DIFF
--- a/templates/_flashes.html.erb
+++ b/templates/_flashes.html.erb
@@ -1,5 +1,5 @@
 <% if flash.any? %>
-  <div id="flash">
+  <div class="flashes">
     <% user_facing_flashes.each do |key, value| -%>
       <div class="flash-<%= key %>"><%= value %></div>
     <% end -%>


### PR DESCRIPTION
Generally speaking, it’s best practice to style off `class`’s instead of `id`’s. There are exceptions, but in this case, I would consider the `id` of `flash` not very useful, so this swaps it for a `class` instead. Also, the flash key on Line 4 was already being output as a class; this unifies the two.