### PR TITLE
Use pry-byebug instead of just byebug

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+HEAD
+
+* Add ability to use byebug navigation commands inside of Pry using the
+  `pry-byebug` gem
+
 1.34.0 (November 15, 2015)
 
 * Fix `block_unknown_urls` deprecation warning with capybara_webkit when running

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -35,10 +35,10 @@ group :development, :test do
   gem "awesome_print"
   gem "bullet"
   gem "bundler-audit", require: false
-  gem "byebug"
   gem "dotenv-rails"
   gem "factory_girl_rails"
   gem "i18n-tasks"
+  gem "pry-byebug"
   gem "pry-rails"
   gem "rspec-rails", "~> 3.3.0"
 end


### PR DESCRIPTION
Why use just Pry or byebug when you can have the power of both?

This lets us use `next`, `continue`, `up`, etc. instead of a Pry
session; conversely, it gives us a full IRB environment inside of a
byebug session.