### PR TITLE
Add ctags configuration dotfile per project basis

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -320,6 +320,10 @@ Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i
       end
     end
 
+    def copy_dotfiles
+      directory("dotfiles", ".")
+    end
+
     def init_git
       run 'git init'
     end

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -44,6 +44,7 @@ module Suspenders
       invoke :copy_miscellaneous_files
       invoke :customize_error_pages
       invoke :remove_routes_comment_lines
+      invoke :setup_dotfiles
       invoke :setup_git
       invoke :setup_database
       invoke :create_heroku_apps
@@ -186,6 +187,10 @@ module Suspenders
     def setup_segment
       say 'Setting up Segment'
       build :setup_segment
+    end
+
+    def setup_dotfiles
+      build :copy_dotfiles
     end
 
     def setup_gitignore

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -29,6 +29,10 @@ RSpec.describe "Suspend a new project with default configuration" do
     expect(ruby_version_file).to eq "#{RUBY_VERSION}\n"
   end
 
+  it "copies dotfiles" do
+    expect(File).to exist("#{project_path}/.ctags")
+  end
+
   it "loads secret_key_base from env" do
     secrets_file = IO.read("#{project_path}/config/secrets.yml")
 

--- a/templates/dotfiles/.ctags
+++ b/templates/dotfiles/.ctags
@@ -1,0 +1,2 @@
+--recurse=yes
+--exclude=vendor


### PR DESCRIPTION
Why:

* Use a config dotfile for ctag options.
* Can add more options here on per-project basis,
  like excluding directories, and support for language specific DSLs.
* Start breaking up `templates/` directory into smaller subdirectories.

Related to https://github.com/thoughtbot/dotfiles/pull/390