### PR TITLE
Fix suspenders development and runtime dependencies

### DIFF
--- a/spec/features/github_spec.rb
+++ b/spec/features/github_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "GitHub" do
   it "suspends a project with --github option" do
     repo_name = 'test'
     run_suspenders("--github=#{repo_name}")
+    setup_app_dependencies
 
     expect(FakeGithub).to have_created_repo(repo_name)
   end

--- a/spec/features/heroku_spec.rb
+++ b/spec/features/heroku_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Heroku" do
     before(:all) do
       clean_up
       run_suspenders("--heroku=true")
+      setup_app_dependencies
     end
 
     it "suspends a project for Heroku" do
@@ -77,6 +78,7 @@ RSpec.describe "Heroku" do
     before(:all) do
       clean_up
       run_suspenders(%{--heroku=true --heroku-flags="--region eu"})
+      setup_app_dependencies
     end
 
     it "suspends a project with extra Heroku flags" do

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Suspend a new project with default configuration" do
     drop_dummy_database
     remove_project_directory
     run_suspenders
+    setup_app_dependencies
   end
 
   it "uses custom Gemfile" do

--- a/spec/support/suspenders.rb
+++ b/spec/support/suspenders.rb
@@ -20,6 +20,16 @@ module SuspendersTestHelpers
     end
   end
 
+  def setup_app_dependencies
+    if File.exist?(project_path)
+      Dir.chdir(project_path) do
+        Bundler.with_clean_env do
+          `bundle check || bundle install`
+        end
+      end
+    end
+  end
+
   def drop_dummy_database
     if File.exist?(project_path)
       Dir.chdir(project_path) do

--- a/suspenders.gemspec
+++ b/suspenders.gemspec
@@ -31,9 +31,4 @@ rush to build something amazing; don't use it if you like missing deadlines.
   s.add_dependency 'rails', Suspenders::RAILS_VERSION
 
   s.add_development_dependency 'rspec', '~> 3.2'
-  s.add_development_dependency 'bitters', '~> 1.3'
-  s.add_development_dependency 'simple_form', '~> 3.2'
-  s.add_development_dependency 'title', '~> 0.0'
-  s.add_development_dependency 'quiet_assets', '~> 1.1'
-  s.add_development_dependency 'capybara-webkit', '~> 1.8'
 end


### PR DESCRIPTION
Suspenders' tests generate an application to run assertions on it. This
means its runtime dependencies are themselves development dependencies.

Those dependencies were not being installed by suspenders' tests,
neither specified in its `.gemspec` as development dependencies, but
they were needed for new installation tests to run.

We address this issue by adding a `setup_app_dependencies` step in the
specs that need it, after generating an application (`run_suspenders`).
This ensures all dependencies are installed before we need them.

This makes it unnecessary to declare app dependencies in
`suspenders.gemspec`, because Rails and Bundler (only declared runtime
dependencies) will take care of those.

[fixes #732]
[fixes #739]

Pairing: @tute and @robskrob.