### PR TITLE
Fix spring binstub test

### DIFF
--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -160,10 +160,18 @@ RSpec.describe "Suspend a new project with default configuration" do
   it "adds spring to binstubs" do
     expect(File).to exist("#{project_path}/bin/spring")
 
-    spring_line = /^ +load File.expand_path\('\.\.\/spring', __FILE__\)$/
-    bin_stubs = %w(rake rails rspec)
-    bin_stubs.each do |bin_stub|
-      expect(IO.read("#{project_path}/bin/#{bin_stub}")).to match(spring_line)
+    bin_stub_files = [
+      IO.read("#{project_path}/bin/rails"),
+      IO.read("#{project_path}/bin/rake"),
+      IO.read("#{project_path}/bin/rspec")
+    ]
+
+    spring_line1 = /^ +spring_bin_path = File.expand_path\('\.\.\/spring', __FILE__\)$/
+    spring_line2 = /^ +load spring_bin_path$/
+
+    bin_stub_files.each do |file|
+      expect(file).to match(spring_line1)
+      expect(file).to match(spring_line2)
     end
   end
 

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -160,18 +160,9 @@ RSpec.describe "Suspend a new project with default configuration" do
   it "adds spring to binstubs" do
     expect(File).to exist("#{project_path}/bin/spring")
 
-    bin_stub_files = [
-      IO.read("#{project_path}/bin/rails"),
-      IO.read("#{project_path}/bin/rake"),
-      IO.read("#{project_path}/bin/rspec"),
-    ]
-
-    spring_line1 = /^ +spring_bin_path = File.expand_path\('\.\.\/spring', __FILE__\)$/
-    spring_line2 = /^ +load spring_bin_path$/
-
-    bin_stub_files.each do |file|
-      expect(file).to match(spring_line1)
-      expect(file).to match(spring_line2)
+    bin_stubs = %w(rake rails rspec)
+    bin_stubs.each do |bin_stub|
+      expect(IO.read("#{project_path}/bin/#{bin_stub}")).to match(/spring/)
     end
   end
 

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe "Suspend a new project with default configuration" do
     bin_stub_files = [
       IO.read("#{project_path}/bin/rails"),
       IO.read("#{project_path}/bin/rake"),
-      IO.read("#{project_path}/bin/rspec")
+      IO.read("#{project_path}/bin/rspec"),
     ]
 
     spring_line1 = /^ +spring_bin_path = File.expand_path\('\.\.\/spring', __FILE__\)$/


### PR DESCRIPTION
It appears that spring has yet again changed their binstub loading technique.

References [a previous commit] (https://github.com/thoughtbot/suspenders/commit/cbb95b648173ff42fe0480f4bc273e9bd4ae7599) and  [the spring change](https://github.com/rails/spring/commit/b583da754ed5abad3f7da8b9b46de673bc10eada)

I am not positive about this multi-line pattern. I attempted a freespace regex mode, but the regex was just more confusing due to the amount of spaces in the lines.

I would probably recommend not matching so exactly if they continue to change this.