### PR TITLE
Upgrade to Rails 5.0.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 master
 
+* Update to Rails 5
+* Drop quiet_assets
 * Drop unneeded `suspenders` aliases: `--skip-test-unit`, `--skip-turbolinks`,
   `--skip-bundle`. Drops `-G` that clashes with Rails’ `--skip-git` alias.
 

--- a/README.md
+++ b/README.md
@@ -74,8 +74,6 @@ And development gems like:
   pre-loading
 * [Web Console](https://github.com/rails/web-console) for better debugging via
   in-browser IRB consoles.
-* [Quiet Assets](https://github.com/evrone/quiet_assets) for muting assets
-  pipeline log messages
 
 And testing gems like:
 

--- a/lib/suspenders/adapters/heroku.rb
+++ b/lib/suspenders/adapters/heroku.rb
@@ -70,15 +70,6 @@ module Suspenders
         )
       end
 
-      def set_heroku_serve_static_files
-        %w(staging production).each do |environment|
-          run_toolbelt_command(
-            "config:add RAILS_SERVE_STATIC_FILES=true",
-            environment,
-          )
-        end
-      end
-
       def set_heroku_application_host
         %w(staging production).each do |environment|
           run_toolbelt_command(

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -13,8 +13,7 @@ module Suspenders
                    :create_review_apps_setup_script,
                    :set_heroku_rails_secrets,
                    :set_heroku_remotes,
-                   :set_heroku_application_host,
-                   :set_heroku_serve_static_files
+                   :set_heroku_application_host
 
     def readme
       template 'README.md.erb', 'README.md'
@@ -79,7 +78,7 @@ module Suspenders
 
     def configure_quiet_assets
       config = <<-RUBY
-    config.quiet_assets = true
+    config.assets.quiet = true
       RUBY
 
       inject_into_class "config/application.rb", "Application", config
@@ -315,8 +314,8 @@ Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i
       generate 'rspec:install'
     end
 
-    def configure_puma
-      copy_file "puma.rb", "config/puma.rb"
+    def replace_default_puma_configuration
+      copy_file "puma.rb", "config/puma.rb", force: true
     end
 
     def set_up_forego

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -136,7 +136,7 @@ module Suspenders
       build :configure_active_job
       build :configure_time_formats
       build :setup_default_rake_task
-      build :configure_puma
+      build :replace_default_puma_configuration
       build :set_up_forego
       build :setup_rack_mini_profiler
     end
@@ -175,7 +175,6 @@ module Suspenders
       if options[:heroku]
         say "Creating Heroku apps"
         build :create_heroku_apps, options[:heroku_flags]
-        build :set_heroku_serve_static_files
         build :set_heroku_remotes
         build :set_heroku_rails_secrets
         build :set_heroku_application_host

--- a/lib/suspenders/version.rb
+++ b/lib/suspenders/version.rb
@@ -1,5 +1,5 @@
 module Suspenders
-  RAILS_VERSION = "~> 4.2.0".freeze
+  RAILS_VERSION = "~> 5.0.0".freeze
   RUBY_VERSION = IO.
     read("#{File.dirname(__FILE__)}/../../.ruby-version").
     strip.

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -111,9 +111,7 @@ RSpec.describe "Suspend a new project with default configuration" do
   it "adds explicit quiet_assets configuration" do
     result = IO.read("#{project_path}/config/application.rb")
 
-    expect(result).to match(
-      /^ +config.quiet_assets = true$/
-    )
+    expect(result).to match(/^ +config.assets.quiet = true$/)
   end
 
   it "configures static_cache_control in production" do

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -23,7 +23,7 @@ gem "title"
 gem "uglifier"
 
 group :development do
-  gem "quiet_assets"
+  gem "listen"
   gem "spring"
   gem "spring-commands-rspec"
   gem "web-console"
@@ -37,7 +37,8 @@ group :development, :test do
   gem "factory_girl_rails"
   gem "pry-byebug"
   gem "pry-rails"
-  gem "rspec-rails", "~> 3.4.0"
+  gem "refills"
+  gem "rspec-rails", "~> 3.5.0.beta4"
 end
 
 group :development, :staging do


### PR DESCRIPTION
Upgrade to Rails 5.0.0

* Replaces default Puma setup configuration that comes with Rails 5.
  We were already using it as per Heroku preference.
* No need of static files custom logic
  See https://blog.heroku.com/archives/2016/5/2/container_ready_rails_5

I needed to add the `listen` gem in development. See related PR to
Rails and its related issues: https://github.com/rails/rails/pull/24243