### PR TITLE
Make Forego port match APPLICATION_HOST port

### DIFF
--- a/templates/sample.env
+++ b/templates/sample.env
@@ -1,6 +1,7 @@
 # https://github.com/ddollar/forego
 ASSET_HOST=localhost:3000
 APPLICATION_HOST=localhost:3000
+PORT=3000
 RACK_ENV=development
 SECRET_KEY_BASE=development_secret
 EXECJS_RUNTIME=Node


### PR DESCRIPTION
Suspenders previously included a `.foreman` file which specified that Foreman should use port 3000, and not the default of 5000 (rationale in a42ec7e). The switch from Foreman to Forego in 6b7614a removed this file since Forego doesn't support it, causing a reversion to port 5000 and a mismatch with the `APPLICATION_HOST` and `ASSET_HOST` variables in the sample `.env` file.

Forego does support specifying a port via the PORT environment variable, so this change adds that variable to the sample `.env` file.

(closes #665)