### PR TITLE
Change SimpleCov output dir while run in CircleCI

### DIFF
--- a/templates/circle.yml.erb
+++ b/templates/circle.yml.erb
@@ -3,4 +3,4 @@ database:
     - bin/setup
 test:
   override:
-    - bin/rake
+    - COVERAGE=true bin/rake

--- a/templates/spec_helper.rb
+++ b/templates/spec_helper.rb
@@ -1,5 +1,11 @@
 if ENV.fetch("COVERAGE", false)
   require "simplecov"
+
+  if ENV["CIRCLE_ARTIFACTS"]
+    dir = File.join(ENV["CIRCLE_ARTIFACTS"], "coverage")
+    SimpleCov.coverage_dir(dir)
+  end
+
   SimpleCov.start "rails"
 end
 


### PR DESCRIPTION
Following [this guide](https://circleci.com/docs/code-coverage) I was able to integrate `simplecov` in `circleci`. Integration means I can see `simplecov`'s html report as artifact in `circleci`.

By the way I placed the new code inside `if ENV.fetch("COVERAGE", false)`. This means you should run your test with `COVERAGE=true rake`. Is it good for you?

In my suspeders' fork I run always `simple_cov`. So my `spec_helper` is:

```ruby
require "simplecov"

if ENV['CIRCLE_ARTIFACTS']
  dir = File.join(ENV['CIRCLE_ARTIFACTS'], "coverage")
  SimpleCov.coverage_dir(dir)
end

SimpleCov.start "rails"

[...]
```
