### PR TITLE
Adds RSpec guard against truncating prod db

### DIFF
--- a/templates/rails_helper.rb
+++ b/templates/rails_helper.rb
@@ -1,6 +1,7 @@
 ENV["RAILS_ENV"] = "test"
 
 require File.expand_path("../../config/environment", __FILE__)
+abort("DATABASE_URL environment variable is set") if ENV["DATABASE_URL"]
 
 require "rspec/rails"
 require "shoulda/matchers"


### PR DESCRIPTION
RSpec-rails introduced a guard against running specs in production environment, this was introduced in version 3.3.3, in PR rspec/rspec-rails@b913f6a.

Rails will override the environment-specific configuration from `database.yml` with `DATABASE_URL` if it's present, so accidentally pulling configuration from the Heroku environment is still a risk.

The guard introduced in this PR prevents the test suite from running against a production db and causing a loss of data.