### PR TITLE
Do not create test file in repo root folder

### DIFF
--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -119,7 +119,6 @@ RSpec.describe "Suspend a new project with default configuration" do
   end
 
   it "configures public_file_server.headers in production" do
-    IO.write("production_config.rb", production_config)
     expect(production_config).to match(
       /^ +config.public_file_server.headers = {\n +"Cache-Control" => "public,/,
     )


### PR DESCRIPTION
I noticed that line 122 creates a file named `production_config.rb` in the repo root path when you run `rspec spec` on my dev machine. I think the line might be a leftover from a previous commit. Am I right?