### PR TITLE
Fix SMTP TimeoutError warning

### DIFF
--- a/templates/errors.rb
+++ b/templates/errors.rb
@@ -23,7 +23,7 @@ SMTP_SERVER_ERRORS = [
   Net::SMTPAuthenticationError,
   Net::SMTPServerBusy,
   Net::SMTPUnknownError,
-  TimeoutError
+  Timeout::Error
 ]
 
 SMTP_CLIENT_ERRORS = [

--- a/templates/errors.rb
+++ b/templates/errors.rb
@@ -15,7 +15,7 @@ HTTP_ERRORS = [
   Net::HTTPBadResponse,
   Net::HTTPHeaderSyntaxError,
   Net::ProtocolError,
-  Timeout::Error
+  Timeout::Error,
 ]
 
 SMTP_SERVER_ERRORS = [
@@ -23,12 +23,12 @@ SMTP_SERVER_ERRORS = [
   Net::SMTPAuthenticationError,
   Net::SMTPServerBusy,
   Net::SMTPUnknownError,
-  Timeout::Error
+  Timeout::Error,
 ]
 
 SMTP_CLIENT_ERRORS = [
   Net::SMTPFatalError,
-  Net::SMTPSyntaxError
+  Net::SMTPSyntaxError,
 ]
 
 SMTP_ERRORS = SMTP_SERVER_ERRORS + SMTP_CLIENT_ERRORS


### PR DESCRIPTION
Fixing issue mentioned in #686 
TimeoutError has been deprecated and in favor of using Timeout::Error in ruby 2.3.0