### PR TITLE
Fix spring binstub test

### DIFF
--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe "Suspend a new project with default configuration" do
   it "adds spring to binstubs" do
     expect(File).to exist("#{project_path}/bin/spring")
 
-    spring_line = /^ +load File.expand_path\("\.\.\/spring", __FILE__\)$/
+    spring_line = /^ +load File.expand_path\('\.\.\/spring', __FILE__\)$/
     bin_stubs = %w(rake rails rspec)
     bin_stubs.each do |bin_stub|
       expect(IO.read("#{project_path}/bin/#{bin_stub}")).to match(spring_line)


### PR DESCRIPTION
## Problem:

It appears that Spring has switched from using double-quotes in their
binstub to using single-quotes. The change has broken one of our tests,
where we are asserting that the binstub contains a line matching a
regular expression.

## Solution:

Update the regular expression to use single-quotes, to match those
created by the binstub generator.