### PR TITLE
Remove disable xml params.

### DIFF
--- a/templates/disable_xml_params.rb
+++ b/templates/disable_xml_params.rb
@@ -1,3 +1,2 @@
-# Protect against injection attacks
-# http://www.kb.cert.org/vuls/id/380039
+# Don't accept XML as input params
 ActionDispatch::ParamsParser::DEFAULT_PARSERS.delete(Mime::XML)


### PR DESCRIPTION
I believe this is no longer an issue - [Vulnerability notes](http://www.kb.cert.org/vuls/id/380039) state that the fixed versions are: 3.2.11, 3.1.10, 3.0.19, 2.3.15, so it should be fixed in the Rails 4.2.xx.