### PR TITLE
Remove generator aliases and redundant flags

### DIFF
--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -14,17 +14,8 @@ module Suspenders
     class_option :heroku_flags, type: :string, default: "",
       desc: "Set extra Heroku flags"
 
-    class_option :github, type: :string, aliases: "-G", default: nil,
+    class_option :github, type: :string, default: nil,
       desc: "Create Github repository and add remote origin pointed to repo"
-
-    class_option :skip_test_unit, type: :boolean, aliases: "-T", default: true,
-      desc: "Skip Test::Unit files"
-
-    class_option :skip_turbolinks, type: :boolean, default: true,
-      desc: "Skip turbolinks gem"
-
-    class_option :skip_bundle, type: :boolean, aliases: "-B", default: true,
-      desc: "Don't run bundle install"
 
     class_option :version, type: :boolean, aliases: "-v", group: :suspenders,
       desc: "Show Suspenders version number and quit"

--- a/spec/features/github_spec.rb
+++ b/spec/features/github_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "GitHub" do
   end
 
   it "suspends a project with --github option" do
-    repo_name = 'test'
+    repo_name = "test"
     run_suspenders("--github=#{repo_name}")
     setup_app_dependencies
 


### PR DESCRIPTION
Former alias (-G) was clashing with rails generator's git ignore.
Added test for alias to catch future clashes.