### PR TITLE
Remove `RAILS_ENV` declarations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+* Remove `RAILS_ENV` definitions
+
 1.36.0 (February 26, 2016)
 
 * Update Bitters to v1.2

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ This:
 
 * Creates a staging and production Heroku app
 * Sets them as `staging` and `production` Git remotes
-* Configures staging with `RACK_ENV` and `RAILS_ENV` environment variables set
+* Configures staging with `RACK_ENV` environment variable set
   to `staging`
 * Adds the [Rails Stdout Logging][logging-gem] gem
   to configure the app to log to standard out,

--- a/lib/suspenders/adapters/heroku.rb
+++ b/lib/suspenders/adapters/heroku.rb
@@ -25,7 +25,7 @@ module Suspenders
       end
 
       def create_staging_heroku_app(flags)
-        rack_env = "RACK_ENV=staging RAILS_ENV=staging"
+        rack_env = "RACK_ENV=staging"
         app_name = heroku_app_name_for("staging")
 
         run_toolbelt_command "create #{app_name} #{flags}", "staging"

--- a/templates/app.json.erb
+++ b/templates/app.json.erb
@@ -17,9 +17,6 @@
     "RACK_ENV":{
       "required":true
     },
-    "RAILS_ENV":{
-      "required":true
-    },
     "SECRET_KEY_BASE":{
       "generator":"secret"
     },

--- a/templates/rails_helper.rb
+++ b/templates/rails_helper.rb
@@ -1,4 +1,4 @@
-ENV["RAILS_ENV"] = "test"
+ENV["RACK_ENV"] = "test"
 
 require File.expand_path("../../config/environment", __FILE__)
 abort("DATABASE_URL environment variable is set") if ENV["DATABASE_URL"]


### PR DESCRIPTION
**DISCLAIMER:** I’m not sure if this is a good idea, just questioning the status quo

The proper way to access Rails' environment is through `Rails.env`,
which checks `RAILS_ENV`, falling back to `RACK_ENV`.