### PR TITLE
Use Heroku Local (Forego) instead of Foreman

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -321,7 +321,7 @@ Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i
       copy_file "puma.rb", "config/puma.rb"
     end
 
-    def setup_foreman
+    def set_up_forego
       copy_file 'sample.env', '.sample.env'
       copy_file 'Procfile', 'Procfile'
     end

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -146,7 +146,7 @@ module Suspenders
       build :fix_i18n_deprecation_warning
       build :setup_default_rake_task
       build :configure_puma
-      build :setup_foreman
+      build :set_up_forego
     end
 
     def setup_stylesheets

--- a/templates/README.md.erb
+++ b/templates/README.md.erb
@@ -12,15 +12,11 @@ your machine with [this script].
 
 [this script]: https://github.com/thoughtbot/laptop
 
-After setting up, you can run the application using [foreman]:
+After setting up, you can run the application using [Heroku Local]:
 
-    % foreman start
+    % heroku local
 
-If you don't have `foreman`, see [Foreman's install instructions][foreman]. It
-is [purposefully excluded from the project's `Gemfile`][exclude].
-
-[foreman]: https://github.com/ddollar/foreman
-[exclude]: https://github.com/ddollar/foreman/pull/437#issuecomment-41110407
+[Heroku Local]: https://devcenter.heroku.com/articles/heroku-local
 
 ## Guidelines
 

--- a/templates/bin_setup.erb
+++ b/templates/bin_setup.erb
@@ -21,15 +21,6 @@ bin/rake dev:prime
 # Add binstubs to PATH via export PATH=".git/safe/../../bin:$PATH" in ~/.zshenv
 mkdir -p .git/safe
 
-# Pick a port for Foreman
-if ! grep --quiet --no-messages --fixed-strings 'port' .foreman; then
-  printf 'port: 3000\n' >> .foreman
-fi
-
-if ! command -v foreman > /dev/null; then
-  gem install foreman
-fi
-
 # Only if this isn't CI
 # if [ -z "$CI" ]; then
 # fi

--- a/templates/sample.env
+++ b/templates/sample.env
@@ -1,4 +1,4 @@
-# http://ddollar.github.com/foreman/
+# https://github.com/ddollar/forego
 ASSET_HOST=localhost:3000
 APPLICATION_HOST=localhost:3000
 RACK_ENV=development

--- a/templates/suspenders_gitignore
+++ b/templates/suspenders_gitignore
@@ -4,7 +4,6 @@
 *.swp
 /.bundle
 /.env
-/.foreman
 /coverage/*
 /db/*.sqlite3
 /log/*


### PR DESCRIPTION
Heroku Local has replaced Foreman in the Heroku Toolbelt.

https://devcenter.heroku.com/changelog-items/692

The command `heroku local` has replaced `foreman`.
Heroku Local makes use of [Forego] to accomplish its tasks
and it is faster and has better cross-platform support.

[Forego]: https://github.com/ddollar/forego