### PR TITLE
Do not touch $HOST in .env

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -113,7 +113,7 @@ module Suspenders
     def setup_asset_host
       replace_in_file 'config/environments/production.rb',
         "# config.action_controller.asset_host = 'http://assets.example.com'",
-        'config.action_controller.asset_host = ENV.fetch("ASSET_HOST", ENV.fetch("HOST"))'
+        'config.action_controller.asset_host = ENV.fetch("ASSET_HOST", ENV.fetch("APPLICATION_HOST"))'
 
       replace_in_file 'config/initializers/assets.rb',
         "config.assets.version = '1.0'",

--- a/templates/sample.env
+++ b/templates/sample.env
@@ -1,6 +1,6 @@
 # http://ddollar.github.com/foreman/
 ASSET_HOST=localhost:3000
-HOST=localhost:3000
+APPLICATION_HOST=localhost:3000
 RACK_ENV=development
 SECRET_KEY_BASE=development_secret
 EXECJS_RUNTIME=Node


### PR DESCRIPTION
The .env should not touch $HOST, since that is controlled by the shell
and changing it can lead to surprises, failures, and even crashes.