### PR TITLE
Fix generators config: remove warning when scaffolding

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -106,7 +106,7 @@ module Suspenders
 
     config.generators do |generate|
       generate.helper false
-      generate.javascript_engine false
+      generate.javascripts false
       generate.request_specs false
       generate.routing_specs false
       generate.stylesheets false


### PR DESCRIPTION
If I run `rails g scaffold post title:string`, I got a warning about javascript-engine

```bash
↳ $ rails g scaffold post title:string
Running via Spring preloader in process 18853
      invoke  active_record
      create    db/migrate/20161219223207_create_posts.rb
      create    app/models/post.rb
      invoke    rspec
      create      spec/models/post_spec.rb
      invoke      factory_girl
      insert        spec/factories.rb
      invoke  resource_route
       route    resources :posts
      invoke  scaffold_controller
      create    app/controllers/posts_controller.rb
      invoke    erb
      create      app/views/posts
      create      app/views/posts/index.html.erb
      create      app/views/posts/edit.html.erb
      create      app/views/posts/show.html.erb
      create      app/views/posts/new.html.erb
      create      app/views/posts/_form.html.erb
      invoke    rspec
      create      spec/controllers/posts_controller_spec.rb
      invoke      rspec
Expected string default value for '--javascript-engine'; got false (boolean)
      invoke  assets
      invoke    scss
```

I think the new way to avoid creating javascripts files during scaffold is using `generate.javascripts false` instead of `generate.javascript_engine false`. Source: http://api.rubyonrails.org/classes/Rails/Generators.html