### PR TITLE
Install Foreman automatically in setup script

### DIFF
--- a/templates/bin_setup.erb
+++ b/templates/bin_setup.erb
@@ -27,8 +27,7 @@ if ! grep --quiet --no-messages --fixed-strings 'port' .foreman; then
 fi
 
 if ! command -v foreman > /dev/null; then
-  printf 'Foreman is not installed.\n'
-  printf 'See https://github.com/ddollar/foreman for install instructions.\n'
+  gem install foreman
 fi
 
 # Only if this isn't CI


### PR DESCRIPTION
Why:

* Right now, the setup script informs you to install Foreman manually
  if is not already installed. Unfortunately, it's very easy to miss
  this message amid all of the other output when you're running the
  script for the first time.
* Foreman is a staple in our development toolkit, and not having it
  installed is frustrating for designers who aren't as familiar with
  Ruby as developers are. Having them ask developers for help every time
  this occurs isn't a long-term solution.

To satisfy the above:

* Just ensure that Foreman is installed.