### PR TITLE
Add quiet_assets as development dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ And development gems like:
   pre-loading
 * [Web Console](https://github.com/rails/web-console) for better debugging via
   in-browser IRB consoles.
+* [Quiet Assets](https://github.com/evrone/quiet_assets) for muting assets
+  pipeline log messages
 
 And testing gems like:
 

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -27,6 +27,14 @@ module Suspenders
       inject_into_class "config/application.rb", "Application", config
     end
 
+    def configure_quiet_assets
+      config = <<-RUBY
+    config.quiet_assets = true
+      RUBY
+
+      inject_into_class "config/application.rb", "Application", config
+    end
+
     def provide_setup_script
       template "bin_setup.erb", "bin/setup", force: true
       run "chmod a+x bin/setup"

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -86,6 +86,7 @@ module Suspenders
       build :provide_dev_prime_task
       build :configure_generators
       build :configure_i18n_for_missing_translations
+      build :configure_quiet_assets
     end
 
     def setup_test_environment

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -76,6 +76,14 @@ RSpec.describe "Suspend a new project with default configuration" do
     )
   end
 
+  it "adds explicit quiet_assets configuration" do
+    result = IO.read("#{project_path}/config/application.rb")
+
+    expect(result).to match(
+      /^ +config.quiet_assets = true$/
+    )
+  end
+
   it "raises on missing translations in development and test" do
     %w[development test].each do |environment|
       environment_file =

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -25,6 +25,7 @@ gem "title"
 gem "uglifier"
 
 group :development do
+  gem "quiet_assets"
   gem "refills"
   gem "spring"
   gem "spring-commands-rspec"


### PR DESCRIPTION
I typically search the logs to find parameters, response codes and
stacktraces. Although we don't need to see what assets have been loaded,
those logs take up more space than the aforementioned ones.

`quiet_assets` hide the assets logs in development, making the log for
the landing page on my current suspenders project go from 64 lines
detailing assets, to 13 relevant lines.