### PR TITLE
Provide Shoulda Matchers config

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -197,6 +197,13 @@ end
       copy_file 'database_cleaner_rspec.rb', 'spec/support/database_cleaner.rb'
     end
 
+    def provide_shoulda_matchers_config
+      copy_file(
+        "shoulda_matchers_config_rspec.rb",
+        "spec/support/shoulda_matchers_config.rb"
+      )
+    end
+
     def configure_spec_support_features
       empty_directory_with_keep_file 'spec/features'
       empty_directory_with_keep_file 'spec/support/features'

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -96,6 +96,7 @@ module Suspenders
       build :configure_rspec
       build :configure_background_jobs_for_rspec
       build :enable_database_cleaner
+      build :provide_shoulda_matchers_config
       build :configure_spec_support_features
       build :configure_ci
       build :configure_i18n_for_test_environment

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -47,7 +47,7 @@ group :test do
   gem "database_cleaner"
   gem "formulaic"
   gem "launchy"
-  gem "shoulda-matchers", require: false
+  gem "shoulda-matchers"
   gem "simplecov", require: false
   gem "timecop"
   gem "webmock"

--- a/templates/rails_helper.rb
+++ b/templates/rails_helper.rb
@@ -4,7 +4,6 @@ require File.expand_path("../../config/environment", __FILE__)
 abort("DATABASE_URL environment variable is set") if ENV["DATABASE_URL"]
 
 require "rspec/rails"
-require "shoulda/matchers"
 
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |file| require file }
 

--- a/templates/shoulda_matchers_config_rspec.rb
+++ b/templates/shoulda_matchers_config_rspec.rb
@@ -1,0 +1,6 @@
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
The recent release of Shoulda Matchers 3.0 introduces some changes,
namely requiring configuration in order to operate.
The absence of the file leads to hard to decipher errors: they indicate
methods are missing and can lead to some frustration trying to
understand what is necessary to get Shoulda to behave correctly.

This PR introduces a build step to provide a config file for in order
for it to be enabled "out-of-the-box". It opts in to enable interaction
with all of Rails, as this seems the principle of least surprise.