### PR TITLE
No need to configure action_mailer_host in staging

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -278,7 +278,6 @@ Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i
     def configure_action_mailer
       action_mailer_host "development", %{"localhost:3000"}
       action_mailer_host "test", %{"www.example.com"}
-      action_mailer_host "staging", %{ENV.fetch("APPLICATION_HOST")}
       action_mailer_host "production", %{ENV.fetch("APPLICATION_HOST")}
     end
 


### PR DESCRIPTION
It inherits production's, which reads the same environmental variable.