### PR TITLE
Fix HOST/APPLICATION_HOST env error

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -86,7 +86,7 @@ module Suspenders
       config = <<-RUBY
 
   # Ensure requests are only served from one, canonical host name
-  config.middleware.use Rack::CanonicalHost, ENV.fetch("HOST")
+  config.middleware.use Rack::CanonicalHost, ENV.fetch("APPLICATION_HOST")
       RUBY
 
       inject_into_file(
@@ -255,8 +255,8 @@ Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i
     def configure_action_mailer
       action_mailer_host "development", %{"localhost:#{port}"}
       action_mailer_host "test", %{"www.example.com"}
-      action_mailer_host "staging", %{ENV.fetch("HOST")}
-      action_mailer_host "production", %{ENV.fetch("HOST")}
+      action_mailer_host "staging", %{ENV.fetch("APPLICATION_HOST")}
+      action_mailer_host "production", %{ENV.fetch("APPLICATION_HOST")}
     end
 
     def configure_active_job

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -111,6 +111,12 @@ RSpec.describe "Suspend a new project with default configuration" do
       to match(/^ +config.action_mailer.delivery_method = :test$/)
   end
 
+  it "uses APPLICATION_HOST, not HOST in the production config" do
+    prod_env_file = IO.read("#{project_path}/config/environments/production.rb")
+    expect(prod_env_file).to match(/"APPLICATION_HOST"/)
+    expect(prod_env_file).not_to match(/"HOST"/)
+  end
+
   it "configs active job queue adapter" do
     application_config = IO.read("#{project_path}/config/application.rb")
     test_config = IO.read("#{project_path}/config/environments/test.rb")


### PR DESCRIPTION
Reason for change:
* In 9d27905884540e44109cc66630062101307f150a, `HOST` was replaced for  `APPLICATION_HOST`
* Some instances were missed, leading to errors on deploy from a fresh build.

What the change was:
* Replace remaining `HOST` instances with `APPLICATION_HOST`
* Add regression spec

Original commit: https://github.com/thoughtbot/suspenders/commit/9d27905884540e44109cc66630062101307f150a