### PR TITLE
Remove turbolinks from application.js file

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -43,6 +43,14 @@ module Suspenders
         'raise_delivery_errors = false', 'raise_delivery_errors = true'
     end
 
+    def remove_turbolinks
+      replace_in_file(
+        "app/assets/javascripts/application.js",
+        "//= require turbolinks",
+        ""
+      )
+    end
+
     def set_test_delivery_method
       inject_into_file(
         "config/environments/development.rb",

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -77,6 +77,7 @@ module Suspenders
       say 'Setting up the development environment'
       build :raise_on_missing_assets_in_test
       build :raise_on_delivery_errors
+      build :remove_turbolinks
       build :set_test_delivery_method
       build :add_bullet_gem_configuration
       build :raise_on_unpermitted_parameters

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -270,6 +270,11 @@ RSpec.describe "Suspend a new project with default configuration" do
     expect(app_css).to match(/normalize-rails.*bourbon.*neat.*base.*refills/m)
   end
 
+  it "doesn't use turbolinks" do
+    app_js = read_project_file(%w(app assets javascripts application.js))
+    expect(app_js).not_to match(/turbolinks/)
+  end
+
   def development_config
     @_development_config ||=
       read_project_file %w(config environments development.rb)


### PR DESCRIPTION
Suspenders doesn't use turbolinks by default. It doesn't include it in
the Gemfile, but the generated `application.js` was trying to include
it, resulting in a failure.

This fix make sure a newly generated application doesn't include
the turbolinks reference.

[fixes #788]