### PR TITLE
Enable file-type inference by default

### DIFF
--- a/templates/spec_helper.rb
+++ b/templates/spec_helper.rb
@@ -17,6 +17,7 @@ RSpec.configure do |config|
   end
 
   config.example_status_persistence_file_path = "tmp/rspec_examples.txt"
+  config.infer_spec_type_from_file_location!
   config.order = :random
 end
 


### PR DESCRIPTION
This is disabled by default in RSpec 3, which encourages this behaviour:

```ruby
RSpec.describe ThingsController, type: :controller do
end
```

But, with this enabled we can simply write:

```ruby
describe ThingsController do
end
```