### PR TITLE
WEB_CONCURRENCY isn't required in app.json

### DIFF
--- a/templates/app.json.erb
+++ b/templates/app.json.erb
@@ -31,9 +31,6 @@
     },
     "SMTP_USERNAME":{
       "required":true
-    },
-    "WEB_CONCURRENCY":{
-      "required":true
     }
   },
   "addons":[


### PR DESCRIPTION
Heroku Review Apps can work well without this configuration set.

[closes #773]