### PR TITLE
Ignore `.env.local` instead of `.env`

### DIFF
--- a/templates/suspenders_gitignore
+++ b/templates/suspenders_gitignore
@@ -3,7 +3,7 @@
 *.swo
 *.swp
 /.bundle
-/.env
+/.env.local
 /.foreman
 /coverage/*
 /db/*.sqlite3
@@ -12,3 +12,4 @@
 /public/assets
 /tags
 /tmp/*
+!.env


### PR DESCRIPTION
Here is an common state that the current `.gitignore` supports:

- The `.sample.env` (or like) file is updated with a set of environment variables after a feature is merged.
- A developer pulls the latest from master and runs the test suite.
- It fails with an opaque error message.

A more robust workflow:

- Version development environment variables in the `.env` file.
- Overrides these locally with the `.env.local` file..

See:

https://github.com/bkeepers/dotenv#should-i-commit-my-env-file
https://github.com/thoughtbot/dotfiles/pull/369