### PR TITLE
Add Heroku Review Apps variables to app.json file

### DIFF
--- a/templates/app.json.erb
+++ b/templates/app.json.erb
@@ -5,6 +5,12 @@
     "EMAIL_RECIPIENTS":{
       "required":true
     },
+    "HEROKU_APP_NAME": {
+      "required": true
+    },
+    "HEROKU_PARENT_APP_NAME": {
+      "required": true
+    },
     "RACK_ENV":{
       "required":true
     },


### PR DESCRIPTION
Why:

* Explained in #719

This change addresses the need by:

* Adding the required variables to the `app.json` template

Fixes #719.

@tute Is this enough?