### PR TITLE
Introduce a stylesheet_base generator

### DIFF
--- a/lib/suspenders.rb
+++ b/lib/suspenders.rb
@@ -1,5 +1,6 @@
 require 'suspenders/version'
 require 'suspenders/generators/app_generator'
+require 'suspenders/generators/static_generator'
 require 'suspenders/actions'
 require "suspenders/adapters/heroku"
 require 'suspenders/app_builder'

--- a/lib/suspenders.rb
+++ b/lib/suspenders.rb
@@ -1,6 +1,7 @@
 require 'suspenders/version'
 require 'suspenders/generators/app_generator'
 require 'suspenders/generators/static_generator'
+require 'suspenders/generators/stylesheet_base_generator'
 require 'suspenders/actions'
 require "suspenders/adapters/heroku"
 require 'suspenders/app_builder'

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -344,12 +344,6 @@ Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i
       copy_file "Procfile", "Procfile"
     end
 
-    def setup_stylesheets
-      remove_file "app/assets/stylesheets/application.css"
-      copy_file "application.scss",
-                "app/assets/stylesheets/application.scss"
-    end
-
     def install_refills
       generate "refills:import", "flashes"
       remove_dir "app/views/refills"

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -240,6 +240,17 @@ module Suspenders
       bundle_command 'exec rake db:create db:migrate'
     end
 
