### PR TITLE
Use Rails AppBuilder methods for Gemfile and .gitignore

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -20,6 +20,14 @@ module Suspenders
       template 'README.md.erb', 'README.md'
     end
 
+    def gitignore
+      copy_file "suspenders_gitignore", ".gitignore"
+    end
+
+    def gemfile
+      template "Gemfile.erb", "Gemfile"
+    end
+
     def raise_on_missing_assets_in_test
       inject_into_file(
         "config/environments/test.rb",
@@ -231,11 +239,6 @@ end
       bundle_command 'exec rake db:create db:migrate'
     end
 
-    def replace_gemfile
-      remove_file 'Gemfile'
-      template 'Gemfile.erb', 'Gemfile'
-    end
-
     def set_ruby_to_version_being_used
       create_file '.ruby-version', "#{Suspenders::RUBY_VERSION}\n"
     end
@@ -346,9 +349,7 @@ Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i
       run "bitters install --path app/assets/stylesheets"
     end
 
-    def gitignore_files
-      remove_file '.gitignore'
-      copy_file 'suspenders_gitignore', '.gitignore'
+    def setup_default_directories
       [
         'app/views/pages',
         'spec/lib',
@@ -358,8 +359,7 @@ Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i
         'spec/support/mixins',
         'spec/support/shared_examples'
       ].each do |dir|
-        run "mkdir #{dir}"
-        run "touch #{dir}/.keep"
+        empty_directory_with_keep_file dir
       end
     end
 

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -57,7 +57,6 @@ module Suspenders
     end
 
     def customize_gemfile
-      build :replace_gemfile
       build :set_ruby_to_version_being_used
 
       if options[:heroku]
@@ -165,8 +164,8 @@ module Suspenders
 
     def setup_git
       if !options[:skip_git]
-        say 'Initializing git'
-        invoke :setup_gitignore
+        say "Initializing git"
+        invoke :setup_default_directories
         invoke :init_git
       end
     end
@@ -202,8 +201,8 @@ module Suspenders
       build :copy_dotfiles
     end
 
-    def setup_gitignore
-      build :gitignore_files
+    def setup_default_directories
+      build :setup_default_directories
     end
 
     def setup_bundler_audit

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -7,6 +7,19 @@ RSpec.describe "Suspend a new project with default configuration" do
     run_suspenders
   end
 
+  it "uses custom Gemfile" do
+    gemfile_file = IO.read("#{project_path}/Gemfile")
+    expect(gemfile_file).to match(
+      /^ruby "#{Suspenders::RUBY_VERSION}"$/,
+    )
+    expect(gemfile_file).to match(
+      /^gem "autoprefixer-rails"$/,
+    )
+    expect(gemfile_file).to match(
+      /^gem "rails", "#{Suspenders::RAILS_VERSION}"$/,
+    )
+  end
+
   it "ensures project specs pass" do
     Dir.chdir(project_path) do
       Bundler.with_clean_env do


### PR DESCRIPTION
Override Rails AppBuilder methods gemfile and .gitignore and allow them to use suspenders templates.
This closes #703 