### PR TITLE
Fix absence of heroku-pipelines in heroku plugins listing.

### DIFF
--- a/lib/suspenders/adapters/heroku.rb
+++ b/lib/suspenders/adapters/heroku.rb
@@ -53,7 +53,7 @@ module Suspenders
       def create_heroku_pipeline
         pipelines_plugin = `heroku help | grep '^\s*pipelines'`
         if pipelines_plugin.empty?
-          puts "You need heroku pipelines plugin. Run: heroku plugins:install heroku-pipelines"
+          puts "You need heroku pipelines plugin. Run: heroku update"
           exit 1
         end
 

--- a/lib/suspenders/adapters/heroku.rb
+++ b/lib/suspenders/adapters/heroku.rb
@@ -51,7 +51,7 @@ module Suspenders
       end
 
       def create_heroku_pipeline
-        pipelines_plugin = `heroku plugins | grep pipelines`
+        pipelines_plugin = `heroku help | grep '^\s*pipelines'`
         if pipelines_plugin.empty?
           puts "You need heroku pipelines plugin. Run: heroku plugins:install heroku-pipelines"
           exit 1

--- a/lib/suspenders/adapters/heroku.rb
+++ b/lib/suspenders/adapters/heroku.rb
@@ -51,7 +51,7 @@ module Suspenders
       end
 
       def create_heroku_pipeline
-        pipelines_plugin = `heroku help | grep '^\s*pipelines'`
+        pipelines_plugin = `heroku help | grep pipelines`
         if pipelines_plugin.empty?
           puts "You need heroku pipelines plugin. Run: heroku update"
           exit 1

--- a/spec/support/fake_heroku.rb
+++ b/spec/support/fake_heroku.rb
@@ -6,8 +6,8 @@ class FakeHeroku
   end
 
   def run!
-    if @args.first == "plugins"
-      puts "heroku-pipelines@0.29.0"
+    if @args.first == "help"
+      puts "pipelines      #  manage collections of apps in pipelines"
     end
     File.open(RECORDER, 'a') do |file|
       file.puts @args.join(' ')

--- a/spec/support/fake_heroku.rb
+++ b/spec/support/fake_heroku.rb
@@ -7,7 +7,8 @@ class FakeHeroku
 
   def run!
     if @args.first == "help"
-      puts "pipelines      #  manage collections of apps in pipelines"
+      # spaces in front are intentional
+      puts "  pipelines      #  manage collections of apps in pipelines"
     end
     File.open(RECORDER, 'a') do |file|
       file.puts @args.join(' ')

--- a/spec/support/fake_heroku.rb
+++ b/spec/support/fake_heroku.rb
@@ -7,8 +7,7 @@ class FakeHeroku
 
   def run!
     if @args.first == "help"
-      # spaces in front are intentional
-      puts "  pipelines      #  manage collections of apps in pipelines"
+      puts "pipelines      #  manage collections of apps in pipelines"
     end
     File.open(RECORDER, 'a') do |file|
       file.puts @args.join(' ')


### PR DESCRIPTION
Since heroku-pipelines became publicly available it is no longer an external plugin. This prevents it to appear in the listing `heroku plugins` which is used to check for it's availability.

By using `heroku help` and grep for `pipelines` it is still possible to do this check. If I'm right this wil work with in both situations: before and after general availability of this plugin.