### PR TITLE
Configure capybara-webkit to block unknown URLs

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -43,7 +43,7 @@ group :development, :test do
 end
 
 group :test do
-  gem "capybara-webkit", ">= 1.2.0"
+  gem "capybara-webkit"
   gem "database_cleaner"
   gem "formulaic"
   gem "launchy"

--- a/templates/rails_helper.rb
+++ b/templates/rails_helper.rb
@@ -14,6 +14,9 @@ module Features
 end
 
 RSpec.configure do |config|
+  config.before(:each, js: true) do
+    page.driver.block_unknown_urls
+  end
   config.include Features, type: :feature
   config.infer_base_class_for_anonymous_controllers = false
   config.infer_spec_type_from_file_location!


### PR DESCRIPTION
Removes capybara-webkit minimum version specification in Gemfile,
relying on bundler to install latest available release.

See: http://blog.arkency.com/2015/02/upgrade-capybara-webkit-to-1-dot-4-and-save-your-time/

[fixes #550]

cc @jferris @croaky for reviews. Thank you!