### PR TITLE
Bugfix: new applications generate only spec directory

### DIFF
--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -26,6 +26,9 @@ module Suspenders
     class_option :path, type: :string, default: nil,
       desc: "Path to the gem"
 
+    class_option :skip_test, type: :boolean, default: true,
+      desc: "Skip Test Unit"
+
     def finish_template
       invoke :suspenders_customization
       super

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -41,6 +41,10 @@ RSpec.describe "Suspend a new project with default configuration" do
     end
   end
 
+  it "doesn't generate test directory" do
+    expect(File).not_to exist("#{project_path}/test")
+  end
+
   it "loads secret_key_base from env" do
     secrets_file = IO.read("#{project_path}/config/secrets.yml")
 


### PR DESCRIPTION
Before this change, new apps had both spec and test directories.

[fixes #798]