### PR TITLE
Return heroku run exit code status

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+1.38.0
+
+* Successful deploys with failing DB migrations on Heroku bugfix
+
 1.37.0 (March 13, 2016)
 
 * Remove `RAILS_ENV` definitions

--- a/spec/features/heroku_spec.rb
+++ b/spec/features/heroku_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Heroku" do
       bin_setup_path = "#{project_path}/bin/setup_review_app"
       bin_setup = IO.read(bin_setup_path)
 
-      expect(bin_setup).to include("heroku run rake db:migrate --app #{app_name}-staging-pr-$1")
+      expect(bin_setup).to include("heroku run rake db:migrate --exit-code --app #{app_name}-staging-pr-$1")
       expect(bin_setup).to include("heroku ps:scale worker=1 --app #{app_name}-staging-pr-$1")
       expect(bin_setup).to include("heroku restart --app #{app_name}-staging-pr-$1")
       expect(File.stat(bin_setup_path)).to be_executable
@@ -41,7 +41,7 @@ RSpec.describe "Heroku" do
       bin_deploy_path = "#{project_path}/bin/deploy"
       bin_deploy = IO.read(bin_deploy_path)
 
-      expect(bin_deploy).to include("heroku run rake db:migrate")
+      expect(bin_deploy).to include("heroku run rake db:migrate --exit-code")
       expect(File.stat(bin_deploy_path)).to be_executable
 
       readme = IO.read("#{project_path}/README.md")

--- a/templates/bin_deploy
+++ b/templates/bin_deploy
@@ -8,5 +8,5 @@ branch="$(git symbolic-ref HEAD --short)"
 target="${1:-staging}"
 
 git push "$target" "$branch:master"
-heroku run rake db:migrate --remote "$target"
+heroku run rake db:migrate --exit-code --remote "$target"
 heroku restart --remote "$target"

--- a/templates/bin_setup_review_app.erb
+++ b/templates/bin_setup_review_app.erb
@@ -14,6 +14,6 @@ heroku pg:backups restore \
   DATABASE_URL \
   --confirm <%= app_name.dasherize %>-staging-pr-$1 \
   --app <%= app_name.dasherize %>-staging-pr-$1
-heroku run rake db:migrate --app <%= app_name.dasherize %>-staging-pr-$1
+heroku run rake db:migrate --exit-code --app <%= app_name.dasherize %>-staging-pr-$1
 heroku ps:scale worker=1 --app <%= app_name.dasherize %>-staging-pr-$1
 heroku restart --app <%= app_name.dasherize %>-staging-pr-$1


### PR DESCRIPTION
I noticed that migrations were failing on my deploys but heroku was still registering it as a successful deploy. It turns out that `heroku run` does not return the status code from the command you want to run.

Adding `--exit-code` to the `heroku run` commands will correctly return the status code to the invoker.

Documentation: https://github.com/heroku/heroku-run