### PR TITLE
Use an sh-compatible construct

### DIFF
--- a/lib/suspenders/adapters/heroku.rb
+++ b/lib/suspenders/adapters/heroku.rb
@@ -87,7 +87,7 @@ module Suspenders
         heroku_app_name = heroku_app_name_for(environment)
         <<~SHELL
 
-          if heroku join --app #{heroku_app_name} &> /dev/null; then
+          if heroku join --app #{heroku_app_name} > /dev/null 2>&1; then
             git remote add #{environment} git@heroku.com:#{heroku_app_name}.git || true
             printf 'You are a collaborator on the "#{heroku_app_name}" Heroku app\n'
           else


### PR DESCRIPTION
As requested by @nickcharlton [here](https://github.com/thoughtbot/administrate/pull/578#issuecomment-274091479). I couldn't run the tests locally since I get this error:

```
Bundler::GemNotFound: Could not find gem 'simple_form' in any of the gem sources listed in your Gemfile.
/home/deivid/.gem/ruby/2.4.0/gems/bundler-1.14.0.pre.2/lib/bundler/resolver.rb:376:in `block in verify_gemfile_dependencies_are_found!'
/home/deivid/.gem/ruby/2.4.0/gems/bundler-1.14.0.pre.2/lib/bundler/resolver.rb:346:in `each'
/home/deivid/.gem/ruby/2.4.0/gems/bundler-1.14.0.pre.2/lib/bundler/resolver.rb:346:in `verify_gemfile_dependencies_are_found!'
/home/deivid/.gem/ruby/2.4.0/gems/bundler-1.14.0.pre.2/lib/bundler/resolver.rb:201:in `start'
/home/deivid/.gem/ruby/2.4.0/gems/bundler-1.14.0.pre.2/lib/bundler/resolver.rb:181:in `resolve'
/home/deivid/.gem/ruby/2.4.0/gems/bundler-1.14.0.pre.2/lib/bundler/definition.rb:251:in `resolve'
/home/deivid/.gem/ruby/2.4.0/gems/bundler-1.14.0.pre.2/lib/bundler/definition.rb:175:in `specs'
/home/deivid/.gem/ruby/2.4.0/gems/bundler-1.14.0.pre.2/lib/bundler/definition.rb:234:in `specs_for'
/home/deivid/.gem/ruby/2.4.0/gems/bundler-1.14.0.pre.2/lib/bundler/definition.rb:223:in `requested_specs'
/home/deivid/.gem/ruby/2.4.0/gems/bundler-1.14.0.pre.2/lib/bundler/runtime.rb:118:in `block in definition_method'
/home/deivid/.gem/ruby/2.4.0/gems/bundler-1.14.0.pre.2/lib/bundler/runtime.rb:19:in `setup'
/home/deivid/.gem/ruby/2.4.0/gems/bundler-1.14.0.pre.2/lib/bundler.rb:102:in `setup'
/home/deivid/.gem/ruby/2.4.0/gems/bundler-1.14.0.pre.2/lib/bundler/setup.rb:20:in `<top (required)>'
/home/deivid/Code/suspenders/tmp/dummy_app/config/boot.rb:3:in `<top (required)>'
/home/deivid/Code/suspenders/tmp/dummy_app/config/application.rb:1:in `require_relative'
/home/deivid/Code/suspenders/tmp/dummy_app/config/application.rb:1:in `<top (required)>'
/home/deivid/Code/suspenders/tmp/dummy_app/Rakefile:4:in `require_relative'
/home/deivid/Code/suspenders/tmp/dummy_app/Rakefile:4:in `<top (required)>'
/home/deivid/.gem/ruby/2.4.0/gems/rake-12.0.0/exe/rake:27:in `<top (required)>'
LoadError: cannot load such file -- bundler/setup
/home/deivid/Code/suspenders/tmp/dummy_app/config/boot.rb:3:in `<top (required)>'
/home/deivid/Code/suspenders/tmp/dummy_app/config/application.rb:1:in `require_relative'
/home/deivid/Code/suspenders/tmp/dummy_app/config/application.rb:1:in `<top (required)>'
/home/deivid/Code/suspenders/tmp/dummy_app/Rakefile:4:in `require_relative'
/home/deivid/Code/suspenders/tmp/dummy_app/Rakefile:4:in `<top (required)>'
/home/deivid/.gem/ruby/2.4.0/gems/rake-12.0.0/exe/rake:27:in `<top (required)>'
```

But I guess this doesn't break anything.