### PR TITLE
Bugfix: configure static_cache_control in production

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@ master
 
 * Update to Ruby 2.3.1
 * Make new apps "deployable to Heroku" by default.
-* Make the help text returned when running `suspenders -h` Suspenders specific 
+* Make the help text returned when running `suspenders -h` Suspenders specific
+* Bugfix: Configure `static_cache_control` in production environment
 
 1.38.1 (April 20, 2016)
 

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -191,7 +191,7 @@ module Suspenders
 
       inject_into_file(
         "config/environments/production.rb",
-        '  config.static_cache_control = "public, max-age=#{1.year.to_i}"',
+        '  config.static_cache_control = "public, max-age=31557600"',
         after: serve_static_files_line
       )
     end

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -123,6 +123,13 @@ RSpec.describe "Suspend a new project with default configuration" do
     )
   end
 
+  it "configures static_cache_control in production" do
+    prod_env_file = IO.read("#{project_path}/config/environments/production.rb")
+    expect(prod_env_file).to match(
+      /config.static_cache_control = "public, max-age=.+"/,
+    )
+  end
+
   it "raises on missing translations in development and test" do
     %w[development test].each do |environment|
       environment_file =


### PR DESCRIPTION
`1.year.to_i` wasn't being parsed nor raising an error, failing silently
to add that line to the `production.rb` file.