### PR TITLE
Ensure stylesheet_base generator runs with a clean bundle

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -322,15 +322,6 @@ Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i
       copy_file "Procfile", "Procfile"
     end
 
-    def install_refills
-      generate "refills:import", "flashes"
-      remove_dir "app/views/refills"
-    end
-
-    def install_bitters
-      run "bitters install --path app/assets/stylesheets"
-    end
-
     def setup_default_directories
       [
         'app/views/pages',

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -39,9 +39,6 @@ module Suspenders
       invoke :setup_secret_token
       invoke :create_suspenders_views
       invoke :configure_app
-      invoke :setup_stylesheets
-      invoke :install_bitters
-      invoke :install_refills
       invoke :copy_miscellaneous_files
       invoke :customize_error_pages
       invoke :remove_config_comment_lines
@@ -141,21 +138,6 @@ module Suspenders
       build :setup_rack_mini_profiler
     end
 
-    def setup_stylesheets
-      say 'Set up stylesheets'
-      build :setup_stylesheets
-    end
-
-    def install_bitters
-      say 'Install Bitters'
-      build :install_bitters
-    end
-
-    def install_refills
-      say "Install Refills"
-      build :install_refills
-    end
-
     def setup_git
       if !options[:skip_git]
         say "Initializing git"
@@ -237,11 +219,8 @@ module Suspenders
 
     def generate_default
       run("spring stop")
-
       generate("suspenders:static")
       generate("suspenders:stylesheet_base")
-
-      bundle_command "install"
     end
 
     def outro

--- a/lib/suspenders/generators/static_generator.rb
+++ b/lib/suspenders/generators/static_generator.rb
@@ -4,6 +4,7 @@ module Suspenders
   class StaticGenerator < Rails::Generators::Base
     def add_high_voltage
       gem "high_voltage"
+      Bundler.with_clean_env { run "bundle install" }
     end
   end
 end

--- a/lib/suspenders/generators/stylesheet_base_generator.rb
+++ b/lib/suspenders/generators/stylesheet_base_generator.rb
@@ -10,6 +10,7 @@ module Suspenders
       gem "bourbon", "5.0.0.beta.6"
       gem "neat", "~> 1.8.0"
       gem "refills", group: [:development, :test]
+      Bundler.with_clean_env { run "bundle install" }
     end
 
     def add_css_config
@@ -22,6 +23,15 @@ module Suspenders
 
     def remove_prior_config
       remove_file "app/assets/stylesheets/application.css"
+    end
+
+    def install_refills
+      generate "refills:import", "flashes"
+      remove_dir "app/views/refills"
+    end
+
+    def install_bitters
+      run "bitters install --path app/assets/stylesheets"
     end
   end
 end

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -262,6 +262,9 @@ RSpec.describe "Suspend a new project with default configuration" do
   end
 
   it "configures bourbon, neat, and refills" do
+    flashes_path = %w(app assets stylesheets refills _flashes.scss)
+    expect(read_project_file(flashes_path)).to match(/mixin/m)
+
     app_css = read_project_file(%w(app assets stylesheets application.scss))
     expect(app_css).to match(/normalize-rails.*bourbon.*neat.*base.*refills/m)
   end


### PR DESCRIPTION
Static and Stylesheet suspenders' generators add gems to the `Gemfile`,
but don't run `bundle install` after the fact, making installations with
clean gem sets fail with errors like:

```
 gemfile  high_voltage
generate  suspenders:stylesheet_base
Could not find gem 'high_voltage' in any of the gem sources listed in
your Gemfile or available on this machine.
Run `bundle install` to install missing gems.
     run  bundle install
Fetching gem metadata from https://rubygems.org/
Fetching version metadata from https://rubygems.org/
Fetching dependency metadata from https://rubygems.org/
Resolving dependencies...
Using rake 11.2.2
```

By adding `bundle install` calls after modifying the `Gemfile` we ensure
each step will have the necessary dependencies for application code to
run.

[fixes #568]
[fixes #787]