### PR TITLE
Update Bourbon to v5.0.0.beta.5

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 ruby "<%= Suspenders::RUBY_VERSION %>"
 
 gem "autoprefixer-rails"
-gem "bourbon", "5.0.0.beta.3"
+gem "bourbon", "5.0.0.beta.5"
 gem "delayed_job_active_record"
 gem "flutie"
 gem "high_voltage"


### PR DESCRIPTION
* Set Bourbon dependency to v5.0.0.beta.5, this should
  resolve issues *ActionView::Template::Error: File to import not found
  or unreadable: bourbon* that v5.0.0.beta.3 was causing

  Please look at this issues for more info:
  https://github.com/thoughtbot/suspenders/issues/727