### PR TITLE
Set development delivery_method to :file

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -51,7 +51,7 @@ module Suspenders
     def set_test_delivery_method
       inject_into_file(
         "config/environments/development.rb",
-        "\n  config.action_mailer.delivery_method = :test",
+        "\n  config.action_mailer.delivery_method = :file",
         after: "config.action_mailer.raise_delivery_errors = true",
       )
     end

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe "Suspend a new project with default configuration" do
   it "configs :test email delivery method for development" do
     dev_env_file = IO.read("#{project_path}/config/environments/development.rb")
     expect(dev_env_file).
-      to match(/^ +config.action_mailer.delivery_method = :test$/)
+      to match(/^ +config.action_mailer.delivery_method = :file$/)
   end
 
   it "uses APPLICATION_HOST, not HOST in the production config" do


### PR DESCRIPTION
`:test` sends the emails to the logs, and to see them one has to scroll
back through them. If we configure delivery_method to be `:file`,
mails will also be created in the `./tmp/mails/` directory

One file will be created for each email address sent to that contains
all email content delivered to that address. This allows to easily
review any and all emails sent, without searching through logs.

See:
* https://github.com/thoughtbot/suspenders/pull/521 (https://github.com/thoughtbot/suspenders/commit/8b45fd42)
* http://blog.mojotech.com/a-decade-of-rails/