### PR TITLE
Adds missing gems for development

### DIFF
--- a/suspenders.gemspec
+++ b/suspenders.gemspec
@@ -36,4 +36,6 @@ rush to build something amazing; don't use it if you like missing deadlines.
   s.add_development_dependency 'title', '~> 0.0'
   s.add_development_dependency 'quiet_assets', '~> 1.1'
   s.add_development_dependency 'capybara-webkit', '~> 1.8'
+  s.add_development_dependency 'bullet', '~> 5.0'
+  s.add_development_dependency 'pg'
 end


### PR DESCRIPTION
Adds the `pg` and `bullet` gems into the gemspec. Seems to fix the errors found in #731 