### PR TITLE
Add view and helper spec helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Suspenders also comes with:
 * Configuration for [Travis Pro][travis] continuous integration
 * The analytics adapter [Segment][segment] (and therefore config for Google
   Analytics, Intercom, Facebook Ads, Twitter Ads, etc.)
+* `page` helper in views to allow Capybara matcher use
+* `stub_current_user` for view and helper specs
 
 [setup]: http://robots.thoughtbot.com/bin-setup
 [compress]: http://robots.thoughtbot.com/content-compression-with-rack-deflater/

--- a/README.md
+++ b/README.md
@@ -100,8 +100,7 @@ Suspenders also comes with:
 * Configuration for [Travis Pro][travis] continuous integration
 * The analytics adapter [Segment][segment] (and therefore config for Google
   Analytics, Intercom, Facebook Ads, Twitter Ads, etc.)
-* `page` helper in views to allow Capybara matcher use
-* `stub_current_user` for view and helper specs
+* Configuration to disable partial double verification for view and helper specs
 
 [setup]: http://robots.thoughtbot.com/bin-setup
 [compress]: http://robots.thoughtbot.com/content-compression-with-rack-deflater/

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -231,6 +231,14 @@ end
       copy_file 'action_mailer.rb', 'spec/support/action_mailer.rb'
     end
 
+    def configure_helper_spec_helpers_in_specs
+      copy_file 'helper_spec_helpers.rb', 'spec/support/helper_spec_helpers.rb'
+    end
+
+    def configure_view_spec_helpers_in_specs
+      copy_file 'view_spec_helpers.rb', 'spec/support/view_spec_helpers.rb'
+    end
+
     def configure_time_formats
       remove_file "config/locales/en.yml"
       template "config_locales_en.yml.erb", "config/locales/en.yml"

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -96,6 +96,8 @@ module Suspenders
       build :configure_i18n_for_test_environment
       build :configure_i18n_tasks
       build :configure_action_mailer_in_specs
+      build :configure_helper_spec_helpers_in_specs
+      build :configure_view_spec_helpers_in_specs
     end
 
     def setup_production_environment

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -49,6 +49,18 @@ RSpec.describe "Suspend a new project with default configuration" do
     expect(File).to exist("#{project_path}/spec/support/i18n.rb")
   end
 
+  it "adds support file for view specs" do
+    run_suspenders
+
+    expect(File).to exist("#{project_path}/spec/support/view_spec_helpers.rb")
+  end
+
+  it "adds support file for helper specs" do
+    run_suspenders
+
+    expect(File).to exist("#{project_path}/spec/support/helper_spec_helpers.rb")
+  end
+
   it "ensures newrelic.yml reads NewRelic license from env" do
     run_suspenders
 

--- a/templates/helper_spec_helpers.rb
+++ b/templates/helper_spec_helpers.rb
@@ -1,0 +1,17 @@
+module HelperSpecHelpers
+  def stub_current_user(as: nil)
+    allow(view).to receive(:current_user).and_return(as)
+  end
+end
+
+RSpec.configure do |config|
+  config.include HelperSpecHelpers, type: :helper
+
+  config.around(:each, type: :helper, allow_helper_stub: true) do |example|
+    config.mock_with :rspec do |mocks|
+      mocks.verify_partial_doubles = false
+      example.run
+      mocks.verify_partial_doubles = true
+    end
+  end
+end

--- a/templates/helper_spec_helpers.rb
+++ b/templates/helper_spec_helpers.rb
@@ -1,9 +1,12 @@
 RSpec.configure do |config|
-  config.around(:each, type: :helper, allow_helper_stub: true) do |example|
+  config.around(:each, type: :helper) do |example|
     config.mock_with :rspec do |mocks|
+      cached_double_verification = mocks.verify_partial_doubles?
       mocks.verify_partial_doubles = false
+
       example.run
-      mocks.verify_partial_doubles = true
+
+      mocks.verify_partial_doubles = cached_double_verification
     end
   end
 end

--- a/templates/helper_spec_helpers.rb
+++ b/templates/helper_spec_helpers.rb
@@ -1,12 +1,4 @@
-module HelperSpecHelpers
-  def stub_current_user(as: nil)
-    allow(view).to receive(:current_user).and_return(as)
-  end
-end
-
 RSpec.configure do |config|
-  config.include HelperSpecHelpers, type: :helper
-
   config.around(:each, type: :helper, allow_helper_stub: true) do |example|
     config.mock_with :rspec do |mocks|
       mocks.verify_partial_doubles = false

--- a/templates/view_spec_helpers.rb
+++ b/templates/view_spec_helpers.rb
@@ -1,8 +1,4 @@
 module ViewSpecHelpers
-  def page
-    Capybara.string(rendered)
-  end
-
   def stub_current_user(as: nil)
     allow(view).to receive(:current_user).and_return(as)
   end

--- a/templates/view_spec_helpers.rb
+++ b/templates/view_spec_helpers.rb
@@ -1,9 +1,12 @@
 RSpec.configure do |config|
-  config.around(:each, type: :view, allow_view_stub: true) do |example|
+  config.around(:each, type: :view) do |example|
     config.mock_with :rspec do |mocks|
+      cached_double_verification = mocks.verify_partial_doubles?
       mocks.verify_partial_doubles = false
+
       example.run
-      mocks.verify_partial_doubles = true
+
+      mocks.verify_partial_doubles = cached_double_verification
     end
   end
 end

--- a/templates/view_spec_helpers.rb
+++ b/templates/view_spec_helpers.rb
@@ -1,0 +1,21 @@
+module ViewSpecHelpers
+  def page
+    Capybara.string(rendered)
+  end
+
+  def stub_current_user(as: nil)
+    allow(view).to receive(:current_user).and_return(as)
+  end
+end
+
+RSpec.configure do |config|
+  config.include ViewSpecHelpers, type: :view
+
+  config.around(:each, type: :view, allow_view_stub: true) do |example|
+    config.mock_with :rspec do |mocks|
+      mocks.verify_partial_doubles = false
+      example.run
+      mocks.verify_partial_doubles = true
+    end
+  end
+end

--- a/templates/view_spec_helpers.rb
+++ b/templates/view_spec_helpers.rb
@@ -1,12 +1,4 @@
-module ViewSpecHelpers
-  def stub_current_user(as: nil)
-    allow(view).to receive(:current_user).and_return(as)
-  end
-end
-
 RSpec.configure do |config|
-  config.include ViewSpecHelpers, type: :view
-
   config.around(:each, type: :view, allow_view_stub: true) do |example|
     config.mock_with :rspec do |mocks|
       mocks.verify_partial_doubles = false


### PR DESCRIPTION
This disables verification of partial doubles in view and helper specs.

What does this mean for you?

1. You can stub locals in view partial specs instead of doing the funky `render "partial/partial"...` dance
2. You can stub `current_user`, `signed_in?`, or other methods defined in other controllers/helpers that you don't normally have access to

Potential downsides:

1. You can stub methods on view that aren't normally defined. Apart from what RSpec considers not available (e.g. `current_user`, etc.) this means you can allow the view to receive literally whatever you want. This may be bad form, although @derekprior made a valid point that, within views, you're very typically interacting with various objects, so the fact that something may or may not be defined (and further stubbing of it) may not be that bad.