### PR TITLE
Add a PageObject class to generated app

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Suspenders also comes with:
 * Configuration for [Hound][hound] Continuous Integration (style)
 * The analytics adapter [Segment][segment] (and therefore config for Google
   Analytics, Intercom, Facebook Ads, Twitter Ads, etc.)
+* A `PageObject` class for [easier testing with page objects][page objects]
 
 [setup]: http://robots.thoughtbot.com/bin-setup
 [compress]: http://robots.thoughtbot.com/content-compression-with-rack-deflater/
@@ -110,6 +111,7 @@ Suspenders also comes with:
 [travis]: http://docs.travis-ci.com/user/travis-pro/
 [hound]: https://houndci.com
 [segment]: https://segment.com
+[page objects]: https://robots.thoughtbot.com/better-acceptance-tests-with-page-objects
 
 ## Heroku
 

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -217,6 +217,10 @@ end
       copy_file "i18n.rb", "spec/support/i18n.rb"
     end
 
+    def add_page_objects_for_tests
+      copy_file "page_object.rb", "spec/support/page_object.rb"
+    end
+
     def configure_i18n_for_missing_translations
       raise_on_missing_translations_in("development")
       raise_on_missing_translations_in("test")

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -98,6 +98,7 @@ module Suspenders
       build :configure_travis
       build :configure_i18n_for_test_environment
       build :configure_i18n_tasks
+      build :add_page_objects_for_tests
       build :configure_action_mailer_in_specs
     end
 

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe "Suspend a new project with default configuration" do
     expect(File).to exist("#{project_path}/spec/i18n_spec.rb")
   end
 
-  it "configs i18n-tasks" do
+  it "configures i18n-tasks" do
     expect(File).to exist("#{project_path}/config/i18n-tasks.yml")
   end
 
@@ -127,6 +127,10 @@ RSpec.describe "Suspend a new project with default configuration" do
     bin_stubs.each do |bin_stub|
       expect(IO.read("#{project_path}/bin/#{bin_stub}")).to match(spring_line)
     end
+  end
+
+  it "adds a page object class for tests" do
+    expect(File).to exist("#{project_path}/spec/support/page_object.rb")
   end
 
   def analytics_partial

--- a/templates/page_object.rb
+++ b/templates/page_object.rb
@@ -1,0 +1,7 @@
+class PageObject
+  include FactoryGirl::Syntax::Methods
+  include Capybara::DSL
+  include Rails.application.routes.url_helpers
+  include AbstractController::Translation
+  include Formulaic::Dsl
+end


### PR DESCRIPTION
It can use Capybara methods like `visit` or `find` directly; it can use `t` instead of `I18n.t`; it has all the Formulaic helpers like `fill_form`; it has all the FactoryGirl helpers.

Example:

```ruby
class UserPage < PageObject
  def initialize
    @user = create(:user)
  end

  def visit_profile
    visit user_path(@user)
  end
end
```