### PR TITLE
Fix bundler caching on travis to speed up builds

### DIFF
--- a/templates/bin_setup.erb
+++ b/templates/bin_setup.erb
@@ -8,7 +8,7 @@ set -e
 
 # Set up Ruby dependencies via Bundler
 gem install bundler --conservative
-bundle check || bundle install --path=vendor/bundle
+bundle check || bundle install
 
 # Set up configurable environment variables
 if [ ! -f .env ]; then

--- a/templates/bin_setup.erb
+++ b/templates/bin_setup.erb
@@ -8,7 +8,7 @@ set -e
 
 # Set up Ruby dependencies via Bundler
 gem install bundler --conservative
-bundle check || bundle install
+bundle check || bundle install --path=vendor/bundle
 
 # Set up configurable environment variables
 if [ ! -f .env ]; then

--- a/templates/suspenders_gitignore
+++ b/templates/suspenders_gitignore
@@ -12,3 +12,4 @@
 /public/assets
 /tags
 /tmp/*
+/vendor/bundle

--- a/templates/travis.yml.erb
+++ b/templates/travis.yml.erb
@@ -9,7 +9,8 @@ branches:
   only:
     - master
 cache:
-  - bundler
+  directories:
+    - vendor/bundle
 language:
   - ruby
 notifications:

--- a/templates/travis.yml.erb
+++ b/templates/travis.yml.erb
@@ -3,6 +3,7 @@ before_install:
   - "echo 'gem: --no-document' > ~/.gemrc"
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
+  - bundle config --local path vendor/bundle
 install:
   - bin/setup
 branches:


### PR DESCRIPTION
Travis can't cache bundler if you use a custom install step (which we're
doing when we call bin/setup). This specifically bundles into a
directory that will then be cached on Travis and used for each build.

* bundle into `vendor/bundle`
* Add `vendor/bundle` to `.gitignore`
* Tell travis to cache `vendor/bundle`

See:

* http://docs.travis-ci.com/user/caching/#Caching-directories-(Bundler%2C-dependencies)
* http://docs.travis-ci.com/user/caching/#With-a-custom-install-step