### PR TITLE
Set default Heroku app to staging, when using Heroku

### DIFF
--- a/lib/suspenders/adapters/heroku.rb
+++ b/lib/suspenders/adapters/heroku.rb
@@ -11,6 +11,7 @@ module Suspenders
           # Set up the staging and production apps.
           #{command_to_join_heroku_app('staging')}
           #{command_to_join_heroku_app('production')}
+          git config heroku.remote staging
         SHELL
 
         app_builder.append_file "bin/setup", remotes

--- a/spec/features/heroku_spec.rb
+++ b/spec/features/heroku_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe "Heroku" do
 
       expect(bin_setup).to include("heroku join --app #{app_name}-production")
       expect(bin_setup).to include("heroku join --app #{app_name}-staging")
+      expect(bin_setup).to include("git config heroku.remote staging")
       expect(File.stat(bin_setup_path)).to be_executable
 
       bin_deploy_path = "#{project_path}/bin/deploy"


### PR DESCRIPTION
Per [Heroku Docs](https://devcenter.heroku.com/articles/multiple-environments) using the `--remote` flag is much preferred over the `--app` flag. This default sets all Heroku commands to use the staging app by default, and you're already able to use the `heroku --remote production` shortcut