### PR TITLE
Removes AIRBRAKE_API_KEY as required env var

### DIFF
--- a/templates/app.json.erb
+++ b/templates/app.json.erb
@@ -2,9 +2,6 @@
   "name":"<%= app_name.dasherize %>",
   "scripts":{},
   "env":{
-    "AIRBRAKE_API_KEY":{
-      "required":true
-    },
     "EMAIL_RECIPIENTS":{
       "required":true
     },


### PR DESCRIPTION
https://github.com/thoughtbot/suspenders/commit/ca11a8638090d9f7b6af1ac55586d24d05c77df6
removed the dependency on `airbrake` in favor of `honeybadger`.

The `AIRBRAKE_API_KEY` was left in `app.json` but is no longer required.
This change removes it.