### PR TITLE
Set the default application host

### DIFF
--- a/lib/suspenders/adapters/heroku.rb
+++ b/lib/suspenders/adapters/heroku.rb
@@ -65,7 +65,6 @@ module Suspenders
           exit 1
         end
 
-        heroku_app_name = app_builder.app_name.dasherize
         run_toolbelt_command(
           "pipelines:create #{heroku_app_name} \
             -a #{heroku_app_name}-staging --stage staging",
@@ -88,6 +87,15 @@ module Suspenders
         end
       end
 
+      def set_heroku_application_host
+        %w(staging production).each do |environment|
+          run_toolbelt_command(
+            "config:add APPLICATION_HOST=#{heroku_app_name}-#{environment}.herokuapp.com",
+            environment,
+          )
+        end
+      end
+
       private
 
       attr_reader :app_builder
@@ -105,8 +113,12 @@ fi
         SHELL
       end
 
+      def heroku_app_name
+        app_builder.app_name.dasherize
+      end
+
       def heroku_app_name_for(environment)
-        "#{app_builder.app_name.dasherize}-#{environment}"
+        "#{heroku_app_name}-#{environment}"
       end
 
       def generate_secret

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -13,6 +13,7 @@ module Suspenders
                    :provide_review_apps_setup_script,
                    :set_heroku_rails_secrets,
                    :set_heroku_remotes,
+                   :set_heroku_application_host,
                    :set_heroku_serve_static_files,
                    :set_up_heroku_specific_gems
 

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -174,6 +174,7 @@ module Suspenders
         build :set_heroku_serve_static_files
         build :set_heroku_remotes
         build :set_heroku_rails_secrets
+        build :set_heroku_application_host
         build :create_heroku_pipelines_config_file
         build :create_heroku_pipeline
         build :provide_deploy_script

--- a/spec/adapters/heroku_spec.rb
+++ b/spec/adapters/heroku_spec.rb
@@ -40,6 +40,21 @@ module Suspenders
         )
       end
 
+      it "sets the application host" do
+        app_builder = double(app_name: app_name)
+        allow(app_builder).to receive(:run)
+
+        Heroku.new(app_builder).set_heroku_application_host
+
+        expect(app_builder).to(
+          have_configured_var("staging", "APPLICATION_HOST"),
+        )
+
+        expect(app_builder).to(
+          have_configured_var("production", "APPLICATION_HOST"),
+        )
+      end
+
       def app_name
         SuspendersTestHelpers::APP_NAME
       end

--- a/spec/features/heroku_spec.rb
+++ b/spec/features/heroku_spec.rb
@@ -21,6 +21,14 @@ RSpec.describe "Heroku" do
         "production",
         "SECRET_KEY_BASE",
       )
+      expect(FakeHeroku).to have_configured_vars(
+        "staging",
+        "APPLICATION_HOST",
+      )
+      expect(FakeHeroku).to have_configured_vars(
+        "production",
+        "APPLICATION_HOST",
+      )
       expect(FakeHeroku).to have_setup_pipeline_for(app_name)
 
       bin_setup_path = "#{project_path}/bin/setup"


### PR DESCRIPTION
This sets the default application host to "[app-name]-[environment].herokuapp.com" to prevent the error I talked about in #746. 

Does this make sense? This configures the app to heroku defaults to make suspenders more plug & play, but still doesn't explain how to change this after acquiring a custom domain. Is a change even required in that case?