### PR TITLE
Specify Bourbon version pessimistically

### DIFF
--- a/lib/suspenders/generators/stylesheet_base_generator.rb
+++ b/lib/suspenders/generators/stylesheet_base_generator.rb
@@ -7,7 +7,7 @@ module Suspenders
       File.dirname(__FILE__))
 
     def add_stylesheet_gems
-      gem "bourbon", "5.0.0.beta.7"
+      gem "bourbon", "~> 5.0.0.beta.7"
       gem "neat", "~> 2.0.0.beta.1"
       gem "refills", group: [:development, :test]
       Bundler.with_clean_env { run "bundle install" }


### PR DESCRIPTION
This matches how we specify the Bourbon dependency in Bitters and means
we won't have to coordinate releases between the two so closely.

Fixes https://github.com/thoughtbot/suspenders/issues/805