### PR TITLE
Make Bitters a runtime dependency

### DIFF
--- a/suspenders.gemspec
+++ b/suspenders.gemspec
@@ -27,11 +27,11 @@ rush to build something amazing; don't use it if you like missing deadlines.
   s.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.version = Suspenders::VERSION
 
+  s.add_dependency 'bitters', '~> 1.3'
   s.add_dependency 'bundler', '~> 1.3'
   s.add_dependency 'rails', Suspenders::RAILS_VERSION
 
   s.add_development_dependency 'rspec', '~> 3.2'
-  s.add_development_dependency 'bitters', '~> 1.3'
   s.add_development_dependency 'simple_form', '~> 3.2'
   s.add_development_dependency 'title', '~> 0.0'
   s.add_development_dependency 'quiet_assets', '~> 1.1'


### PR DESCRIPTION
- Bitters was made a development dependency rather than a runtime dependency in
  3b7ce010560c965010b9a72f55979720e175362c, likely by accident.
- The reason we need Bitters to be a runtime dependency is so we can force
  installation of a specific version of Bitters, rather than leaning on a
  version the person might have installed already.
- Fixes #738