### PR TITLE
Update the viewport meta tag

### DIFF
--- a/templates/suspenders_layout.html.erb.erb
+++ b/templates/suspenders_layout.html.erb.erb
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="ROBOTS" content="NOODP" />
-  <meta name="viewport" content="initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <%%#
     Configure default and controller-, and view-specific titles in
     config/locales/en.yml. For more see:


### PR DESCRIPTION
- Add `width=device-width` to set the virtual viewport to the width of
the device's screen
- Add `shrink-to-fit=no` to tell Safari 9 not to shrink overflowing
content to fit the width of the virtual viewport

References:
- https://css-tricks.com/snippets/html/responsive-meta-tag/
- https://bitsofco.de/ios-safari-and-shrink-to-fit/