### PR TITLE
Add default .hound.yml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ Suspenders also comes with:
 * [t() and l() in specs without prefixing with I18n][i18n]
 * An automatically-created `SECRET_KEY_BASE` environment variable in all
   environments
-* Configuration for [Travis Pro][travis] continuous integration
+* Configuration for [Travis][travis] Continuous Integration (tests)
+* Configuration for [Hound][hound] Continuous Integration (style)
 * The analytics adapter [Segment][segment] (and therefore config for Google
   Analytics, Intercom, Facebook Ads, Twitter Ads, etc.)
 
@@ -107,6 +108,7 @@ Suspenders also comes with:
 [binstub]: https://github.com/thoughtbot/suspenders/pull/282
 [i18n]: https://github.com/thoughtbot/suspenders/pull/304
 [travis]: http://docs.travis-ci.com/user/travis-pro/
+[hound]: https://houndci.com
 [segment]: https://segment.com
 
 ## Heroku

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -58,6 +58,10 @@ module Suspenders
       copy_file 'factory_girl_rspec.rb', 'spec/support/factory_girl.rb'
     end
 
+    def set_up_hound
+      copy_file "hound.yml", ".hound.yml"
+    end
+
     def configure_newrelic
       template 'newrelic.yml.erb', 'config/newrelic.yml'
     end

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -88,6 +88,7 @@ module Suspenders
     def setup_test_environment
       say 'Setting up the test environment'
       build :set_up_factory_girl_for_rspec
+      build :set_up_hound
       build :generate_rspec
       build :configure_rspec
       build :configure_background_jobs_for_rspec

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -43,6 +43,12 @@ RSpec.describe "Suspend a new project with default configuration" do
     expect(File).to exist("#{project_path}/spec/support/i18n.rb")
   end
 
+  it "creates good default .hound.yml" do
+    hound_config_file = IO.read("#{project_path}/.hound.yml")
+
+    expect(hound_config_file).to include "enabled: true"
+  end
+
   it "ensures newrelic.yml reads NewRelic license from env" do
     newrelic_file = IO.read("#{project_path}/config/newrelic.yml")
 

--- a/templates/hound.yml
+++ b/templates/hound.yml
@@ -1,0 +1,17 @@
+# See https://houndci.com/configuration for help.
+coffeescript:
+  # config_file: .coffeescript-style.json
+  enabled: true
+haml:
+  # config_file: .haml-style.yml
+  enabled: true
+javascript:
+  # config_file: .javascript-style.json
+  enabled: true
+  # ignore_file: .javascript_ignore
+ruby:
+  # config_file: .ruby-style.yml
+  enabled: true
+scss:
+  # config_file: .scss-style.yml
+  enabled: true


### PR DESCRIPTION
* Turn on JavaScript but not CoffeeScript by default.
* Help avoid configuration mistakes by providing this stub
  and a link to the configuration page.