### PR TITLE
Drop staging environment file

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+master
+
+* Drops staging environment in favor of configuration through env variables
+
 1.38.0
 
 * Successful deploys with failing DB migrations on Heroku bugfix

--- a/lib/suspenders/adapters/heroku.rb
+++ b/lib/suspenders/adapters/heroku.rb
@@ -25,11 +25,9 @@ module Suspenders
       end
 
       def create_staging_heroku_app(flags)
-        rack_env = "RACK_ENV=staging"
         app_name = heroku_app_name_for("staging")
 
         run_toolbelt_command "create #{app_name} #{flags}", "staging"
-        run_toolbelt_command "config:add #{rack_env}", "staging"
       end
 
       def create_production_heroku_app(flags)

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -196,20 +196,6 @@ module Suspenders
       )
     end
 
-    def setup_staging_environment
-      staging_file = 'config/environments/staging.rb'
-      copy_file 'staging.rb', staging_file
-
-      config = <<-RUBY
-
-Rails.application.configure do
-  # ...
-end
-      RUBY
-
-      append_file staging_file, config
-    end
-
     def setup_secret_token
       template 'secrets.yml', 'config/secrets.yml', force: true
     end

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -34,7 +34,6 @@ module Suspenders
       invoke :setup_development_environment
       invoke :setup_test_environment
       invoke :setup_production_environment
-      invoke :setup_staging_environment
       invoke :setup_secret_token
       invoke :create_suspenders_views
       invoke :configure_app
@@ -116,11 +115,6 @@ module Suspenders
       build :enable_rack_canonical_host
       build :enable_rack_deflater
       build :setup_asset_host
-    end
-
-    def setup_staging_environment
-      say 'Setting up the staging environment'
-      build :setup_staging_environment
     end
 
     def setup_secret_token

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -28,14 +28,6 @@ RSpec.describe "Suspend a new project with default configuration" do
     end
   end
 
-  it "inherits staging config from production" do
-    staging_file = IO.read("#{project_path}/config/environments/staging.rb")
-    config_stub = "Rails.application.configure do"
-
-    expect(staging_file).to match(/^require_relative "production"/)
-    expect(staging_file).to match(/#{config_stub}/), staging_file
-  end
-
   it "creates .ruby-version from Suspenders .ruby-version" do
     ruby_version_file = IO.read("#{project_path}/.ruby-version")
 
@@ -160,6 +152,12 @@ RSpec.describe "Suspend a new project with default configuration" do
     prod_env_file = IO.read("#{project_path}/config/environments/production.rb")
     expect(prod_env_file).to match(/"APPLICATION_HOST"/)
     expect(prod_env_file).not_to match(/"HOST"/)
+  end
+
+  it "configures email interceptor in smtp config" do
+    smtp_file = IO.read("#{project_path}/config/smtp.rb")
+    expect(smtp_file).
+      to match(/RecipientInterceptor.new\(ENV\["EMAIL_RECIPIENTS"\]\)/)
   end
 
   it "configures language in html element" do

--- a/templates/smtp.rb
+++ b/templates/smtp.rb
@@ -7,3 +7,7 @@ SMTP_SETTINGS = {
   port: "587",
   user_name: ENV.fetch("SMTP_USERNAME")
 }
+
+if ENV["EMAIL_RECIPIENTS"].present?
+  Mail.register_interceptor RecipientInterceptor.new(ENV["EMAIL_RECIPIENTS"])
+end

--- a/templates/staging.rb
+++ b/templates/staging.rb
@@ -1,5 +1,0 @@
-require_relative "production"
-
-Mail.register_interceptor(
-  RecipientInterceptor.new(ENV.fetch("EMAIL_RECIPIENTS"))
-)


### PR DESCRIPTION
The only custom configuration of suspended apps for the staging
environment was the email interceptor, which can live in `production.rb`
and be configured through environmental variables.

* Simplifies configuration
* Enforces staging/production parity
* Follows Heroku recommendations (https://devcenter.heroku.com/articles/multiple-environments)

[fixes #506]