### PR TITLE
Improve Errors for Invalid I18n Keys in Specs

### DIFF
--- a/templates/i18n.rb
+++ b/templates/i18n.rb
@@ -1,3 +1,3 @@
 RSpec.configure do |config|
-  config.include AbstractController::Translation
+  config.include ActionView::Helpers::TranslationHelper
 end


### PR DESCRIPTION
Suspenders [currently mixes-in][1] `AbstractController::Translation` in
specs [so that the `t()` helper method is available][2]. However, this
helper method produces unintuitive failure/error messages in certain
cases when used in specs:

1. Passing a missing translation key to `t()` in specs produces an RSpec
failure indicating that the text "translation missing" was not found,
instead of an exception indicating the key itself is missing from the
translations.

  ```
  Failure/Error: expect(page).to have_content t("invalid_key")
        expected to find text "translation missing: en.invalid_key" in
       "All text on the page."
  ```

  Additionally, when using this kind of expectation against `page` in a
feature spec, RSpec outputs the entire text of the page, which may fill
the terminal window and cause the actual failure message to scroll out
of view.

2. Attempting to use a relative translation key (i.e., `t(".foo")`)
within in a spec results in an unintuitive `NameError`:

  ```
  Failure/Error: expect(page).to have_content t(".invalid_key")
  NameError:
        undefined local variable or method `controller_path' for
        #<RSpec::ExampleGroups::IndexPage:0x00>
  ```

To improve these error messages, this commit mixes-in
[`ActionView::Helpers::TranslationHelper`][3] in specs instead of
[`AbstractController::Translation`][4].

These modules both define `t()` and `l()` helpers, and ultimately
delegate to `I18n.t()` and `I18n.l()`, respectively; however,
`ActionView::Helpers::TranslationHelper` produces more intuitive error
messages in the above cases.

Specifically:

1. `t()` now respects `ActionView::Base.raise_on_missing_translations`
(set to `true` in the test environment), so missing translation keys in
specs will raise an exception and the failure message will not output
the extraneous page content:

  ```
  Failure/Error: expect(page).to have_content t("invalid_key")
  I18n::MissingTranslationData:
        translation missing: en.invalid_key
  ```

2. Erroneously using a relative key now raises a clearer exception:

  ```
  Failure/Error: expect(page).to have_content t(".invalid_key")
  RuntimeError:
        Cannot use t(".invalid_key") shortcut because path is not
        available
  ```

[1]: 304
[2]: https://robots.thoughtbot.com/foolproof-i18n-setup-in-rails#time-39-s-a-wasting
[3]: https://github.com/rails/rails/blob/master/actionview/lib/action_view/helpers/translation_helper.rb
[4]: https://github.com/rails/rails/blob/master/actionpack/lib/abstract_controller/translation.rb