### PR TITLE
Prefer using public_file_server.headers.

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -169,10 +169,13 @@ module Suspenders
         "config.assets.version = '1.0'",
         'config.assets.version = (ENV["ASSETS_VERSION"] || "1.0")'
 
-      configure_environment(
-        "production",
-        'config.static_cache_control = "public, max-age=31557600"',
-      )
+      config = <<-EOD
+config.public_file_server.headers = {
+    "Cache-Control" => "public, max-age=31557600",
+  }
+      EOD
+
+      configure_environment("production", config)
     end
 
     def setup_secret_token

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -114,9 +114,10 @@ RSpec.describe "Suspend a new project with default configuration" do
     expect(result).to match(/^ +config.assets.quiet = true$/)
   end
 
-  it "configures static_cache_control in production" do
+  it "configures public_file_server.headers in production" do
+    IO.write("production_config.rb", production_config)
     expect(production_config).to match(
-      /config.static_cache_control = "public, max-age=.+"/,
+      /^ +config.public_file_server.headers = {\n +"Cache-Control" => "public,/,
     )
   end
 


### PR DESCRIPTION
In Rails 5, deploying to production environments will print a deprecation
warning when configuring config.static_cache_control. This changes the
configuration to use the new style config.public_file_server.headers.