### PR TITLE
Generate Heroku deployable apps by default, and have a different script to set up heroku services

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 1.31.0 (unreleased)
 
 * Update to Ruby 2.2.3
+* Assume new apps will be deployed to Heroku (like `--heroku true` in previous versions)
 
 1.30.0 (July 30, 2015)
 

--- a/README.md
+++ b/README.md
@@ -113,11 +113,12 @@ Suspenders also comes with:
 
 ## Heroku
 
-You can optionally create Heroku staging and production apps:
+By default, suspenders will create Heroku staging and production apps. To turn
+off this behavior:
 
-    suspenders app --heroku true
+    suspenders app --heroku false
 
-This:
+The Heroku integration:
 
 * Creates a staging and production Heroku app
 * Sets them as `staging` and `production` Git remotes
@@ -133,7 +134,6 @@ This:
 You can optionally specify alternate Heroku flags:
 
     suspenders app \
-      --heroku true \
       --heroku-flags "--region eu --addons newrelic,sendgrid,ssl"
 
 See all possible Heroku flags:

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -6,7 +6,7 @@ module Suspenders
     class_option :database, type: :string, aliases: "-d", default: "postgresql",
       desc: "Configure for selected database (options: #{DATABASES.join("/")})"
 
-    class_option :heroku, type: :boolean, aliases: "-H", default: false,
+    class_option :heroku, type: :boolean, aliases: "-H", default: true,
       desc: "Create staging and production Heroku apps"
 
     class_option :heroku_flags, type: :string, default: "",


### PR DESCRIPTION
* I consistently forget to pass `--heroku true`, even though 100% of apps I work on are deployed to Heroku
* Without the `--heroku true` option, the apps don't have key gems like `rails_stdout_logging`, so errors don't have backtraces
* thoughtbot uses Heroku for all new projects unless there's a compelling reason not to. Since Suspenders is our application template, it should reflect our real-world usage.