### PR TITLE
Update Bitters to 1.5

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 master
 
 * Update Bourbon to 5.0.0.beta.7
+* Update Bitters to 1.5.0
 
 1.42.0 (July 23, 2016)
 

--- a/suspenders.gemspec
+++ b/suspenders.gemspec
@@ -27,7 +27,7 @@ rush to build something amazing; don't use it if you like missing deadlines.
   s.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.version = Suspenders::VERSION
 
-  s.add_dependency 'bitters', '~> 1.4'
+  s.add_dependency 'bitters', '~> 1.5'
   s.add_dependency 'bundler', '~> 1.3'
   s.add_dependency 'rails', Suspenders::RAILS_VERSION
 


### PR DESCRIPTION
We just cut the `1.5` release of Bitters, which continues the work found in https://github.com/thoughtbot/suspenders/pull/806.

Bitters `1.5` change log:

**Changed**

- Updated Bourbon dependency to 5.0.0.beta.7.

Once we merge this, I recommend we cut a `1.43.0` of Suspenders to release these fixes from the Bourbon/Bitters issues.