### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Suspenders [![Build Status](https://secure.travis-ci.org/thoughtbot/suspenders.svg?branch=master)](http://travis-ci.org/thoughtbot/suspenders)
 
 Suspenders is the base Rails application used at
-[thoughtbot](http://thoughtbot.com).
+[thoughtbot](https://thoughtbot.com/).
 
   ![Suspenders boy](http://media.tumblr.com/1TEAMALpseh5xzf0Jt6bcwSMo1_400.png)
 
@@ -41,7 +41,7 @@ It includes application gems like:
 * [Postgres](https://github.com/ged/ruby-pg) for access to the Postgres database
 * [Rack Canonical Host](https://github.com/tylerhunt/rack-canonical-host) to
   ensure all requests are served from the same domain
-* [Rack Timeout](https://github.com/kch/rack-timeout) to abort requests that are
+* [Rack Timeout](https://github.com/heroku/rack-timeout) to abort requests that are
   taking too long
 * [Recipient Interceptor](https://github.com/croaky/recipient_interceptor) to
   avoid accidentally sending emails to real people from staging
@@ -81,7 +81,7 @@ And testing gems like:
 * [RSpec Mocks](https://github.com/rspec/rspec-mocks) for stubbing and spying
 * [Shoulda Matchers](https://github.com/thoughtbot/shoulda-matchers) for common
   RSpec matchers
-* [Timecop](https://github.com/jtrupiano/timecop-console) for testing time
+* [Timecop](https://github.com/ferndopolis/timecop-console) for testing time
 
 ## Other goodies
 
@@ -102,8 +102,8 @@ Suspenders also comes with:
 * The analytics adapter [Segment][segment] (and therefore config for Google
   Analytics, Intercom, Facebook Ads, Twitter Ads, etc.)
 
-[setup]: http://robots.thoughtbot.com/bin-setup
-[compress]: http://robots.thoughtbot.com/content-compression-with-rack-deflater/
+[setup]: https://robots.thoughtbot.com/bin-setup
+[compress]: https://robots.thoughtbot.com/content-compression-with-rack-deflater
 [pool]: https://devcenter.heroku.com/articles/concurrency-and-database-connections
 [binstub]: https://github.com/thoughtbot/suspenders/pull/282
 [i18n]: https://github.com/thoughtbot/suspenders/pull/304


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/kch/rack-timeout | https://github.com/heroku/rack-timeout 
https://github.com/jtrupiano/timecop-console | https://github.com/ferndopolis/timecop-console 

### HTTPS Corrected URLs 
Was | Now 
--- | --- 
http://thoughtbot.com | https://thoughtbot.com/ 
http://robots.thoughtbot.com/bin-setup | https://robots.thoughtbot.com/bin-setup 
http://robots.thoughtbot.com/content-compression-with-rack-deflater/ | https://robots.thoughtbot.com/content-compression-with-rack-deflater 
