### PR TITLE
Fix bundler-audit to exit on update failure

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -34,7 +34,7 @@ end
 group :development, :test do
   gem "awesome_print"
   gem "bullet"
-  gem "bundler-audit", require: false
+  gem "bundler-audit", ">= 0.5.0", require: false
   gem "dotenv-rails"
   gem "factory_girl_rails"
   gem "pry-byebug"


### PR DESCRIPTION
Prevent bundle audit check from passing when the vulnerability db is
out-of-date due to a failed update. This fix is intended to be temporary
until a fix is released for:

https://github.com/rubysec/bundler-audit/issues/114