### PR TITLE
Add bullet as development dependency

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -19,6 +19,23 @@ module Suspenders
       )
     end
 
+    def add_bullet_gem_configuration
+      config = <<-RUBY
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.bullet_logger = true
+    Bullet.rails_logger = true
+  end
+
+      RUBY
+
+      inject_into_file(
+        "config/environments/development.rb",
+        config,
+        after: "config.action_mailer.raise_delivery_errors = true\n",
+      )
+    end
+
     def raise_on_unpermitted_parameters
       config = <<-RUBY
     config.action_controller.action_on_unpermitted_parameters = :raise

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -82,6 +82,7 @@ module Suspenders
       say 'Setting up the development environment'
       build :raise_on_delivery_errors
       build :set_test_delivery_method
+      build :add_bullet_gem_configuration
       build :raise_on_unpermitted_parameters
       build :provide_setup_script
       build :provide_dev_prime_task

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -141,6 +141,14 @@ RSpec.describe "Suspend a new project with default configuration" do
     )
   end
 
+  it "configs bullet gem in development" do
+    test_config = IO.read("#{project_path}/config/environments/development.rb")
+
+    expect(test_config).to match /^ +Bullet.enable = true$/
+    expect(test_config).to match /^ +Bullet.bullet_logger = true$/
+    expect(test_config).to match /^ +Bullet.rails_logger = true$/
+  end
+
   it "adds spring to binstubs" do
     expect(File).to exist("#{project_path}/bin/spring")
 

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -33,6 +33,7 @@ end
 
 group :development, :test do
   gem "awesome_print"
+  gem "bullet"
   gem "bundler-audit", require: false
   gem "byebug"
   gem "dotenv-rails"


### PR DESCRIPTION
Bullet notifies automatically if there is any request in the application
where we are performing N+1 queries, or unused eager loading.

With this check we make sure we eager load what is needed, and nothing
more, without having to check each endpoint.