### PR TITLE
Fix memoization for rails's server port value

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -485,7 +485,7 @@ end
     end
 
     def port
-      @port ||= [3000, 4000, 5000, 7000, 8000, 9000].sample
+      @@port ||= [3000, 4000, 5000, 7000, 8000, 9000].sample
     end
 
     def serve_static_files_line


### PR DESCRIPTION
I think multiple instance of `AppBuilder` are currently being initialized during `suspenders APP_NAME` process because `bin/setup` and `development.rb`have different port values.

So I think we can use a class variable to memoize the value. Is it dirty?
