### PR TITLE
Remove comments and newlines in config files

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -434,6 +434,28 @@ you can deploy to staging and production with:
       end
     end
 
+    def remove_config_comment_lines
+      config_files = [
+        "application.rb",
+        "environment.rb",
+        "environments/development.rb",
+        "environments/production.rb",
+        "environments/test.rb",
+      ]
+
+      config_files.each do |config_file|
+        path = File.join(destination_root, "config/#{config_file}")
+
+        accepted_content = File.readlines(path).reject do |line|
+          line =~ /^.*#.*$/ || line =~ /^$\n/
+        end
+
+        File.open(path, "w") do |file|
+          accepted_content.each { |line| file.puts line }
+        end
+      end
+    end
+
     def remove_routes_comment_lines
       replace_in_file 'config/routes.rb',
         /Rails\.application\.routes\.draw do.*end/m,

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -43,6 +43,7 @@ module Suspenders
       invoke :install_refills
       invoke :copy_miscellaneous_files
       invoke :customize_error_pages
+      invoke :remove_config_comment_lines
       invoke :remove_routes_comment_lines
       invoke :setup_git
       invoke :setup_database
@@ -214,6 +215,10 @@ module Suspenders
     def customize_error_pages
       say 'Customizing the 500/404/422 pages'
       build :customize_error_pages
+    end
+
+    def remove_config_comment_lines
+      build :remove_config_comment_lines
     end
 
     def remove_routes_comment_lines

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -129,6 +129,21 @@ RSpec.describe "Suspend a new project with default configuration" do
     end
   end
 
+  it "removes comments and extra newlines from config files" do
+    config_files = [
+      IO.read("#{project_path}/config/application.rb"),
+      IO.read("#{project_path}/config/environment.rb"),
+      IO.read("#{project_path}/config/environments/development.rb"),
+      IO.read("#{project_path}/config/environments/production.rb"),
+      IO.read("#{project_path}/config/environments/test.rb"),
+    ]
+
+    config_files.each do |file|
+      expect(file).not_to match(/.*#.*/)
+      expect(file).not_to match(/^$\n/)
+    end
+  end
+
   def analytics_partial
     IO.read("#{project_path}/app/views/application/_analytics.html.erb")
   end


### PR DESCRIPTION
* At some point in ever suspenderized project, I end up doing this as a PR

What `config/environments/test.rb` and `config/application.rb` configs file looks like with this change (all of the other config files have a similar before/after, this is just as an example):

BEFORE:

```ruby
Rails.application.configure do
  # Settings specified here will take precedence over those in config/application.rb.

  # The test environment is used exclusively to run your application's
  # test suite. You never need to work with it otherwise. Remember that
  # your test database is "scratch space" for the test suite and is wiped
  # and recreated between test runs. Don't rely on the data there!
  config.cache_classes = true

  # Do not eager load code on boot. This avoids loading your whole application
  # just for the purpose of running a single test. If you are using a tool that
  # preloads Rails for running tests, you may have to set it to true.
  config.eager_load = false

  # Configure static file server for tests with Cache-Control for performance.
  config.serve_static_files   = true
  config.static_cache_control = 'public, max-age=3600'

  # Show full error reports and disable caching.
  config.consider_all_requests_local       = true
  config.action_controller.perform_caching = false

  # Raise exceptions instead of rendering exception templates.
  config.action_dispatch.show_exceptions = false

  # Disable request forgery protection in test environment.
  config.action_controller.allow_forgery_protection = false

  # Tell Action Mailer not to deliver emails to the real world.
  # The :test delivery method accumulates sent emails in the
  # ActionMailer::Base.deliveries array.
  config.action_mailer.delivery_method = :test

  # Randomize the order test cases are executed.
  config.active_support.test_order = :random

  # Print deprecation notices to the stderr.
  config.active_support.deprecation = :stderr

  # Raises error for missing translations
  config.action_view.raise_on_missing_translations = true

  config.action_mailer.default_url_options = { host: "www.example.com" }

  config.active_job.queue_adapter = :inline
end
```

AFTER:

```ruby
Rails.application.configure do
  config.cache_classes = true
  config.eager_load = false
  config.serve_static_files   = true
  config.static_cache_control = 'public, max-age=3600'
  config.consider_all_requests_local       = true
  config.action_controller.perform_caching = false
  config.action_dispatch.show_exceptions = false
  config.action_controller.allow_forgery_protection = false
  config.action_mailer.delivery_method = :test
  config.active_support.test_order = :random
  config.active_support.deprecation = :stderr
  config.action_view.raise_on_missing_translations = true
  config.action_mailer.default_url_options = { host: "www.example.com" }
  config.active_job.queue_adapter = :inline
end
```

BEFORE:

```ruby
require File.expand_path('../boot', __FILE__)

require "rails"
# Pick the frameworks you want:
require "active_model/railtie"
require "active_job/railtie"
require "active_record/railtie"
require "action_controller/railtie"
require "action_mailer/railtie"
require "action_view/railtie"
require "sprockets/railtie"
# require "rails/test_unit/railtie"

# Require the gems listed in Gemfile, including any gems
# you've limited to :test, :development, or :production.
Bundler.require(*Rails.groups)

module DummyApp
  class Application < Rails::Application
    config.i18n.enforce_available_locales = true

    config.generators do |generate|
      generate.helper false
      generate.javascript_engine false
      generate.request_specs false
      generate.routing_specs false
      generate.stylesheets false
      generate.test_framework :rspec
      generate.view_specs false
    end

    config.action_controller.action_on_unpermitted_parameters = :raise
    # Settings in config/environments/* take precedence over those specified here.
    # Application configuration should go into files in config/initializers
    # -- all .rb files in that directory are automatically loaded.

    # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
    # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
    # config.time_zone = 'Central Time (US & Canada)'

    # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
    # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
    # config.i18n.default_locale = :de

    # Do not swallow errors in after_commit/after_rollback callbacks.
    config.active_record.raise_in_transactional_callbacks = true

    config.active_job.queue_adapter = :delayed_job
  end
end
```

AFTER:

```ruby
require File.expand_path('../boot', __FILE__)
require "rails"
require "active_model/railtie"
require "active_job/railtie"
require "active_record/railtie"
require "action_controller/railtie"
require "action_mailer/railtie"
require "action_view/railtie"
require "sprockets/railtie"
Bundler.require(*Rails.groups)
module DummyApp
  class Application < Rails::Application
    config.i18n.enforce_available_locales = true
    config.generators do |generate|
      generate.helper false
      generate.javascript_engine false
      generate.request_specs false
      generate.routing_specs false
      generate.stylesheets false
      generate.test_framework :rspec
      generate.view_specs false
    end
    config.action_controller.action_on_unpermitted_parameters = :raise
    config.active_record.raise_in_transactional_callbacks = true
    config.active_job.queue_adapter = :delayed_job
  end
end
```