### PR TITLE
Require spec/support files in alphabetical order

### DIFF
--- a/templates/rails_helper.rb
+++ b/templates/rails_helper.rb
@@ -5,7 +5,7 @@ require File.expand_path("../../config/environment", __FILE__)
 require "rspec/rails"
 require "shoulda/matchers"
 
-Dir[Rails.root.join("spec/support/**/*.rb")].each { |file| require file }
+Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |file| require file }
 
 module Features
   # Extend this module in spec/support/features/*.rb


### PR DESCRIPTION
This ensures that the `require` order is the same on all machines, including CI.

For example, we mainly use OS X as our local development machines, while CI runs
on Linux. We've run into ordering issues before due to the different OS's, and
this changes has historically fixed it.