### PR TITLE
Update Neat to 1.8.0

### DIFF
--- a/lib/suspenders/generators/stylesheet_base_generator.rb
+++ b/lib/suspenders/generators/stylesheet_base_generator.rb
@@ -8,7 +8,7 @@ module Suspenders
 
     def add_stylesheet_gems
       gem "bourbon", "5.0.0.beta.6"
-      gem "neat", "~> 1.7.0"
+      gem "neat", "~> 1.8.0"
       gem "refills", group: [:development, :test]
     end
 


### PR DESCRIPTION
Neat 1.8 drops the Bourbon dependency.