### PR TITLE
Configure SimpleForm earlier

### DIFF
--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -58,6 +58,7 @@ module Suspenders
 
     def customize_gemfile
       build :replace_gemfile
+      build :configure_simple_form
       build :set_ruby_to_version_being_used
 
       if options[:heroku]
@@ -140,7 +141,6 @@ module Suspenders
       build :configure_action_mailer
       build :configure_active_job
       build :configure_time_formats
-      build :configure_simple_form
       build :disable_xml_params
       build :fix_i18n_deprecation_warning
       build :setup_default_rake_task


### PR DESCRIPTION
A spec run in master looks like:

```
[Simple Form] Simple Form is not configured in the application and will use the default values. Use `rails generate simple_form:install` to generate the Simple Form configuration.
[Simple Form] Simple Form is not configured in the application and will use the default values. Use `rails generate simple_form:install` to generate the Simple Form configuration.
[Simple Form] Simple Form is not configured in the application and will use the default values. Use `rails generate simple_form:install` to generate the Simple Form configuration.
.

Finished in 22.78 seconds (files took 0.12645 seconds to load)
1 example, 0 failures
```

If we configure SimpleForm earlier in the process, we get the warning
only once, during the generation of the initializer:

```
[Simple Form] Simple Form is not configured in the application and will use the default values. Use `rails generate simple_form:install` to generate the Simple Form configuration.
.

Finished in 19.64 seconds (files took 0.13412 seconds to load)
1 example, 0 failures
```

It might be an issue with SimpleForm that during the configuration of
the gem it warns that it's not configured.

[fixes #452]
[fixes #640]