### PR TITLE
View each failure in specs with multiple expects

### DIFF
--- a/templates/spec_helper.rb
+++ b/templates/spec_helper.rb
@@ -16,6 +16,10 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  config.define_derived_metadata do |meta|
+    meta[:aggregate_failures] = true
+  end
+
   config.example_status_persistence_file_path = "tmp/rspec_examples.txt"
   config.order = :random
 end


### PR DESCRIPTION
When we write tests with multiple expects, only the first failure is
reported when the test fails. `aggregate_failures` allows us to see
any or all the failures that happened in a specific test.

https://www.relishapp.com/rspec/rspec-core/docs/expectation-framework-integration/aggregating-failures