### PR TITLE
Prevents extra spacing in generated bin/setup with heroku

### DIFF
--- a/lib/suspenders/adapters/heroku.rb
+++ b/lib/suspenders/adapters/heroku.rb
@@ -7,10 +7,10 @@ module Suspenders
 
       def set_heroku_remotes
         remotes = <<-SHELL.strip_heredoc
-          #{command_to_join_heroku_app('staging')}
-          #{command_to_join_heroku_app('production')}
+#{command_to_join_heroku_app('staging')}
+#{command_to_join_heroku_app('production')}
 
-          git config heroku.remote staging
+git config heroku.remote staging
         SHELL
 
         app_builder.append_file "bin/setup", remotes

--- a/spec/features/heroku_spec.rb
+++ b/spec/features/heroku_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe "Heroku" do
       bin_setup_path = "#{project_path}/bin/setup"
       bin_setup = IO.read(bin_setup_path)
 
-      expect(bin_setup).to include("heroku join --app #{app_name}-production")
-      expect(bin_setup).to include("heroku join --app #{app_name}-staging")
-      expect(bin_setup).to include("git config heroku.remote staging")
+      expect(bin_setup).to match(/^if heroku join --app #{app_name}-production/)
+      expect(bin_setup).to match(/^if heroku join --app #{app_name}-staging/)
+      expect(bin_setup).to match(/^git config heroku.remote staging/)
       expect(File.stat(bin_setup_path)).to be_executable
 
       readme = IO.read("#{project_path}/README.md")


### PR DESCRIPTION
Not sure about the first lines, it was generated fine. But the last one had extra leading spaces.

e.g.:
```
else
  printf 'Ask for access to the "camera-production" Heroku app
'
fi


          git config heroku.remote staging
```

(Not sure about the consecutive empty lines either)