### PR TITLE
Remove the fix_i18n_deprecation_warning method

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -318,14 +318,6 @@ Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i
       configure_environment "test", "config.active_job.queue_adapter = :inline"
     end
 
-    def fix_i18n_deprecation_warning
-      config = <<-RUBY
-    config.i18n.enforce_available_locales = true
-      RUBY
-
-      inject_into_class 'config/application.rb', 'Application', config
-    end
-
     def generate_rspec
       generate 'rspec:install'
     end

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -143,7 +143,6 @@ module Suspenders
       build :configure_active_job
       build :configure_time_formats
       build :disable_xml_params
-      build :fix_i18n_deprecation_warning
       build :setup_default_rake_task
       build :configure_puma
       build :set_up_forego


### PR DESCRIPTION
`fix_i18n_deprecation_warning` is no longer needed since this
configuration is the default in Rails now
