### PR TITLE
Don't use port 5000 as an option

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -511,7 +511,7 @@ end
     end
 
     def port
-      @port ||= [3000, 4000, 5000, 7000, 8000, 9000].sample
+      @port ||= [3000, 4000, 7000, 8000, 9000].sample
     end
 
     def serve_static_files_line


### PR DESCRIPTION
OS X Yosemite uses port 5000 for AirPlay streaming.
Running Rails on port 5000 will add noise to the backtrace such as:

```
HTTP parse error, malformed request ():
ENV:
{"rack.version"=>[1, 1], "rack.errors"=>#<IO:<STDERR>>,
"rack.multithread"=>true, "rack.multiprocess"=>false,
"rack.run_once"=>false, "SCRIPT_NAME"=>"", "CONTENT_TYPE"=>"text/plain",
"QUERY_STRING"=>"txtAirPlay&txtRAOP", "SERVER_PROTOCOL"=>"HTTP/1.1",
"SERVER_SOFTWARE"=>"2.11.2", "GATEWAY_INTERFACE"=>"CGI/1.2",
"REQUEST_METHOD"=>"GET", "REQUEST_PATH"=>"/info",
"REQUEST_URI"=>"/info?txtAirPlay&txtRAOP"}
```

http://stackoverflow.com/questions/31194909/http-parse-errors-coming-from-airplay