### PR TITLE
Added version command to CLI

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+1.34.0 (unreleased)
+
+* Suspenders command line responds to `-v` and `--version` options
+
 1.33.0 (October 23, 2015)
 
 * Add `quiet_assets` as development dependency

--- a/bin/suspenders
+++ b/bin/suspenders
@@ -11,6 +11,11 @@ if ['create', '--create'].include? ARGV[0]
   puts "[WARNING] the suspenders create argument is deprecated. Just use `suspenders #{ARGV.join}` instead"
 end
 
+if ['-v', '--version'].include? ARGV[0]
+  puts Suspenders::VERSION
+  exit 0
+end
+
 templates_root = File.expand_path(File.join("..", "templates"), File.dirname(__FILE__))
 Suspenders::AppGenerator.source_root templates_root
 Suspenders::AppGenerator.source_paths << Rails::Generators::AppGenerator.source_root << templates_root


### PR DESCRIPTION
In the latest version 1.33.0, when you type 'suspenders --version' in the CLI, Suspenders responds with the message 'No value provided for required arguments 'app_path'.

I fixed this by adding '-v' and '--version' commands in bin/suspenders.rb.  Those commands will now return the proper suspenders version in the CLI. 