### PR TITLE
Introduce a stylesheet_base generator

### DIFF
--- a/lib/suspenders.rb
+++ b/lib/suspenders.rb
@@ -1,6 +1,7 @@
 require 'suspenders/version'
 require 'suspenders/generators/app_generator'
 require 'suspenders/generators/static_generator'
+require 'suspenders/generators/stylesheet_base_generator'
 require 'suspenders/actions'
 require "suspenders/adapters/heroku"
 require 'suspenders/app_builder'

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -318,12 +318,6 @@ Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i
       copy_file "Procfile", "Procfile"
     end
 
-    def setup_stylesheets
-      remove_file "app/assets/stylesheets/application.css"
-      copy_file "application.scss",
-                "app/assets/stylesheets/application.scss"
-    end
-
     def install_refills
       generate "refills:import", "flashes"
       remove_dir "app/views/refills"

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -249,6 +249,7 @@ module Suspenders
       run("spring stop")
 
       generate("suspenders:static")
+      generate("suspenders:stylesheet_base")
 
       bundle_command "install"
     end

--- a/lib/suspenders/generators/stylesheet_base_generator.rb
+++ b/lib/suspenders/generators/stylesheet_base_generator.rb
@@ -1,0 +1,27 @@
+require "rails/generators"
+
+module Suspenders
+  class StylesheetBaseGenerator < Rails::Generators::Base
+    source_root File.expand_path(
+      File.join("..", "..", "..", "templates"),
+      File.dirname(__FILE__))
+
+    def add_stylesheet_gems
+      gem "bourbon", "5.0.0.beta.6"
+      gem "neat", "~> 1.7.0"
+      gem "refills", group: [:development, :test]
+    end
+
+    def add_css_config
+      copy_file(
+        "application.scss",
+        "app/assets/stylesheets/application.scss",
+        force: true,
+      )
+    end
+
+    def remove_prior_config
+      remove_file "app/assets/stylesheets/application.css"
+    end
+  end
+end

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -264,7 +264,24 @@ RSpec.describe "Suspend a new project with default configuration" do
     expect(gemfile).to match(/high_voltage/)
   end
 
+  it "adds and configures bourbon, neat, and refills" do
+    gemfile = read_project_file("Gemfile")
+
+    expect(gemfile).to match(/bourbon/)
+    expect(gemfile).to match(/neat/)
+    expect(gemfile).to match(/refills/)
+  end
+
+  it "configures bourbon, neat, and refills" do
+    app_css = read_project_file(%w(app assets stylesheets application.scss))
+    expect(app_css).to match(/normalize-rails.*bourbon.*neat.*base.*refills/m)
+  end
+
   def analytics_partial
     IO.read("#{project_path}/app/views/application/_analytics.html.erb")
+  end
+
+  def read_project_file(path)
+    IO.read(File.join(project_path, *path))
   end
 end

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -3,12 +3,10 @@ source "https://rubygems.org"
 ruby "<%= Suspenders::RUBY_VERSION %>"
 
 gem "autoprefixer-rails"
-gem "bourbon", "5.0.0.beta.6"
 gem "delayed_job_active_record"
 gem "flutie"
 gem "honeybadger"
 gem "jquery-rails"
-gem "neat", "~> 1.7.0"
 gem "normalize-rails", "~> 3.0.0"
 gem "pg"
 gem "puma"
@@ -39,7 +37,6 @@ group :development, :test do
   gem "factory_girl_rails"
   gem "pry-byebug"
   gem "pry-rails"
-  gem "refills"
   gem "rspec-rails", "~> 3.4.0"
 end
 


### PR DESCRIPTION
This introduces the `suspenders:stylesheet_base` generator, which adds
our typical foundations for CSS. In this case it is Bourbon, Neat, and
Refills.

Of note, the `application.scss` must list the imports in a specific
order.

Paired with Justin Moore.