### PR TITLE
Download and use latest styleguides from thoughtbot

### DIFF
--- a/lib/suspenders/actions.rb
+++ b/lib/suspenders/actions.rb
@@ -2,9 +2,14 @@ require "net/http"
 
 module Suspenders
   module Actions
-    def download_file(relative_path, source)
-      file_contents = Net::HTTP.get(URI(source))
-      path = File.join(destination_root, relative_path)
+    def config_url(github_repository, relative_path)
+      github_uri_from_master_branch(github_repository, relative_path)
+    end
+
+    def download_file(uri, destination_path = "")
+      file_contents = Net::HTTP.get(uri)
+      filename = uri.path.split("/").last
+      path = File.join(destination_root, destination_path, filename)
 
       File.open(path, "w") { |file| file.write(file_contents) }
     end
@@ -37,6 +42,12 @@ module Suspenders
         "\n\n  #{config}",
         before: "\nend"
       )
+    end
+
+    private
+
+    def github_uri_from_master_branch(repo_name, path)
+      URI("https://raw.githubusercontent.com/#{repo_name}/master/#{path}")
     end
   end
 end

--- a/lib/suspenders/actions.rb
+++ b/lib/suspenders/actions.rb
@@ -1,5 +1,14 @@
+require "net/http"
+
 module Suspenders
   module Actions
+    def download_file(relative_path, source)
+      file_contents = Net::HTTP.get(URI(source))
+      path = File.join(destination_root, relative_path)
+
+      File.open(path, "w") { |file| file.write(file_contents) }
+    end
+
     def replace_in_file(relative_path, find, replace)
       path = File.join(destination_root, relative_path)
       contents = IO.read(path)

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -375,6 +375,21 @@ Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i
       directory("dotfiles", ".")
     end
 
+    def download_style_guides
+      download_file(
+        ".jscsrc",
+        "https://raw.githubusercontent.com/thoughtbot/guides/master/style/javascript/.jscsrc",
+      )
+      download_file(
+        ".rubocop.yml",
+        "https://raw.githubusercontent.com/thoughtbot/guides/master/style/ruby/.rubocop.yml",
+      )
+      download_file(
+        ".scss-lint.yml",
+        "https://raw.githubusercontent.com/thoughtbot/guides/master/style/sass/.scss-lint.yml",
+      )
+    end
+
     def init_git
       run 'git init'
     end

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -376,17 +376,10 @@ Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i
     end
 
     def download_style_guides
+      download_file(config_url("thoughtbot/guides", "style/javascript/.jscsrc"))
+      download_file(config_url("thoughtbot/guides", "style/ruby/.rubocop.yml"))
       download_file(
-        ".jscsrc",
-        "https://raw.githubusercontent.com/thoughtbot/guides/master/style/javascript/.jscsrc",
-      )
-      download_file(
-        ".rubocop.yml",
-        "https://raw.githubusercontent.com/thoughtbot/guides/master/style/ruby/.rubocop.yml",
-      )
-      download_file(
-        ".scss-lint.yml",
-        "https://raw.githubusercontent.com/thoughtbot/guides/master/style/sass/.scss-lint.yml",
+        config_url("thoughtbot/guides", "style/sass/.scss-lint.yml"),
       )
     end
 

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -53,6 +53,7 @@ module Suspenders
       invoke :setup_segment
       invoke :setup_bundler_audit
       invoke :setup_spring
+      invoke :download_style_guides
       invoke :outro
     end
 
@@ -224,6 +225,11 @@ module Suspenders
     def copy_miscellaneous_files
       say 'Copying miscellaneous support files'
       build :copy_miscellaneous_files
+    end
+
+    def download_style_guides
+      say "Downloading style guides from thoughtbot/guides"
+      build :download_style_guides
     end
 
     def customize_error_pages

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -69,6 +69,24 @@ RSpec.describe "Suspend a new project with default configuration" do
     expect(hound_config_file).to include "enabled: true"
   end
 
+  it "downloads the JSCS styleguide from thoughtbot's guides" do
+    jscsrc_file = IO.read("#{project_path}/.jscsrc")
+
+    expect(jscsrc_file).to include('"disallowSpaceBeforeSemicolon": true')
+  end
+
+  it "downloads the Ruby styleguide from thoughtbot's guides" do
+    rubocop_file = IO.read("#{project_path}/.rubocop.yml")
+
+    expect(rubocop_file).to include("AllCops:")
+  end
+
+  it "downloads the SCSS styleguide from thoughtbot's guides" do
+    scss_lint_file = IO.read("#{project_path}/.scss-lint.yml")
+
+    expect(scss_lint_file).to include("ImportantRule:")
+  end
+
   it "ensures newrelic.yml reads NewRelic license from env" do
     newrelic_file = IO.read("#{project_path}/config/newrelic.yml")
 

--- a/templates/hound.yml
+++ b/templates/hound.yml
@@ -1,17 +1,17 @@
 # See https://houndci.com/configuration for help.
 coffeescript:
-  # config_file: .coffeescript-style.json
+  config_file: .coffeescript-style.json
   enabled: true
 haml:
   # config_file: .haml-style.yml
   enabled: true
 javascript:
-  # config_file: .javascript-style.json
+  config_file: .javascript-style.json
   enabled: true
   # ignore_file: .javascript_ignore
 ruby:
-  # config_file: .ruby-style.yml
+  config_file: .ruby-style.yml
   enabled: true
 scss:
-  # config_file: .scss-style.yml
+  config_file: .scss-style.yml
   enabled: true

--- a/templates/hound.yml
+++ b/templates/hound.yml
@@ -1,17 +1,17 @@
 # See https://houndci.com/configuration for help.
 coffeescript:
-  config_file: .coffeescript-style.json
+  # config_file: .coffeescript-style.json
   enabled: true
 haml:
   # config_file: .haml-style.yml
   enabled: true
 javascript:
-  config_file: .javascript-style.json
+  config_file: .jscsrc
   enabled: true
   # ignore_file: .javascript_ignore
 ruby:
-  config_file: .ruby-style.yml
+  config_file: .rubocop.yml
   enabled: true
 scss:
-  config_file: .scss-style.yml
+  config_file: .sass-lint.yml
   enabled: true


### PR DESCRIPTION
When users build a new project, they should have styleguides encouraging
the latest best practices available for local linting as well as through
Hound.

This change downloads the latest Ruby, JavaScript, and Sass
styleguides that we have in our https://github.com/thoughtbot/guides
repo for immediate use. It uncomments the relevant Hound configuration
to enable their immediate use.

Thanks to @tysongach and @teoljungberg for the idea to incorporate these
stylesheets directly, suggested in #695 and thoughtbot/guides#379.
