### PR TITLE
Add support for customization

### DIFF
--- a/bin/suspenders
+++ b/bin/suspenders
@@ -14,10 +14,16 @@ if ARGV.empty?
 elsif ['-v', '--version'].include? ARGV[0]
   puts Suspenders::VERSION
   exit 0
+elsif ARGV[1] == '-c'
+  $LOAD_PATH << "#{ARGV[2]}/lib"
+  require 'suspenders/generators/custom_app_generator'
+  custom_templates_root = "#{ARGV[2]}/templates"
+  custom_generator_class = Suspenders::CustomAppGenerator
 end
 
-templates_root = File.expand_path(File.join("..", "templates"), File.dirname(__FILE__))
-Suspenders::AppGenerator.source_root templates_root
-Suspenders::AppGenerator.source_paths << Rails::Generators::AppGenerator.source_root << templates_root
+templates_root = custom_templates_root || File.expand_path(File.join("..", "templates"), File.dirname(__FILE__))
+generator_class = custom_generator_class || Suspenders::AppGenerator
+generator_class.source_root templates_root
+generator_class.source_paths << Rails::Generators::AppGenerator.source_root << templates_root
 
-Suspenders::AppGenerator.start
+generator_class.start


### PR DESCRIPTION
**Why**:
- Some people might want to configure their Rails app differently from
what suspenders does by default

**How**:
- Allow the user to specify the `-c` flag, followed by a local path
that  contains the custom app generator, app builder, and templates.
For example: `suspenders app -c /path/to/custom/files`
- It is assumed that the custom files are organized in the same
directory structure as suspenders, and that the custom app generator
and builder class names are called `CustomAppGenerator` and
`CustomAppBuilder` respectively.