### PR TITLE
Generate empty spec/factories.rb file

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -58,6 +58,10 @@ module Suspenders
       copy_file 'factory_girl_rspec.rb', 'spec/support/factory_girl.rb'
     end
 
+    def generate_factories_file
+      copy_file "factories.rb", "spec/factories.rb"
+    end
+
     def set_up_hound
       copy_file "hound.yml", ".hound.yml"
     end

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -91,6 +91,7 @@ module Suspenders
     def setup_test_environment
       say 'Setting up the test environment'
       build :set_up_factory_girl_for_rspec
+      build :generate_factories_file
       build :set_up_hound
       build :generate_rspec
       build :configure_rspec

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -154,6 +154,10 @@ RSpec.describe "Suspend a new project with default configuration" do
     end
   end
 
+  it "copies factories.rb" do
+    expect(File).to exist("#{project_path}/spec/factories.rb")
+  end
+
   def analytics_partial
     IO.read("#{project_path}/app/views/application/_analytics.html.erb")
   end

--- a/templates/factories.rb
+++ b/templates/factories.rb
@@ -1,0 +1,2 @@
+FactoryGirl.define do
+end


### PR DESCRIPTION
Our guides say

> Use one factories.rb file per project.

and the factory_girl_rails documentation says

> If you use factory_girl for fixture replacement and already have a
> factories.rb file in the directory that contains your tests,
> factory_girl_rails will insert new factory definitions at the top of
> factories.rb.

Generating this file will allow use to conform to our guides more
easily. Will close #622.