### PR TITLE
Provide suspenders-specific help output

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@ master
 
 * Update to Ruby 2.3.1
 * Make new apps "deployable to Heroku" by default.
+* Make the help text returned when running `suspenders -h` Suspenders specific 
 
 1.38.1 (April 20, 2016)
 

--- a/USAGE
+++ b/USAGE
@@ -1,0 +1,13 @@
+Description:
+    Suspenders is a Rails template with thoughtbot standard
+    defaults, ready to deploy to Heroku.
+
+    For full details on the changes we've made compared to
+    a vanilla Rails app, check our GitHub project:
+        https://github.com/thoughtbot/suspenders
+
+Example:
+    suspenders ~/Code/weblog
+
+    This generates a Rails installation in ~/Code/weblog configured
+    with our preferred defaults.

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -24,6 +24,12 @@ module Suspenders
     class_option :skip_bundle, type: :boolean, aliases: "-B", default: true,
       desc: "Don't run bundle install"
 
+    class_option :version, type: :boolean, aliases: "-v", group: :suspenders,
+      desc: "Show Suspenders version number and quit"
+
+    class_option :help, type: :boolean, aliases: '-h', group: :suspenders,
+      desc: "Show this help message and quit"
+
     def finish_template
       invoke :suspenders_customization
       super
@@ -236,6 +242,10 @@ module Suspenders
     def outro
       say 'Congratulations! You just pulled our suspenders.'
       say honeybadger_outro
+    end
+
+    def self.banner
+      "suspenders #{arguments.map(&:usage).join(' ')} [options]"
     end
 
     protected

--- a/spec/features/cli_help_spec.rb
+++ b/spec/features/cli_help_spec.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+
+RSpec.describe "Command line help output" do
+  let(:help_text) { suspenders_help_command }
+
+  it "does not contain the default rails usage statement" do
+    expect(help_text).not_to include("rails new APP_PATH [options]")
+  end
+
+  it "provides the correct usage statement for suspenders" do
+    expect(help_text).to include <<~EOH
+      Usage:
+        suspenders APP_PATH [options]
+    EOH
+  end
+
+  it "does not contain the default rails group" do
+    expect(help_text).not_to include("Rails options:")
+  end
+
+  it "provides help and version usage within the suspenders group" do
+    expect(help_text).to include <<~EOH
+Suspenders options:
+  -h, [--help], [--no-help]        # Show this help message and quit
+  -v, [--version], [--no-version]  # Show Suspenders version number and quit
+EOH
+  end
+
+  it "does not show the default extended rails help section" do
+    expect(help_text).not_to include("Create suspenders files for app generator.")
+  end
+
+  it "contains the usage statement from the suspenders gem" do
+    expect(help_text).to include IO.read(usage_file)
+  end
+end

--- a/spec/support/suspenders.rb
+++ b/spec/support/suspenders.rb
@@ -20,6 +20,16 @@ module SuspendersTestHelpers
     end
   end
 
+  def suspenders_help_command
+    Dir.chdir(tmp_path) do
+      Bundler.with_clean_env do
+        `
+          #{suspenders_bin} -h
+        `
+      end
+    end
+  end
+
   def setup_app_dependencies
     if File.exist?(project_path)
       Dir.chdir(project_path) do
@@ -46,6 +56,10 @@ module SuspendersTestHelpers
 
   def project_path
     @project_path ||= Pathname.new("#{tmp_path}/#{APP_NAME}")
+  end
+
+  def usage_file
+    @usage_path ||= File.join(root_path, "USAGE")
   end
 
   private


### PR DESCRIPTION
This updates the command line output when you run `suspenders -h`.

Rather than receiving the rails usage and help messages, it will now provide instructions on how to use suspenders instead.