### PR TITLE
Call create only once for the heroku pipeline

### DIFF
--- a/lib/suspenders/adapters/heroku.rb
+++ b/lib/suspenders/adapters/heroku.rb
@@ -69,12 +69,14 @@ module Suspenders
 
         heroku_app_name = app_builder.app_name.dasherize
         run_toolbelt_command(
-          "pipelines:create #{heroku_app_name} -a #{heroku_app_name}-staging --stage staging",
+          "pipelines:create #{heroku_app_name} \
+            -a #{heroku_app_name}-staging --stage staging",
           "staging",
         )
 
         run_toolbelt_command(
-          "pipelines:add #{heroku_app_name} -a #{heroku_app_name}-production --stage production",
+          "pipelines:add #{heroku_app_name} \
+            -a #{heroku_app_name}-production --stage production",
           "production",
         )
       end

--- a/lib/suspenders/adapters/heroku.rb
+++ b/lib/suspenders/adapters/heroku.rb
@@ -68,12 +68,15 @@ module Suspenders
         end
 
         heroku_app_name = app_builder.app_name.dasherize
-        %w(staging production).each do |environment|
-          run_toolbelt_command(
-            "pipelines:create #{heroku_app_name} -a #{heroku_app_name}-#{environment} --stage #{environment}",
-            environment,
-          )
-        end
+        run_toolbelt_command(
+          "pipelines:create #{heroku_app_name} -a #{heroku_app_name}-staging --stage staging",
+          "staging",
+        )
+
+        run_toolbelt_command(
+          "pipelines:add #{heroku_app_name} -a #{heroku_app_name}-production --stage production",
+          "production",
+        )
       end
 
       def set_heroku_serve_static_files

--- a/spec/support/fake_heroku.rb
+++ b/spec/support/fake_heroku.rb
@@ -44,7 +44,7 @@ class FakeHeroku
 
   def self.has_setup_pipeline_for?(app_name)
     commands_ran =~ /^pipelines:create #{app_name} -a #{app_name}-staging --stage staging/ &&
-      commands_ran =~ /^pipelines:create #{app_name} -a #{app_name}-production --stage production/
+      commands_ran =~ /^pipelines:add #{app_name} -a #{app_name}-production --stage production/
   end
 
   def self.commands_ran


### PR DESCRIPTION
Why:

* The pipelines `create` command was being called twice, which creates
  two pipelines, one for each environment

This change addresses the need by:

* Creating the pipeline with one of the environments and then adding the
  other one

Fixes #689