### PR TITLE
Default `EMAIL_RECIPIENTS` to be empty

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 master
 
+* Default an unspecified `EMAIL_RECIPIENTS` to be the empty string
 * Drops staging environment in favor of configuration through env variables
 
 1.38.0

--- a/templates/smtp.rb
+++ b/templates/smtp.rb
@@ -9,5 +9,7 @@ SMTP_SETTINGS = {
 }
 
 if ENV["EMAIL_RECIPIENTS"].present?
-  Mail.register_interceptor RecipientInterceptor.new(ENV["EMAIL_RECIPIENTS"])
+  Mail.register_interceptor RecipientInterceptor.new(
+    ENV.fetch("EMAIL_RECIPIENTS", ""),
+  )
 end


### PR DESCRIPTION
Some applications might not need to configure email interception out of
the box.

Without additional configuration, a newly `suspender`'d application
won't properly run in a `RACK_ENV=staging` environment.