### PR TITLE
Add foreman as development dependency

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -27,6 +27,7 @@ gem "title"
 gem "uglifier"
 
 group :development do
+  gem "foreman"
   gem "spring"
   gem "spring-commands-rspec"
   gem "web-console"


### PR DESCRIPTION
Avoids errors when trying to start foreman in development environment.