### PR TITLE
Bring back bitters development dependency

### DIFF
--- a/suspenders.gemspec
+++ b/suspenders.gemspec
@@ -30,5 +30,6 @@ rush to build something amazing; don't use it if you like missing deadlines.
   s.add_dependency 'bundler', '~> 1.3'
   s.add_dependency 'rails', Suspenders::RAILS_VERSION
 
+  s.add_development_dependency 'bitters', '~> 1.3'
   s.add_development_dependency 'rspec', '~> 3.2'
 end


### PR DESCRIPTION
@robskrob and I dropped that dependency in
ef3428e, but didn't notice that this is
not a generated app's dependency, and it's a suspenders dependency
instead. It should then be specified in the gemspec.

[fixes #748]