### PR TITLE
Update CircleCI config

### DIFF
--- a/templates/circle.yml.erb
+++ b/templates/circle.yml.erb
@@ -1,8 +1,9 @@
+checkout:
+  post:
+    - cp .sample.env .env
+database:
+  override:
+    - bin/setup
 test:
   override:
     - bundle exec rake
-deployment:
-  staging:
-    branch: master
-    commands:
-      - bin/deploy staging


### PR DESCRIPTION
The current circle.yml template does not set the env vars before running the build, which can lead to build failures. It also doesn't set a db setup command, which causes Circle to run `rake db:create
db:schema:load` by inference.

This PR sets the command to copy env vars from the .sample.env file post checkout, following CircleCI's recommendation for this type of operation: https://circleci.com/docs/manually#checkout
This allows for the env vars to be available for all steps of the build,making it safe to run commands that load an environment, particularly`rake`.

It also sets the database setup command to `bundle exec rake db:setup` to keep in line with the Suspenders setup script, even though I believe it is technically equivalent to the inferred command.