### PR TITLE
Improve testability

### DIFF
--- a/lib/suspenders.rb
+++ b/lib/suspenders.rb
@@ -1,4 +1,5 @@
 require 'suspenders/version'
 require 'suspenders/generators/app_generator'
 require 'suspenders/actions'
+require "suspenders/adapters/heroku"
 require 'suspenders/app_builder'

--- a/lib/suspenders/adapters/heroku.rb
+++ b/lib/suspenders/adapters/heroku.rb
@@ -1,0 +1,67 @@
+module Suspenders
+  module Adapters
+    class Heroku
+      def initialize(app_builder)
+        @app_builder = app_builder
+      end
+
+      def set_heroku_remotes
+        remotes = <<-SHELL.strip_heredoc
+
+          # Set up the staging and production apps.
+          #{command_to_join_heroku_app('staging')}
+          #{command_to_join_heroku_app('production')}
+        SHELL
+
+        app_builder.append_file "bin/setup", remotes
+      end
+
+      def set_up_heroku_specific_gems
+        app_builder.inject_into_file(
+          "Gemfile",
+          %{\n\s\sgem "rails_stdout_logging"},
+          after: /group :staging, :production do/,
+        )
+      end
+
+      def set_heroku_rails_secrets
+        %w(staging production).each do |environment|
+          run_toolbelt_command(
+            "config:add SECRET_KEY_BASE=#{generate_secret}",
+            environment,
+          )
+        end
+      end
+
+      private
+
+      attr_reader :app_builder
+
+      def command_to_join_heroku_app(environment)
+        heroku_app_name = heroku_app_name_for(environment)
+        <<-SHELL
+if heroku join --app #{heroku_app_name} &> /dev/null; then
+  git remote add #{environment} git@heroku.com:#{heroku_app_name}.git || true
+  printf 'You are a collaborator on the "#{heroku_app_name}" Heroku app\n'
+else
+  printf 'Ask for access to the "#{heroku_app_name}" Heroku app\n'
+fi
+        SHELL
+      end
+
+      def heroku_app_name_for(environment)
+        "#{app_builder.app_name.dasherize}-#{environment}"
+      end
+
+      def generate_secret
+        SecureRandom.hex(64)
+      end
+
+      def run_toolbelt_command(command, environment)
+        app_builder.run(
+          "heroku #{command} --remote #{environment}",
+        )
+      end
+    end
+  end
+end

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -1,6 +1,14 @@
+require "forwardable"
+
 module Suspenders
   class AppBuilder < Rails::AppBuilder
     include Suspenders::Actions
+    extend Forwardable
+
+    def_delegators :heroku_adapter,
+                   :set_heroku_remotes,
+                   :set_up_heroku_specific_gems,
+                   :set_heroku_rails_secrets
 
     def readme
       template 'README.md.erb', 'README.md'
@@ -214,14 +222,6 @@ end
       create_file '.ruby-version', "#{Suspenders::RUBY_VERSION}\n"
     end
 
-    def setup_heroku_specific_gems
-      inject_into_file(
-        "Gemfile",
-        %{\n\s\sgem "rails_stdout_logging"},
-        after: /group :staging, :production do/
-      )
-    end
-
     def enable_database_cleaner
       copy_file 'database_cleaner_rspec.rb', 'spec/support/database_cleaner.rb'
     end
@@ -386,35 +386,6 @@ Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i
       create_production_heroku_app(flags)
     end
 
-    def set_heroku_remotes
-      remotes = <<-SHELL
-
-# Set up the staging and production apps.
-#{join_heroku_app('staging')}
-#{join_heroku_app('production')}
-      SHELL
-
-      append_file 'bin/setup', remotes
-    end
-
-    def join_heroku_app(environment)
-      heroku_app_name = heroku_app_name_for(environment)
-      <<-SHELL
-if heroku join --app #{heroku_app_name} &> /dev/null; then
-  git remote add #{environment} git@heroku.com:#{heroku_app_name}.git || true
-  printf 'You are a collaborator on the "#{heroku_app_name}" Heroku app\n'
-else
-  printf 'Ask for access to the "#{heroku_app_name}" Heroku app\n'
-fi
-      SHELL
-    end
-
-    def set_heroku_rails_secrets
-      %w(staging production).each do |environment|
-        run_heroku "config:add SECRET_KEY_BASE=#{generate_secret}", environment
-      end
-    end
-
     def set_heroku_serve_static_files
       %w(staging production).each do |environment|
         run_heroku "config:add RAILS_SERVE_STATIC_FILES=true", environment
@@ -453,8 +424,7 @@ you can deploy to staging and production with:
     end
 
     def create_github_repo(repo_name)
-      path_addition = override_path_for_tests
-      run "#{path_addition} hub create #{repo_name}"
+      run "hub create #{repo_name}"
     end
 
     def setup_segment
@@ -546,20 +516,12 @@ end
       uncomment_lines("config/environments/#{environment}.rb", config)
     end
 
