### PR TITLE
Drop initializer for disabling XML parser

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -471,10 +471,6 @@ you can deploy to staging and production with:
         "Rails.application.routes.draw do\nend"
     end
 
-    def disable_xml_params
-      copy_file 'disable_xml_params.rb', 'config/initializers/disable_xml_params.rb'
-    end
-
     def setup_default_rake_task
       append_file 'Rakefile' do
         <<-EOS

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -136,7 +136,6 @@ module Suspenders
       build :configure_action_mailer
       build :configure_active_job
       build :configure_time_formats
-      build :disable_xml_params
       build :setup_default_rake_task
       build :configure_puma
       build :set_up_forego

--- a/templates/disable_xml_params.rb
+++ b/templates/disable_xml_params.rb
@@ -1,1 +1,0 @@
-ActionDispatch::ParamsParser::DEFAULT_PARSERS.delete(Mime::XML)


### PR DESCRIPTION
Vulnerabillity was fixed three years ago
(https://www.kb.cert.org/vuls/id/380039).

Also, this code doesn't work in Rails 5.