### PR TITLE
Remove rails_stdout_logging gem

### DIFF
--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -242,12 +242,6 @@ RSpec.describe "Suspend a new project with default configuration" do
     expect(app_json_file).to match(/"name":"#{app_name.dasherize}"/)
   end
 
-  it "sets up heroku specific gems" do
-    gemfile_file = IO.read("#{project_path}/Gemfile")
-
-    expect(gemfile_file).to include %{gem "rails_stdout_logging"}
-  end
-
   def app_name
     SuspendersTestHelpers::APP_NAME
   end

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -56,5 +56,4 @@ end
 
 group :staging, :production do
   gem "rack-timeout"
-  gem "rails_stdout_logging"
 end


### PR DESCRIPTION
No longer needed since Rails 5 includes Heroku's 12factor methodology