### PR TITLE
Add lang attribute to html element in layout

### DIFF
--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -129,6 +129,12 @@ RSpec.describe "Suspend a new project with default configuration" do
     expect(prod_env_file).not_to match(/"HOST"/)
   end
 
+  it "configures language in html element" do
+    layout_path = "/app/views/layouts/application.html.erb"
+    layout_file = IO.read("#{project_path}#{layout_path}")
+    expect(layout_file).to match(/<html lang="en">/)
+  end
+
   it "configs active job queue adapter" do
     application_config = IO.read("#{project_path}/config/application.rb")
     test_config = IO.read("#{project_path}/config/environments/test.rb")

--- a/templates/suspenders_layout.html.erb.erb
+++ b/templates/suspenders_layout.html.erb.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="<%= I18n.locale %>">
 <head>
   <meta charset="utf-8" />
   <meta name="ROBOTS" content="NOODP" />


### PR DESCRIPTION
Identifying the language of the document is important for a number of
reasons:

* It allows braille translation software to substitute control codes
for accented characters, and insert control codes necessary to prevent
erroneous creation of Grade 2 braille contractions.
* Speech synthesizers that support multiple languages will be able to
orient and adapt to the pronunciation and syntax that are specific to
the language of the page, speaking the text in the appropriate accent
with proper pronunciation.
* Marking the language can benefit future developments in technology,
for example users who are unable to translate between languages
themselves will be able to use machines to translate unfamiliar
languages.
* Marking the language can also assist user agents in providing
definitions using a dictionary.

See http://www.w3.org/TR/WCAG20-TECHS/H57.html