### PR TITLE
Remove Capybara-Webkit deprecation warning

### DIFF
--- a/templates/rails_helper.rb
+++ b/templates/rails_helper.rb
@@ -14,8 +14,9 @@ end
 
 RSpec.configure do |config|
   config.before(:each, js: true) do
-    page.driver.block_unknown_urls
+    page.block_unknown_urls = true
   end
+
   config.include Features, type: :feature
   config.infer_base_class_for_anonymous_controllers = false
   config.infer_spec_type_from_file_location!


### PR DESCRIPTION
Capybara-Webkit's current release (1.7.1) issues a deprecation warning
on the use of `page.driver.block_unknown_urls`. This change updates to
use the preferred, non-deprecated syntax.