### PR TITLE
Replaces static error pages with controller

### DIFF
--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -42,9 +42,9 @@ module Suspenders
       invoke :install_bitters
       invoke :install_refills
       invoke :copy_miscellaneous_files
-      invoke :customize_error_pages
       invoke :remove_config_comment_lines
       invoke :remove_routes_comment_lines
+      invoke :setup_error_page_controller
       invoke :setup_dotfiles
       invoke :setup_git
       invoke :setup_database
@@ -226,17 +226,21 @@ module Suspenders
       build :copy_miscellaneous_files
     end
 
-    def customize_error_pages
-      say 'Customizing the 500/404/422 pages'
-      build :customize_error_pages
-    end
-
     def remove_config_comment_lines
       build :remove_config_comment_lines
     end
 
     def remove_routes_comment_lines
       build :remove_routes_comment_lines
+    end
+
+    def setup_error_page_controller
+      say "Setting up error pages"
+      build :inject_error_handling
+      build :copy_error_controller
+      build :inject_error_routes
+      build :delete_static_error_pages
+      build :copy_error_views
     end
 
     def outro

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -224,6 +224,24 @@ RSpec.describe "Suspend a new project with default configuration" do
     expect(File).to exist("#{project_path}/spec/factories.rb")
   end
 
+  it "creates an errors controller" do
+    expect(File).to exist(
+      "#{project_path}/app/controllers/errors_controller.rb",
+    )
+  end
+
+  it "creates a 404 page view" do
+    expect(File).to exist(
+      "#{project_path}/app/views/errors/not_found.html.erb",
+    )
+  end
+
+  it "creates a 500 page view" do
+    expect(File).to exist(
+      "#{project_path}/app/views/errors/internal_server_error.html.erb",
+    )
+  end
+
   def app_name
     SuspendersTestHelpers::APP_NAME
   end

--- a/templates/errors/internal_server_error.html.erb
+++ b/templates/errors/internal_server_error.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1>We're sorry, but something went wrong.</h1>
+</div>
+<p>If you are the application owner check the logs for more information.</p>

--- a/templates/errors/not_found.html.erb
+++ b/templates/errors/not_found.html.erb
@@ -1,0 +1,2 @@
+<h1>The page you were looking for doesn't exist.</h1>
+<p>You may have mistyped the address or the page may have moved.</p>

--- a/templates/errors_controller.rb
+++ b/templates/errors_controller.rb
@@ -1,0 +1,13 @@
+class ErrorsController < ActionController::Base
+  # Prevent CSRF attacks by raising an exception.
+  # For APIs, you may want to use :null_session instead.
+  protect_from_forgery with: :exception
+
+  def internal_server_error
+    render(status: 404)
+  end
+
+  def not_found
+    render(status: 500)
+  end
+end


### PR DESCRIPTION
This adds basic generators for error pages that use
controllers and views instead of static html pages
with inline css, etc.

Closes #673