### PR TITLE
Update browser support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 * Remove `RAILS_ENV` definitions
 * Update Bourbon to v5.0.0.beta.3
 * Update Bitters to v1.3
+* Update Autoprefixer config, drop support for IE 9, IE 10 and iOS 7
 
 1.36.0 (February 26, 2016)
 

--- a/templates/browserslist
+++ b/templates/browserslist
@@ -1,4 +1,3 @@
 Last 2 versions
-Explorer >= 9
-iOS >= 7.1
+Explorer >= 11
 Android >= 4.4


### PR DESCRIPTION
- According to http://caniuse.com/usage-table, global usage of IE 9 and 10 are
both around 0.6%.