-    def override_path_for_tests
-      if ENV['TESTING']
-        support_bin = File.expand_path(File.join('..', '..', 'spec', 'fakes', 'bin'))
-        "PATH=#{support_bin}:$PATH"
-      end
-    end
-
     def run_heroku(command, environment)
-      path_addition = override_path_for_tests
-      run "#{path_addition} heroku #{command} --remote #{environment}"
+      run "heroku #{command} --remote #{environment}"
     end
 
-    def generate_secret
-      SecureRandom.hex(64)
+    def heroku_adapter
+      @heroku_adapter ||= Adapters::Heroku.new(self)
     end
 
     def serve_static_files_line

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -61,7 +61,7 @@ module Suspenders
       build :set_ruby_to_version_being_used
 
       if options[:heroku]
-        build :setup_heroku_specific_gems
+        build :set_up_heroku_specific_gems
       end
 
       bundle_command 'install'

--- a/spec/adapters/heroku_spec.rb
+++ b/spec/adapters/heroku_spec.rb
@@ -1,0 +1,52 @@
+require "spec_helper"
+
+module Suspenders
+  module Adapters
+    RSpec.describe Heroku do
+      it "sets the heroku remotes" do
+        setup_file = "bin/setup"
+        app_builder = double(app_name: app_name)
+        allow(app_builder).to receive(:append_file)
+
+        Heroku.new(app_builder).set_heroku_remotes
+
+        expect(app_builder).to have_received(:append_file).
+          with(setup_file, /heroku join --app #{app_name.dasherize}-production/)
+        expect(app_builder).to have_received(:append_file).
+          with(setup_file, /heroku join --app #{app_name.dasherize}-staging/)
+      end
+
+      it "sets up the heroku specific gems" do
+        app_builder = double(app_name: app_name)
+        allow(app_builder).to receive(:inject_into_file)
+
+        Heroku.new(app_builder).set_up_heroku_specific_gems
+
+        expect(app_builder).to have_received(:inject_into_file).
+          with("Gemfile", /rails_stdout_logging/, anything)
+      end
+
+      it "sets the heroku rails secrets" do
+        app_builder = double(app_name: app_name)
+        allow(app_builder).to receive(:run)
+
+        Heroku.new(app_builder).set_heroku_rails_secrets
+
+        expect(app_builder).to(
+          have_configured_var("staging", "SECRET_KEY_BASE"),
+        )
+        expect(app_builder).to(
+          have_configured_var("production", "SECRET_KEY_BASE"),
+        )
+      end
+
+      def app_name
+        SuspendersTestHelpers::APP_NAME
+      end
+
+      def have_configured_var(remote_name, var)
+        have_received(:run).with(/config:add #{var}=.+ --remote #{remote_name}/)
+      end
+    end
+  end
+end

--- a/spec/features/heroku_spec.rb
+++ b/spec/features/heroku_spec.rb
@@ -1,57 +1,72 @@
 require "spec_helper"
 
 RSpec.describe "Heroku" do
-  before do
+  context "--heroku" do
+    before(:all) do
+      clean_up
+      run_suspenders("--heroku=true")
+    end
+
+    it "suspends a project for Heroku" do
+      app_name = SuspendersTestHelpers::APP_NAME.dasherize
+
+      expect(FakeHeroku).to(
+        have_gem_included(project_path, "rails_stdout_logging"),
+      )
+      expect(FakeHeroku).to have_created_app_for("staging")
+      expect(FakeHeroku).to have_created_app_for("production")
+      expect(FakeHeroku).to have_configured_vars("staging", "SECRET_KEY_BASE")
+      expect(FakeHeroku).to have_configured_vars(
+        "production",
+        "SECRET_KEY_BASE",
+      )
+
+      bin_setup_path = "#{project_path}/bin/setup"
+      bin_setup = IO.read(bin_setup_path)
+
+      expect(bin_setup).to include("heroku join --app #{app_name}-production")
+      expect(bin_setup).to include("heroku join --app #{app_name}-staging")
+      expect(File.stat(bin_setup_path)).to be_executable
+
+      bin_deploy_path = "#{project_path}/bin/deploy"
+      bin_deploy = IO.read(bin_deploy_path)
+
+      expect(bin_deploy).to include("heroku run rake db:migrate")
+      expect(File.stat(bin_deploy_path)).to be_executable
+
+      readme = IO.read("#{project_path}/README.md")
+
+      expect(readme).to include("./bin/deploy staging")
+      expect(readme).to include("./bin/deploy production")
+
+      circle_yml_path = "#{project_path}/circle.yml"
+      circle_yml = IO.read(circle_yml_path)
+
+      expect(circle_yml).to include <<-YML.strip_heredoc
+      deployment:
+        staging:
+          branch: master
+          commands:
+            - bin/deploy staging
+      YML
+    end
+  end
+
+  context "--heroku with region flag" do
+    before(:all) do
+      clean_up
+      run_suspenders(%{--heroku=true --heroku-flags="--region eu"})
+    end
+
+    it "suspends a project with extra Heroku flags" do
+      expect(FakeHeroku).to have_created_app_for("staging", "--region eu")
+      expect(FakeHeroku).to have_created_app_for("production", "--region eu")
+    end
+  end
+
+  def clean_up
     drop_dummy_database
     remove_project_directory
-  end
-
-  it "suspends a project for Heroku" do
-    run_suspenders("--heroku=true")
-
-    expect(FakeHeroku).to(
-      have_gem_included(project_path, "rails_stdout_logging")
-    )
-    expect(FakeHeroku).to have_created_app_for("staging")
-    expect(FakeHeroku).to have_created_app_for("production")
-    expect(FakeHeroku).to have_configured_vars("staging", "SECRET_KEY_BASE")
-    expect(FakeHeroku).to have_configured_vars("production", "SECRET_KEY_BASE")
-
-    bin_setup_path = "#{project_path}/bin/setup"
-    bin_setup = IO.read(bin_setup_path)
-    app_name = SuspendersTestHelpers::APP_NAME.dasherize
-
-    expect(bin_setup).to include("heroku join --app #{app_name}-production")
-    expect(bin_setup).to include("heroku join --app #{app_name}-staging")
-    expect(File.stat(bin_setup_path)).to be_executable
-
-    bin_deploy_path = "#{project_path}/bin/deploy"
-    bin_deploy = IO.read(bin_deploy_path)
-
-    expect(bin_deploy).to include("heroku run rake db:migrate")
-    expect(File.stat(bin_deploy_path)).to be_executable
-
-    readme = IO.read("#{project_path}/README.md")
-
-    expect(readme).to include("./bin/deploy staging")
-    expect(readme).to include("./bin/deploy production")
-
-    circle_yml_path = "#{project_path}/circle.yml"
-    circle_yml = IO.read(circle_yml_path)
-
-    expect(circle_yml).to include <<-YML.strip_heredoc
-    deployment:
-      staging:
-        branch: master
-        commands:
-          - bin/deploy staging
-    YML
-  end
-
-  it "suspends a project with extra Heroku flags" do
-    run_suspenders(%{--heroku=true --heroku-flags="--region eu"})
-
-    expect(FakeHeroku).to have_created_app_for("staging", "--region eu")
-    expect(FakeHeroku).to have_created_app_for("production", "--region eu")
+    FakeHeroku.clear!
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,11 +10,11 @@ RSpec.configure do |config|
   config.include SuspendersTestHelpers
 
   config.before(:all) do
+    add_fakes_to_path
     create_tmp_directory
   end
 
   config.before(:each) do
-    FakeHeroku.clear!
     FakeGithub.clear!
   end
 end

--- a/spec/support/fake_heroku.rb
+++ b/spec/support/fake_heroku.rb
@@ -36,8 +36,10 @@ class FakeHeroku
   end
 
   def self.has_configured_vars?(remote_name, var)
-    File.foreach(RECORDER).any? do |line|
-      line =~ /^config:add #{var}=.+ --remote #{remote_name}\n$/
-    end
+    commands_ran =~ /^config:add #{var}=.+ --remote #{remote_name}\n/
+  end
+
+  def self.commands_ran
+    @commands_ran ||= File.read(RECORDER)
   end
 end

--- a/spec/support/suspenders.rb
+++ b/spec/support/suspenders.rb
@@ -12,9 +12,10 @@ module SuspendersTestHelpers
   def run_suspenders(arguments = nil)
     Dir.chdir(tmp_path) do
       Bundler.with_clean_env do
-        ENV['TESTING'] = '1'
-
-        %x(#{suspenders_bin} #{APP_NAME} #{arguments})
+        add_fakes_to_path
+        `
+          #{suspenders_bin} #{APP_NAME} #{arguments}
+        `
       end
     end
   end
@@ -29,6 +30,10 @@ module SuspendersTestHelpers
     end
   end
 
+  def add_fakes_to_path
+    ENV["PATH"] = "#{support_bin}:#{ENV['PATH']}"
+  end
+
   def project_path
     @project_path ||= Pathname.new("#{tmp_path}/#{APP_NAME}")
   end
@@ -41,6 +46,10 @@ module SuspendersTestHelpers
 
   def suspenders_bin
     File.join(root_path, 'bin', 'suspenders')
+  end
+
+  def support_bin
+    File.join(root_path, "spec", "fakes", "bin")
   end
 
   def root_path


### PR DESCRIPTION
Improve testability for Heroku actions

Why:

* It was very coupled and difficult to test in isolation, there was pretty much one single integration test.

This change addresses the need by:

* Making it easier to test and reason about Heroku functionality we want to use, by allows for smaller, faster and more focused tests.
* Using mocks instead of depending on side effects because it was tricky to build a fake of the an AppBuilder, that has a lot of functionality and it is already being tested in our integration tests.
* Using a mockist approach, that ensures the correct methods are called with the right arguments (this last part is wip)

Interested in opinions before I go much further with this. /cc @tute 