### PR TITLE
Move recipient_interceptor to :staging gem group

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -18,7 +18,6 @@ gem "normalize-rails", "~> 3.0.0"
 gem "pg"
 gem "rack-canonical-host"
 gem "rails", "<%= Suspenders::RAILS_VERSION %>"
-gem "recipient_interceptor"
 gem "refills"
 gem "sass-rails", "~> 5.0"
 gem "simple_form"
@@ -55,4 +54,8 @@ end
 
 group :staging, :production do
   gem "rack-timeout"
+end
+
+group :staging do
+  gem "recipient_interceptor"
 end


### PR DESCRIPTION
Since recipient interceptor is used only in staging, could we move the gem in the appropriate group?