### PR TITLE
Fix Circle deploys by removing redundant remote

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -429,7 +429,6 @@ you can deploy to staging and production with:
         staging:
           branch: master
           commands:
-            - git remote add staging git@heroku.com:#{staging_remote_name}.git
             - bin/deploy staging
       YML
 

--- a/spec/features/heroku_spec.rb
+++ b/spec/features/heroku_spec.rb
@@ -44,7 +44,6 @@ RSpec.describe "Heroku" do
       staging:
         branch: master
         commands:
-          - git remote add staging git@heroku.com:#{app_name}-staging.git
           - bin/deploy staging
     YML
   end


### PR DESCRIPTION
Bug found here, on a fresh suspenders app: https://circleci.com/gh/thoughtbot/automatic-holiday-dataviz/1

## Problem:

The circle configuration tries to deploy the build to the heroku staging
environment if it finishes successfully.

Because both the .circle.yml and bin/setup scripts
define the staging remote for git,
the build fails with a warning about the duplicate remote.

## Solution:

Only set the staging remote once, in the setup script.
Remove the redundant source definition from `circle.yml`