### PR TITLE
Disable CSS transitions in tests

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -231,6 +231,13 @@ end
       copy_file '_javascript.html.erb', 'app/views/application/_javascript.html.erb'
     end
 
+    def create_shared_css_overrides
+      copy_file(
+        "_css_overrides.html.erb",
+        "app/views/application/_css_overrides.html.erb",
+      )
+    end
+
     def create_application_layout
       template 'suspenders_layout.html.erb.erb',
         'app/views/layouts/application.html.erb',

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -133,6 +133,7 @@ module Suspenders
       build :create_partials_directory
       build :create_shared_flashes
       build :create_shared_javascripts
+      build :create_shared_css_overrides
       build :create_application_layout
     end
 

--- a/templates/_css_overrides.html.erb
+++ b/templates/_css_overrides.html.erb
@@ -1,0 +1,8 @@
+<% if Rails.env.test? %>
+  <style type="text/css">
+    * {
+      transition-property: none !important;
+      -webkit-transition-property: none !important;
+    }
+  </style>
+<% end %>

--- a/templates/suspenders_layout.html.erb.erb
+++ b/templates/suspenders_layout.html.erb.erb
@@ -17,5 +17,6 @@
   <%%= render "flashes" -%>
   <%%= yield %>
   <%%= render "javascript" %>
+  <%%= render "css_overrides" %>
 </body>
 </html>


### PR DESCRIPTION
CSS transitions often break tests. For example, a popup can take some
time to be fully shown if there is a transition time applied to its
show effect. The test will see that the popup is present and will try to
use it, but the element is ready yet.

This disables the CSS transitions in the test environment and removes
timing issues related to CSS.