### PR TITLE
Add foreman installer to bin/setup

### DIFF
--- a/templates/bin_setup.erb
+++ b/templates/bin_setup.erb
@@ -8,6 +8,7 @@ set -e
 
 # Set up Ruby dependencies via Bundler
 gem install bundler --conservative
+gem install foreman
 bundle check || bundle install
 
 # Set up configurable environment variables


### PR DESCRIPTION
Since it's explicitly excluded, it would be nice to include this in the bin/setup pattern.