### PR TITLE
Cast ENV variables in database.yml to Integer

### DIFF
--- a/templates/postgresql_database.yml.erb
+++ b/templates/postgresql_database.yml.erb
@@ -4,8 +4,8 @@ development: &default
   encoding: utf8
   host: localhost
   min_messages: warning
-  pool: <%%= ENV.fetch("DB_POOL", 5) %>
-  reaping_frequency: <%%= ENV.fetch("DB_REAPING_FREQUENCY", 10) %>
+  pool: <%%= Integer(ENV.fetch("DB_POOL", 5)) %>
+  reaping_frequency: <%%= Integer(ENV.fetch("DB_REAPING_FREQUENCY", 10)) %>
   timeout: 5000
 
 test:
@@ -15,7 +15,7 @@ test:
 production: &deploy
   encoding: utf8
   min_messages: warning
-  pool: <%%= [ENV.fetch("MAX_THREADS", 5), ENV.fetch("DB_POOL", 5)].max %>
+  pool: <%%= [Integer(ENV.fetch("MAX_THREADS", 5)), Integer(ENV.fetch("DB_POOL", 5))].max %>
   timeout: 5000
   url:  <%%= ENV.fetch("DATABASE_URL", "") %>
 


### PR DESCRIPTION
If you define e.g. `MAX_THREADS=1` in `.env` you get

```bash
(erb):17:in `each': Cannot load `Rails.application.database_configuration`:
comparison of Fixnum with String failed (ArgumentError)
```

That's because in `database.yml` this line:

```yml
  pool: <%= [ENV.fetch("MAX_THREADS", 5), ENV.fetch("DB_POOL", 5)].max %>
```
will be evaluated as

```yml
pool: <%= ["1", 5)].max %>
```

Casting ENV variables to Integer(), as in `puma.rb`, should fix the problem.