### PR TITLE
Raise on missing Sprockets assets in test

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -14,6 +14,14 @@ module Suspenders
       template 'README.md.erb', 'README.md'
     end
 
+    def raise_on_missing_assets_in_test
+      inject_into_file(
+        "config/environments/test.rb",
+        "\n  config.assets.raise_runtime_errors = true",
+        after: "Rails.application.configure do",
+      )
+    end
+
     def raise_on_delivery_errors
       replace_in_file 'config/environments/development.rb',
         'raise_delivery_errors = false', 'raise_delivery_errors = true'

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -80,6 +80,7 @@ module Suspenders
 
     def setup_development_environment
       say 'Setting up the development environment'
+      build :raise_on_missing_assets_in_test
       build :raise_on_delivery_errors
       build :set_test_delivery_method
       build :add_bullet_gem_configuration

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -149,6 +149,14 @@ RSpec.describe "Suspend a new project with default configuration" do
     expect(test_config).to match /^ +Bullet.rails_logger = true$/
   end
 
+  it "configs missing assets to raise in test" do
+    test_config = IO.read("#{project_path}/config/environments/test.rb")
+
+    expect(test_config).to match(
+      /^ +config.assets.raise_runtime_errors = true$/,
+    )
+  end
+
   it "adds spring to binstubs" do
     expect(File).to exist("#{project_path}/bin/spring")
 


### PR DESCRIPTION
When testing features, we'd prefer to be notified of asset pipeline
issues as early as possible.