### PR TITLE
Generate `rack_mini_profiler`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 master (unreleased)
 
 * Switch from Airbrake to Honeybadger
+* Generate applications with `rack_mini_profiler` (disabled by default, enabled
+  by setting `RACK_MINI_PROFILER=1`)
 
 1.35.0 (December 30, 2015)
 

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -28,6 +28,13 @@ module Suspenders
       template "Gemfile.erb", "Gemfile"
     end
 
+    def setup_rack_mini_profiler
+      copy_file(
+        "rack_mini_profiler.rb",
+        "config/initializers/rack_mini_profiler.rb",
+      )
+    end
+
     def raise_on_missing_assets_in_test
       inject_into_file(
         "config/environments/test.rb",

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -145,6 +145,7 @@ module Suspenders
       build :setup_default_rake_task
       build :configure_puma
       build :set_up_forego
+      build :setup_rack_mini_profiler
     end
 
     def setup_stylesheets

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -82,6 +82,23 @@ RSpec.describe "Suspend a new project with default configuration" do
     expect(hound_config_file).to include "enabled: true"
   end
 
+  it "ensures Gemfile contains `rack-mini-profiler`" do
+    gemfile = IO.read("#{project_path}/Gemfile")
+
+    expect(gemfile).to include %{gem "rack-mini-profiler", require: false}
+  end
+
+  it "ensures .sample.env defaults to RACK_MINI_PROFILER=0" do
+    env = IO.read("#{project_path}/.env")
+
+    expect(env).to include "RACK_MINI_PROFILER=0"
+  end
+
+  it "creates a rack-mini-profiler initializer" do
+    expect(File).
+      to exist("#{project_path}/config/initializers/rack_mini_profiler.rb")
+  end
+
   it "ensures newrelic.yml reads NewRelic license from env" do
     newrelic_file = IO.read("#{project_path}/config/newrelic.yml")
 

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -42,6 +42,10 @@ group :development, :test do
   gem "rspec-rails", "~> 3.4.0"
 end
 
+group :development, :staging do
+  gem "rack-mini-profiler", require: false
+end
+
 group :test do
   gem "capybara-webkit"
   gem "database_cleaner"

--- a/templates/dotfiles/.env
+++ b/templates/dotfiles/.env
@@ -3,6 +3,7 @@ ASSET_HOST=localhost:3000
 APPLICATION_HOST=localhost:3000
 PORT=3000
 RACK_ENV=development
+RACK_MINI_PROFILER=0
 SECRET_KEY_BASE=development_secret
 EXECJS_RUNTIME=Node
 SMTP_ADDRESS=smtp.example.com

--- a/templates/rack_mini_profiler.rb
+++ b/templates/rack_mini_profiler.rb
@@ -1,0 +1,5 @@
+if ENV["RACK_MINI_PROFILER"].to_i > 0
+  require "rack-mini-profiler"
+
+  Rack::MiniProfilerRails.initialize!(Rails.application)
+end


### PR DESCRIPTION
Uses [rack-mini-profiler][gem] gem to help debug slow queries /
requests.

Enable it by setting `ENV["RACK_MINI_PROFILER"] = 1`.

[gem]: https://github.com/MiniProfiler/rack-mini-profiler#rails