### PR TITLE
Config Circle to use rake binstub instead

### DIFF
--- a/templates/circle.yml.erb
+++ b/templates/circle.yml.erb
@@ -6,4 +6,4 @@ database:
     - bin/setup
 test:
   override:
-    - bundle exec rake
+    - bin/rake


### PR DESCRIPTION
There is no need to use `bundle exec` given we have binstub in `bin/`.