### PR TITLE
Rename development data concept to avoid db/seeds confusion

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -33,7 +33,7 @@ module Suspenders
     end
 
     def provide_dev_prime_task
-      copy_file 'development_seeds.rb', 'lib/tasks/development_seeds.rake'
+      copy_file 'dev.rake', 'lib/tasks/dev.rake'
     end
 
     def configure_generators

--- a/templates/dev.rake
+++ b/templates/dev.rake
@@ -2,7 +2,7 @@ if Rails.env.development? || Rails.env.test?
   require "factory_girl"
 
   namespace :dev do
-    desc "Seed data for development environment"
+    desc "Sample data for local development environment"
     task prime: "db:setup" do
       include FactoryGirl::Syntax::Methods
 


### PR DESCRIPTION
Using db/seeds for data which must be loaded in a production environment
is a standard Rails convention.  We cause confusion by using the word
"seed" elsewhere in a Rails app, where that is not the context.

The `dev:prime` task is actually providing local fake/sample data for
developers to see the app in use, but not production-required data to
actually run the application.