### PR TITLE
Set auto-deploy for Heroku suspended apps

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -400,6 +400,20 @@ you can deploy to staging and production with:
       run "chmod a+x bin/deploy"
     end
 
+    def configure_automatic_deployment
+      staging_remote_name = heroku_app_name_for("staging")
+      deploy_command = <<-YML.strip_heredoc
+      deployment:
+        staging:
+          branch: master
+          commands:
+            - git remote add staging git@heroku.com:#{staging_remote_name}.git
+            - bin/deploy staging
+      YML
+
+      append_file "circle.yml", deploy_command
+    end
+
     def create_github_repo(repo_name)
       path_addition = override_path_for_tests
       run "#{path_addition} hub create #{repo_name}"

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -175,6 +175,7 @@ module Suspenders
         build :set_heroku_remotes
         build :set_heroku_rails_secrets
         build :provide_deploy_script
+        build :configure_automatic_deployment
       end
     end
 

--- a/spec/features/heroku_spec.rb
+++ b/spec/features/heroku_spec.rb
@@ -35,6 +35,18 @@ RSpec.describe "Heroku" do
 
     expect(readme).to include("./bin/deploy staging")
     expect(readme).to include("./bin/deploy production")
+
+    circle_yml_path = "#{project_path}/circle.yml"
+    circle_yml = IO.read(circle_yml_path)
+
+    expect(circle_yml).to include <<-YML.strip_heredoc
+    deployment:
+      staging:
+        branch: master
+        commands:
+          - git remote add staging git@heroku.com:#{app_name}-staging.git
+          - bin/deploy staging
+    YML
   end
 
   it "suspends a project with extra Heroku flags" do


### PR DESCRIPTION
Previously, the Circle CI config for suspended applications enabled
automatic deployments for all apps. Given that the `bin/deploy` script
is only generated for apps suspended with the `--heroku true` flag, this
led to builds failing on the deployment step due to the script not being
found.

This PR adds the deployment command to `circle.yml` only when an app is
suspended with the Heroku options. There are still manual setup steps
required, such as setting the Heroku API and SSH key but those are
clearly indicated by the error messages on Circle CI and makes
Suspenders defaults more "out-of-the-box" friendly.