### PR TITLE
Fixes deprecation warning from capybara-webkit

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -246,6 +246,10 @@ end
       copy_file 'action_mailer.rb', 'spec/support/action_mailer.rb'
     end
 
+    def configure_capybara_webkit
+      copy_file "capybara_webkit.rb", "spec/support/capybara_webkit.rb"
+    end
+
     def configure_time_formats
       remove_file "config/locales/en.yml"
       template "config_locales_en.yml.erb", "config/locales/en.yml"

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -103,6 +103,7 @@ module Suspenders
       build :configure_i18n_for_test_environment
       build :configure_i18n_tasks
       build :configure_action_mailer_in_specs
+      build :configure_capybara_webkit
     end
 
     def setup_production_environment

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -43,6 +43,10 @@ RSpec.describe "Suspend a new project with default configuration" do
     expect(File).to exist("#{project_path}/spec/support/action_mailer.rb")
   end
 
+  it "configures capybara-webkit" do
+    expect(File).to exist("#{project_path}/spec/support/capybara_webkit.rb")
+  end
+
   it "adds support file for i18n" do
     expect(File).to exist("#{project_path}/spec/support/i18n.rb")
   end

--- a/templates/capybara_webkit.rb
+++ b/templates/capybara_webkit.rb
@@ -1,0 +1,5 @@
+Capybara.javascript_driver = :webkit
+
+Capybara::Webkit.configure do |config|
+  config.block_unknown_urls
+end

--- a/templates/rails_helper.rb
+++ b/templates/rails_helper.rb
@@ -13,9 +13,6 @@ module Features
 end
 
 RSpec.configure do |config|
-  config.before(:each, js: true) do
-    page.driver.block_unknown_urls
-  end
   config.include Features, type: :feature
   config.infer_base_class_for_anonymous_controllers = false
   config.infer_spec_type_from_file_location!
@@ -23,4 +20,3 @@ RSpec.configure do |config|
 end
 
 ActiveRecord::Migration.maintain_test_schema!
-Capybara.javascript_driver = :webkit


### PR DESCRIPTION
When enabling javascript testing in a new app, the developer would receive the following message in their rspec output:

    [DEPRECATION] block_unknown_urls is deprecated. Please use Capybara::Webkit.configure instead:

      Capybara::Webkit.configure do |config|
        config.block_unknown_urls
      end

    This option is global and can be configured once (not in a `before` or `setup` block).

This change creates spec/support/capybara_webkit.rb that contains the configuration and removes code in spec_helper.rb triggering the deprecation warning.