### PR TITLE
Remove database host config for Linux support

### DIFF
--- a/templates/postgresql_database.yml.erb
+++ b/templates/postgresql_database.yml.erb
@@ -2,7 +2,6 @@ development: &default
   adapter: postgresql
   database: <%= app_name %>_development
   encoding: utf8
-  host: localhost
   min_messages: warning
   pool: <%%= Integer(ENV.fetch("DB_POOL", 5)) %>
   reaping_frequency: <%%= Integer(ENV.fetch("DB_REAPING_FREQUENCY", 10)) %>


### PR DESCRIPTION
Extracted from https://github.com/thoughtbot/administrate/pull/359.
Issue first reported in https://github.com/thoughtbot/administrate/issues/296.

## Problem:

Ubuntu (and possibly other Linux distributions)
don't recognize `localhost` as a valid host parameter
in `config/database.yml`.

Running `bin/setup` gives them the error:

```
Couldn't create database for {"adapter"=>"postgresql",
"database"=>"administrate-prototype_development",
"encoding"=>"utf8",
"host"=>"localhost",
"min_messages"=>"warning",
"pool"=>2,
"timeout"=>5000}
```

## Solution:

Remove the `host` key from `config/database.yml`.

Without the `host` key, OS X defaults to `localhost`
and Ubuntu defaults to its Linux-y equivalent.