+    def replace_gemfile(path)
+      remove_file 'Gemfile'
+      template 'Gemfile.erb', 'Gemfile' do |content|
+        if path
+          content.gsub(%r{gem .suspenders.}) { |s| %{#{s}, path: "#{path}"} }
+        else
+          content
+        end
+      end
+    end
+
     def set_ruby_to_version_being_used
       create_file '.ruby-version', "#{Suspenders::RUBY_VERSION}\n"
     end
@@ -342,6 +353,7 @@ Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i
 
     def install_refills
       generate "refills:import", "flashes"
+      run "rm app/views/refills/_flashes.html.erb"
       remove_dir "app/views/refills"
     end
 

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -241,8 +241,7 @@ module Suspenders
     end
 
     def replace_gemfile(path)
-      remove_file 'Gemfile'
-      template 'Gemfile.erb', 'Gemfile' do |content|
+      template 'Gemfile.erb', 'Gemfile', force: true do |content|
         if path
           content.gsub(%r{gem .suspenders.}) { |s| %{#{s}, path: "#{path}"} }
         else
@@ -353,7 +352,6 @@ Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i
 
     def install_refills
       generate "refills:import", "flashes"
-      run "rm app/views/refills/_flashes.html.erb"
       remove_dir "app/views/refills"
     end
 

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -24,6 +24,9 @@ module Suspenders
     class_option :skip_bundle, type: :boolean, aliases: "-B", default: true,
       desc: "Don't run bundle install"
 
+    class_option :path, type: :string, default: nil,
+      desc: "Path to the gem"
+
     def finish_template
       invoke :suspenders_customization
       super
@@ -52,10 +55,12 @@ module Suspenders
       invoke :setup_segment
       invoke :setup_bundler_audit
       invoke :setup_spring
+      invoke :generate_all
       invoke :outro
     end
 
     def customize_gemfile
+      build :replace_gemfile, options[:path]
       build :set_ruby_to_version_being_used
 
       if options[:heroku]
@@ -231,6 +236,11 @@ module Suspenders
 
     def remove_routes_comment_lines
       build :remove_routes_comment_lines
+    end
+
+    def generate_all
+      generate("suspenders:static")
+      bundle_command "install"
     end
 
     def outro

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -244,6 +244,7 @@ module Suspenders
       run("spring stop")
 
       generate("suspenders:static")
+      generate("suspenders:stylesheet_base")
 
       bundle_command "install"
     end

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -239,7 +239,10 @@ module Suspenders
     end
 
     def generate_all
+      run("spring stop")
+
       generate("suspenders:static")
+
       bundle_command "install"
     end
 

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -55,7 +55,7 @@ module Suspenders
       invoke :setup_segment
       invoke :setup_bundler_audit
       invoke :setup_spring
-      invoke :generate_all
+      invoke :generate_default
       invoke :outro
     end
 
@@ -238,7 +238,7 @@ module Suspenders
       build :remove_routes_comment_lines
     end
 
-    def generate_all
+    def generate_default
       run("spring stop")
 
       generate("suspenders:static")

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -3,6 +3,8 @@ require 'rails/generators/rails/app/app_generator'
 
 module Suspenders
   class AppGenerator < Rails::Generators::AppGenerator
+    hide!
+
     class_option :database, type: :string, aliases: "-d", default: "postgresql",
       desc: "Configure for selected database (options: #{DATABASES.join("/")})"
 

--- a/lib/suspenders/generators/static_generator.rb
+++ b/lib/suspenders/generators/static_generator.rb
@@ -1,0 +1,9 @@
+require 'rails/generators'
+
+module Suspenders
+  class StaticGenerator < Rails::Generators::Base
+    def add_high_voltage
+      gem "high_voltage"
+    end
+  end
+end

--- a/lib/suspenders/generators/static_generator.rb
+++ b/lib/suspenders/generators/static_generator.rb
@@ -1,4 +1,4 @@
-require 'rails/generators'
+require "rails/generators"
 
 module Suspenders
   class StaticGenerator < Rails::Generators::Base

--- a/lib/suspenders/generators/stylesheet_base_generator.rb
+++ b/lib/suspenders/generators/stylesheet_base_generator.rb
@@ -1,0 +1,21 @@
+require "rails/generators"
+
+module Suspenders
+  class StylesheetBaseGenerator < Rails::Generators::Base
+    source_root File.expand_path(
+      File.join("..", "..", "..", "templates"),
+      File.dirname(__FILE__))
+ 
+    def add_stylesheet_gems
+      gem "bourbon", "5.0.0.beta.5"
+      gem "neat", "~> 1.7.0"
+      gem "refills", group: [:development, :test]
+    end
+
+    def add_css_config
+      copy_file "application.scss",
+        "app/assets/stylesheets/application.scss",
+        force: true
+    end
+  end
+end

--- a/lib/suspenders/generators/stylesheet_base_generator.rb
+++ b/lib/suspenders/generators/stylesheet_base_generator.rb
@@ -5,7 +5,7 @@ module Suspenders
     source_root File.expand_path(
       File.join("..", "..", "..", "templates"),
       File.dirname(__FILE__))
- 
+
     def add_stylesheet_gems
       gem "bourbon", "5.0.0.beta.5"
       gem "neat", "~> 1.7.0"
@@ -13,9 +13,11 @@ module Suspenders
     end
 
     def add_css_config
-      copy_file "application.scss",
+      copy_file(
+        "application.scss",
         "app/assets/stylesheets/application.scss",
-        force: true
+        force: true,
+      )
     end
   end
 end

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -232,7 +232,24 @@ RSpec.describe "Suspend a new project with default configuration" do
     expect(gemfile).to match(/high_voltage/)
   end
 
+  it "adds and configures bourbon, neat, and refills" do
+    gemfile = read_project_file("Gemfile")
+
+    expect(gemfile).to match(/bourbon/)
+    expect(gemfile).to match(/neat/)
+    expect(gemfile).to match(/refills/)
+  end
+
+  it "configures bourbon, neat, and refills" do
+    app_css = read_project_file(%w(app assets stylesheets application.scss))
+    expect(app_css).to match(/normalize-rails.*bourbon.*neat.*base.*refills/m)
+  end
+
   def analytics_partial
     IO.read("#{project_path}/app/views/application/_analytics.html.erb")
+  end
+
+  def read_project_file(path)
+    IO.read(File.join(project_path, *path))
   end
 end

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -227,6 +227,11 @@ RSpec.describe "Suspend a new project with default configuration" do
     SuspendersTestHelpers::APP_NAME
   end
 
+  it "adds high_voltage" do
+    gemfile = IO.read("#{project_path}/Gemfile")
+    expect(gemfile).to match(/high_voltage/)
+  end
+
   def analytics_partial
     IO.read("#{project_path}/app/views/application/_analytics.html.erb")
   end

--- a/spec/support/suspenders.rb
+++ b/spec/support/suspenders.rb
@@ -10,6 +10,7 @@ module SuspendersTestHelpers
   end
 
   def run_suspenders(arguments = nil)
+    arguments = "--path=#{root_path} #{arguments}"
     Dir.chdir(tmp_path) do
       Bundler.with_clean_env do
         add_fakes_to_path

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -6,7 +6,6 @@ gem "autoprefixer-rails"
 gem "bourbon", "5.0.0.beta.5"
 gem "delayed_job_active_record"
 gem "flutie"
-gem "high_voltage"
 gem "honeybadger"
 gem "jquery-rails"
 gem "neat", "~> 1.7.0"
@@ -21,12 +20,12 @@ gem "sass-rails", "~> 5.0"
 gem "simple_form"
 gem "sprockets", ">= 3.0.0"
 gem "sprockets-es6"
+gem "suspenders"
 gem "title"
 gem "uglifier"
 
 group :development do
   gem "quiet_assets"
-  gem "refills"
   gem "spring"
   gem "spring-commands-rspec"
   gem "web-console"
@@ -41,6 +40,7 @@ group :development, :test do
   gem "pry-byebug"
   gem "pry-rails"
   gem "rspec-rails", "~> 3.4.0"
+  gem "refills"
 end
 
 group :development, :staging do

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -3,12 +3,10 @@ source "https://rubygems.org"
 ruby "<%= Suspenders::RUBY_VERSION %>"
 
 gem "autoprefixer-rails"
-gem "bourbon", "5.0.0.beta.5"
 gem "delayed_job_active_record"
 gem "flutie"
 gem "honeybadger"
 gem "jquery-rails"
-gem "neat", "~> 1.7.0"
 gem "newrelic_rpm", ">= 3.9.8"
 gem "normalize-rails", "~> 3.0.0"
 gem "pg"
@@ -40,7 +38,6 @@ group :development, :test do
   gem "pry-byebug"
   gem "pry-rails"
   gem "rspec-rails", "~> 3.4.0"
-  gem "refills"
 end
 
 group :development, :staging do


### PR DESCRIPTION
This introduces the `suspenders:stylesheet_base` generator, which adds
our typical foundations for CSS. In this case it is Bourbon, Neat, and
Refills.

Of note, the `application.scss` must list the imports in a specific
order.

This is a branch off of `gen-high_voltage`. Paired with Justin Moore.