### PR TITLE
Make new apps "deployable to Heroku" by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 master
 
 * Update to Ruby 2.3.1
+* Make new apps "deployable to Heroku" by default.
 
 1.38.1 (April 20, 2016)
 

--- a/lib/suspenders/adapters/heroku.rb
+++ b/lib/suspenders/adapters/heroku.rb
@@ -16,14 +16,6 @@ module Suspenders
         app_builder.append_file "bin/setup", remotes
       end
 
-      def set_up_heroku_specific_gems
-        app_builder.inject_into_file(
-          "Gemfile",
-          %{\n\s\sgem "rails_stdout_logging"},
-          after: /group :staging, :production do/,
-        )
-      end
-
       def create_staging_heroku_app(flags)
         app_name = heroku_app_name_for("staging")
 
@@ -45,7 +37,7 @@ module Suspenders
         end
       end
 
-      def provide_review_apps_setup_script
+      def create_review_apps_setup_script
         app_builder.template(
           "bin_setup_review_app.erb",
           "bin/setup_review_app",
@@ -54,7 +46,7 @@ module Suspenders
         app_builder.run "chmod a+x bin/setup_review_app"
       end
 
-      def create_heroku_pipelines_config_file
+      def create_heroku_application_manifest_file
         app_builder.template "app.json.erb", "app.json"
       end
 

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -6,16 +6,15 @@ module Suspenders
     extend Forwardable
 
     def_delegators :heroku_adapter,
-                   :create_heroku_pipelines_config_file,
+                   :create_heroku_application_manifest_file,
                    :create_heroku_pipeline,
                    :create_production_heroku_app,
                    :create_staging_heroku_app,
-                   :provide_review_apps_setup_script,
+                   :create_review_apps_setup_script,
                    :set_heroku_rails_secrets,
                    :set_heroku_remotes,
                    :set_heroku_application_host,
-                   :set_heroku_serve_static_files,
-                   :set_up_heroku_specific_gems
+                   :set_heroku_serve_static_files
 
     def readme
       template 'README.md.erb', 'README.md'
@@ -376,7 +375,7 @@ Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i
       create_production_heroku_app(flags)
     end
 
-    def provide_deploy_script
+    def create_deploy_script
       copy_file "bin_deploy", "bin/deploy"
 
       instructions = <<-MARKDOWN

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -47,6 +47,7 @@ module Suspenders
       invoke :setup_dotfiles
       invoke :setup_git
       invoke :setup_database
+      invoke :create_local_heroku_setup
       invoke :create_heroku_apps
       invoke :create_github_repo
       invoke :setup_segment
@@ -57,11 +58,6 @@ module Suspenders
 
     def customize_gemfile
       build :set_ruby_to_version_being_used
-
-      if options[:heroku]
-        build :set_up_heroku_specific_gems
-      end
-
       bundle_command 'install'
       build :configure_simple_form
     end
@@ -165,18 +161,22 @@ module Suspenders
       end
     end
 
+    def create_local_heroku_setup
+      say "Creating local Heroku setup"
+      build :create_review_apps_setup_script
+      build :create_deploy_script
+      build :create_heroku_application_manifest_file
+    end
+
     def create_heroku_apps
       if options[:heroku]
         say "Creating Heroku apps"
         build :create_heroku_apps, options[:heroku_flags]
-        build :provide_review_apps_setup_script
         build :set_heroku_serve_static_files
         build :set_heroku_remotes
         build :set_heroku_rails_secrets
         build :set_heroku_application_host
-        build :create_heroku_pipelines_config_file
         build :create_heroku_pipeline
-        build :provide_deploy_script
         build :configure_automatic_deployment
       end
     end

--- a/spec/adapters/heroku_spec.rb
+++ b/spec/adapters/heroku_spec.rb
@@ -16,16 +16,6 @@ module Suspenders
           with(setup_file, /heroku join --app #{app_name.dasherize}-staging/)
       end
 
-      it "sets up the heroku specific gems" do
-        app_builder = double(app_name: app_name)
-        allow(app_builder).to receive(:inject_into_file)
-
-        Heroku.new(app_builder).set_up_heroku_specific_gems
-
-        expect(app_builder).to have_received(:inject_into_file).
-          with("Gemfile", /rails_stdout_logging/, anything)
-      end
-
       it "sets the heroku rails secrets" do
         app_builder = double(app_name: app_name)
         allow(app_builder).to receive(:run)

--- a/spec/features/heroku_spec.rb
+++ b/spec/features/heroku_spec.rb
@@ -11,9 +11,6 @@ RSpec.describe "Heroku" do
     it "suspends a project for Heroku" do
       app_name = SuspendersTestHelpers::APP_NAME.dasherize
 
-      expect(FakeHeroku).to(
-        have_gem_included(project_path, "rails_stdout_logging"),
-      )
       expect(FakeHeroku).to have_created_app_for("staging")
       expect(FakeHeroku).to have_created_app_for("production")
       expect(FakeHeroku).to have_configured_vars("staging", "SECRET_KEY_BASE")
@@ -39,20 +36,6 @@ RSpec.describe "Heroku" do
       expect(bin_setup).to include("git config heroku.remote staging")
       expect(File.stat(bin_setup_path)).to be_executable
 
-      bin_setup_path = "#{project_path}/bin/setup_review_app"
-      bin_setup = IO.read(bin_setup_path)
-
-      expect(bin_setup).to include("heroku run rake db:migrate --exit-code --app #{app_name}-staging-pr-$1")
-      expect(bin_setup).to include("heroku ps:scale worker=1 --app #{app_name}-staging-pr-$1")
-      expect(bin_setup).to include("heroku restart --app #{app_name}-staging-pr-$1")
-      expect(File.stat(bin_setup_path)).to be_executable
-
-      bin_deploy_path = "#{project_path}/bin/deploy"
-      bin_deploy = IO.read(bin_deploy_path)
-
-      expect(bin_deploy).to include("heroku run rake db:migrate --exit-code")
-      expect(File.stat(bin_deploy_path)).to be_executable
-
       readme = IO.read("#{project_path}/README.md")
 
       expect(readme).to include("./bin/deploy staging")
@@ -68,17 +51,6 @@ RSpec.describe "Heroku" do
           commands:
             - bin/deploy staging
       YML
-    end
-
-    it "adds app.json file" do
-      expect(File).to exist("#{project_path}/app.json")
-    end
-
-    it "includes application name in app.json file" do
-      app_json_file = IO.read("#{project_path}/app.json")
-      app_name = SuspendersTestHelpers::APP_NAME.dasherize
-
-      expect(app_json_file).to match(/"name":"#{app_name}"/)
     end
   end
 

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -223,6 +223,39 @@ RSpec.describe "Suspend a new project with default configuration" do
     expect(File).to exist("#{project_path}/spec/factories.rb")
   end
 
+  it "creates review apps setup script" do
+    bin_setup_path = "#{project_path}/bin/setup_review_app"
+    bin_setup = IO.read(bin_setup_path)
+
+    expect(bin_setup).to include("heroku run rake db:migrate --exit-code "\
+                                 "--app #{app_name.dasherize}-staging-pr-$1")
+    expect(bin_setup).to include("heroku ps:scale worker=1 "\
+                                 "--app #{app_name.dasherize}-staging-pr-$1")
+    expect(bin_setup).to include("heroku restart "\
+                                 "--app #{app_name.dasherize}-staging-pr-$1")
+    expect(File.stat(bin_setup_path)).to be_executable
+  end
+
+  it "creates deploy script" do
+    bin_deploy_path = "#{project_path}/bin/deploy"
+    bin_deploy = IO.read(bin_deploy_path)
+
+    expect(bin_deploy).to include("heroku run rake db:migrate --exit-code")
+    expect(File.stat(bin_deploy_path)).to be_executable
+  end
+
+  it "creates heroku application manifest file with application name in it" do
+    app_json_file = IO.read("#{project_path}/app.json")
+
+    expect(app_json_file).to match(/"name":"#{app_name.dasherize}"/)
+  end
+
+  it "sets up heroku specific gems" do
+    gemfile_file = IO.read("#{project_path}/Gemfile")
+
+    expect(gemfile_file).to include %{gem "rails_stdout_logging"}
+  end
+
   def app_name
     SuspendersTestHelpers::APP_NAME
   end

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -60,4 +60,5 @@ end
 
 group :staging, :production do
   gem "rack-timeout"
+  gem "rails_stdout_logging"
 end


### PR DESCRIPTION
This change makes new suspender apps "deployable to Heroku" by default,
moving the Heroku setup in the local machine to be run by default (i.e.
with the --heroku flag off). All the setup that requires to hit the
Heroku API to create the staging and production apps is kept to be run
only with the flag on.