### PR TITLE
Changed order in customize_gemfile in app_generator

### DIFF
--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -58,7 +58,6 @@ module Suspenders
 
     def customize_gemfile
       build :replace_gemfile
-      build :configure_simple_form
       build :set_ruby_to_version_being_used
 
       if options[:heroku]
@@ -66,6 +65,7 @@ module Suspenders
       end
 
       bundle_command 'install'
+      build :configure_simple_form
     end
 
     def setup_database


### PR DESCRIPTION
I changed the order of build inside customize_gemfile in app_generator.rb

Why:
I noticed that with a fresh gemset, apart from the dependencies that come with Suspenders, it was crashing during app generation while trying to configure simple_form, due to a missing "bundle install", which was meant to happen after that. I actually feel pretty dumb to open a pull request like this on such a great repo