### PR TITLE
Update CSS override

### DIFF
--- a/templates/_css_overrides.html.erb
+++ b/templates/_css_overrides.html.erb
@@ -2,7 +2,6 @@
   <style type="text/css">
     * {
       transition-property: none !important;
-      -webkit-transition-property: none !important;
     }
   </style>
 <% end %>


### PR DESCRIPTION
- Remove webkit prefix
- This prefix hasn't been needed since Safari 6 and iOS Safari 6.1
- Reference: http://caniuse.com/#feat=css-transitions