### PR TITLE
Introduce Heroku Pipelines support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Then run:
 
 This will create a Rails app in `projectname` using the latest version of Rails.
 
+### Associated services
+
+* Enable [Circle CI](https://circleci.com/) Continuous Integration
+* Enable [GitHub auto deploys to Heroku staging and review
+    apps](https://dashboard.heroku.com/apps/app-name-staging/deploy/github).
+
 ## Gemfile
 
 To see the latest and greatest gems, look at Suspenders'
@@ -128,9 +134,11 @@ This:
 * Adds the [Rails Stdout Logging][logging-gem] gem
   to configure the app to log to standard out,
   which is how [Heroku's logging][heroku-logging] works.
+* Creates a [Heroku Pipeline] for review apps
 
 [logging-gem]: https://github.com/heroku/rails_stdout_logging
 [heroku-logging]: https://devcenter.heroku.com/articles/logging#writing-to-your-log
+[Heroku Pipeline]: https://devcenter.heroku.com/articles/pipelines
 
 You can optionally specify alternate Heroku flags:
 

--- a/bin/setup
+++ b/bin/setup
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/sh
 
 # Run this script immediately after cloning the codebase.
 

--- a/lib/suspenders/adapters/heroku.rb
+++ b/lib/suspenders/adapters/heroku.rb
@@ -7,10 +7,9 @@ module Suspenders
 
       def set_heroku_remotes
         remotes = <<-SHELL.strip_heredoc
-
-          # Set up the staging and production apps.
           #{command_to_join_heroku_app('staging')}
           #{command_to_join_heroku_app('production')}
+
           git config heroku.remote staging
         SHELL
 
@@ -25,10 +24,62 @@ module Suspenders
         )
       end
 
+      def create_staging_heroku_app(flags)
+        rack_env = "RACK_ENV=staging RAILS_ENV=staging"
+        app_name = heroku_app_name_for("staging")
+
+        run_toolbelt_command "create #{app_name} #{flags}", "staging"
+        run_toolbelt_command "config:add #{rack_env}", "staging"
+      end
+
+      def create_production_heroku_app(flags)
+        app_name = heroku_app_name_for("production")
+
+        run_toolbelt_command "create #{app_name} #{flags}", "production"
+      end
+
       def set_heroku_rails_secrets
         %w(staging production).each do |environment|
           run_toolbelt_command(
             "config:add SECRET_KEY_BASE=#{generate_secret}",
+            environment,
+          )
+        end
+      end
+
+      def provide_review_apps_setup_script
+        app_builder.template(
+          "bin_setup_review_app.erb",
+          "bin/setup_review_app",
+          force: true,
+        )
+        app_builder.run "chmod a+x bin/setup_review_app"
+      end
+
+      def create_heroku_pipelines_config_file
+        app_builder.template "app.json.erb", "app.json"
+      end
+
+      def create_heroku_pipeline
+        pipelines_plugin = `heroku plugins | grep pipelines`
+        if pipelines_plugin.empty?
+          puts "You need heroku pipelines plugin. Run: heroku plugins:install heroku-pipelines"
+          exit 1
+        end
+
+        heroku_app_name = app_builder.app_name.dasherize
+        %w(staging production).each do |environment|
+          run_toolbelt_command(
+            "pipelines:create #{heroku_app_name} -a #{heroku_app_name}-#{environment} --stage #{environment}",
+            environment,
+          )
+        end
+      end
+
+      def set_heroku_serve_static_files
+        %w(staging production).each do |environment|
+          run_toolbelt_command(
+            "config:add RAILS_SERVE_STATIC_FILES=true",
             environment,
           )
         end
@@ -41,6 +92,7 @@ module Suspenders
       def command_to_join_heroku_app(environment)
         heroku_app_name = heroku_app_name_for(environment)
         <<-SHELL
+
 if heroku join --app #{heroku_app_name} &> /dev/null; then
   git remote add #{environment} git@heroku.com:#{heroku_app_name}.git || true
   printf 'You are a collaborator on the "#{heroku_app_name}" Heroku app\n'

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -176,9 +176,12 @@ module Suspenders
       if options[:heroku]
         say "Creating Heroku apps"
         build :create_heroku_apps, options[:heroku_flags]
+        build :provide_review_apps_setup_script
         build :set_heroku_serve_static_files
         build :set_heroku_remotes
         build :set_heroku_rails_secrets
+        build :create_heroku_pipelines_config_file
+        build :create_heroku_pipeline
         build :provide_deploy_script
         build :configure_automatic_deployment
       end

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -41,6 +41,16 @@ RSpec.describe "Suspend a new project with default configuration" do
     expect(secrets_file).to match(/secret_key_base: <%= ENV\["SECRET_KEY_BASE"\] %>/)
   end
 
+  it "adds bin/setup file" do
+    expect(File).to exist("#{project_path}/bin/setup")
+  end
+
+  it "makes bin/setup executable" do
+    bin_setup_path = "#{project_path}/bin/setup"
+
+    expect(File.stat(bin_setup_path)).to be_executable
+  end
+
   it "adds support file for action mailer" do
     expect(File).to exist("#{project_path}/spec/support/action_mailer.rb")
   end
@@ -102,7 +112,6 @@ RSpec.describe "Suspend a new project with default configuration" do
 
   it "evaluates en.yml.erb" do
     locales_en_file = IO.read("#{project_path}/config/locales/en.yml")
-    app_name = SuspendersTestHelpers::APP_NAME
 
     expect(locales_en_file).to match(/application: #{app_name.humanize}/)
   end
@@ -183,6 +192,10 @@ RSpec.describe "Suspend a new project with default configuration" do
 
   it "copies factories.rb" do
     expect(File).to exist("#{project_path}/spec/factories.rb")
+  end
+
+  def app_name
+    SuspendersTestHelpers::APP_NAME
   end
 
   def analytics_partial

--- a/spec/support/fake_heroku.rb
+++ b/spec/support/fake_heroku.rb
@@ -6,6 +6,9 @@ class FakeHeroku
   end
 
   def run!
+    if @args.first == "plugins"
+      puts "heroku-pipelines@0.29.0"
+    end
     File.open(RECORDER, 'a') do |file|
       file.puts @args.join(' ')
     end
@@ -37,6 +40,11 @@ class FakeHeroku
 
   def self.has_configured_vars?(remote_name, var)
     commands_ran =~ /^config:add #{var}=.+ --remote #{remote_name}\n/
+  end
+
+  def self.has_setup_pipeline_for?(app_name)
+    commands_ran =~ /^pipelines:create #{app_name} -a #{app_name}-staging --stage staging/ &&
+      commands_ran =~ /^pipelines:create #{app_name} -a #{app_name}-production --stage production/
   end
 
   def self.commands_ran

--- a/templates/app.json.erb
+++ b/templates/app.json.erb
@@ -1,0 +1,39 @@
+{
+  "name":"<%= app_name.dasherize %>",
+  "scripts":{},
+  "env":{
+    "AIRBRAKE_API_KEY":{
+      "required":true
+    },
+    "EMAIL_RECIPIENTS":{
+      "required":true
+    },
+    "RACK_ENV":{
+      "required":true
+    },
+    "RAILS_ENV":{
+      "required":true
+    },
+    "SECRET_KEY_BASE":{
+      "generator":"secret"
+    },
+    "SMTP_ADDRESS":{
+      "required":true
+    },
+    "SMTP_DOMAIN":{
+      "required":true
+    },
+    "SMTP_PASSWORD":{
+      "required":true
+    },
+    "SMTP_USERNAME":{
+      "required":true
+    },
+    "WEB_CONCURRENCY":{
+      "required":true
+    }
+  },
+  "addons":[
+    "heroku-postgresql"
+  ]
+}

--- a/templates/bin_setup
+++ b/templates/bin_setup
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/sh
 
 # Set up Rails app. Run this script immediately after cloning the codebase.
 # https://github.com/thoughtbot/guides/tree/master/protocol

--- a/templates/bin_setup_review_app.erb
+++ b/templates/bin_setup_review_app.erb
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# Run this script to set up a review app's database and worker dyno
+
+set -e
+
+if [ -z "$1" ]; then
+  printf "You must provide a review app (same as the pull request) id.\n"
+  exit 64
+fi
+
+heroku pg:backups restore \
+  `heroku pg:backups public-url -a <%= app_name.dasherize %>-staging` \
+  DATABASE_URL \
+  --confirm <%= app_name.dasherize %>-staging-pr-$1 \
+  --app <%= app_name.dasherize %>-staging-pr-$1
+heroku run rake db:migrate --app <%= app_name.dasherize %>-staging-pr-$1
+heroku ps:scale worker=1 --app <%= app_name.dasherize %>-staging-pr-$1
+heroku restart --app <%= app_name.dasherize %>-staging-pr-$1


### PR DESCRIPTION
Why:

* We have observed that running acceptance through Heroku Pipelines is a
  better flow for code reviews, by allowing to show work in progress
  earlier, and fixing issue before merging into master

This change addresses the need by:

* Creating a pipeline for the new app, and adding the staging and
  production environments to it
* Adding a required `app.json` configuration file
* Setting `Rack::CanonicalHost` only in staging and production, and not
  review apps (otherwise review apps redirect to staging)
* Adding a setup script for review apps to scale up workers to 1 and run migrations

## Done

- [x] Check if heroku pipelines plugin is installed
```bash
if heroku pipelines &> /dev/null; then
  do_it
else
  printf 'You need heroku pipelines plugin. Run: heroku plugins:install heroku-pipelines'
fi
```
- [x] Fix `APPLICATION_HOST`: https://github.com/thoughtbot/suspenders/pull/639#issuecomment-152546822. If we do, we don't need a conditional around `Rack::CanonicalHost`.
- [x] Emails are being sent with the staging URL, and so links don't work for review apps (related to previous point)
- [x] Work around the fact that there are no after hooks after a review app is created, and we need to set up the database at first manually (`bin/setup_review_app`).
- [x] Emails aren't send because review apps are not starting with a worker dyno (`bin/setup_review_app`)
- [x] Add instructions for hooking up the pipeline to GitHub autodeploys in README
  * needs to set up Circle CI with the new GitHub repo
  * needs to hook up GitHub autodeploys in Heroku
  * needs to hook up GitHub auto review apps in Heroku
