### PR TITLE
Fail the build if there are any violations found

### DIFF
--- a/templates/hound.yml
+++ b/templates/hound.yml
@@ -1,4 +1,6 @@
 # See https://houndci.com/configuration for help.
+fail_on_violations: true
+
 coffeescript:
   # config_file: .coffeescript-style.json
   enabled: true


### PR DESCRIPTION
We've been using this in Hound and enjoying the benefit it gives.

A PR should not be merged consciously with a failed build. And
inconsistent code should fall under that umbrella.