### PR TITLE
Cleanup generated `bin/setup` file

### DIFF
--- a/templates/bin_setup.erb
+++ b/templates/bin_setup.erb
@@ -16,7 +16,7 @@ if [ ! -f .env ]; then
 fi
 
 # Set up database and add any development seed data
-bundle exec rake db:setup dev:prime
+bin/rake dev:prime
 
 # Add binstubs to PATH via export PATH=".git/safe/../../bin:$PATH" in ~/.zshenv
 mkdir -p .git/safe


### PR DESCRIPTION
According to the current definition of the [dev:prime][task] Rake
task, chaining `db:setup` before `dev:prime` is unnecessary.

Additionally, the generated Rails application uses Bundler's [binstubs],
so we can replace `bundle exec rake` with `bin/rake`.

[task]: https://github.com/thoughtbot/suspenders/blob/bfd75f9f16f8557ddf91a069525d13f7bdc7ce8f/templates/dev.rake#L6
[binstubs]: http://bundler.io/v1.10/bundle_binstubs.html