### PR TITLE
Schedule Heroku Backups and Capture backup of existing staging database for Review Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ This:
 * Configures staging with `RACK_ENV` environment variable set
   to `staging`
 * Creates a [Heroku Pipeline] for review apps
+* Schedules automated backups for 10AM UTC for both `staging` and `production`
 
 [Heroku Pipeline]: https://devcenter.heroku.com/articles/pipelines
 

--- a/lib/suspenders/adapters/heroku.rb
+++ b/lib/suspenders/adapters/heroku.rb
@@ -37,6 +37,15 @@ module Suspenders
         end
       end
 
+      def set_heroku_backup_schedule
+        %w(staging production).each do |environment|
+          run_toolbelt_command(
+            "pg:backups:schedule DATABASE_URL --at '02:00 America/Los_Angeles'",
+            environment,
+          )
+        end
+      end
+      
       def create_review_apps_setup_script
         app_builder.template(
           "bin_setup_review_app.erb",

--- a/lib/suspenders/adapters/heroku.rb
+++ b/lib/suspenders/adapters/heroku.rb
@@ -40,7 +40,7 @@ module Suspenders
       def set_heroku_backup_schedule
         %w(staging production).each do |environment|
           run_toolbelt_command(
-            "pg:backups:schedule DATABASE_URL --at '02:00 America/Los_Angeles'",
+            "pg:backups:schedule DATABASE_URL --at '10:00 UTC'",
             environment,
           )
         end

--- a/lib/suspenders/adapters/heroku.rb
+++ b/lib/suspenders/adapters/heroku.rb
@@ -45,7 +45,7 @@ module Suspenders
           )
         end
       end
-      
+
       def create_review_apps_setup_script
         app_builder.template(
           "bin_setup_review_app.erb",

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -12,6 +12,7 @@ module Suspenders
                    :create_staging_heroku_app,
                    :create_review_apps_setup_script,
                    :set_heroku_rails_secrets,
+                   :set_heroku_backup_schedule,
                    :set_heroku_remotes,
                    :set_heroku_application_host
 

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -164,6 +164,7 @@ module Suspenders
         build :set_heroku_remotes
         build :set_heroku_rails_secrets
         build :set_heroku_application_host
+        build :set_heroku_backup_schedule
         build :create_heroku_pipeline
         build :configure_automatic_deployment
       end

--- a/spec/adapters/heroku_spec.rb
+++ b/spec/adapters/heroku_spec.rb
@@ -61,7 +61,7 @@ module Suspenders
 
       def have_backup_schedule(remote_name)
         have_received(:run).
-          with(/pg:backups:schedule DATABASE_URL --at '02:00 America\/Los_Angeles' --remote #{remote_name}/)
+          with(/pg:backups:schedule DATABASE_URL --at '10:00 UTC' --remote #{remote_name}/)
       end
 
       def have_configured_var(remote_name, var)

--- a/spec/adapters/heroku_spec.rb
+++ b/spec/adapters/heroku_spec.rb
@@ -58,7 +58,7 @@ module Suspenders
       def app_name
         SuspendersTestHelpers::APP_NAME
       end
-      
+
       def have_backup_schedule(remote_name)
         have_received(:run).
           with(/pg:backups:schedule DATABASE_URL --at '02:00 America\/Los_Angeles' --remote #{remote_name}/)

--- a/spec/adapters/heroku_spec.rb
+++ b/spec/adapters/heroku_spec.rb
@@ -39,7 +39,7 @@ module Suspenders
         expect(app_builder).to have_backup_schedule("staging")
         expect(app_builder).to have_backup_schedule("production")
       end
-      
+
       it "sets the application host" do
         app_builder = double(app_name: app_name)
         allow(app_builder).to receive(:run)

--- a/spec/adapters/heroku_spec.rb
+++ b/spec/adapters/heroku_spec.rb
@@ -30,6 +30,16 @@ module Suspenders
         )
       end
 
+      it "sets the heroku backup schedule" do
+        app_builder = double(app_name: app_name)
+        allow(app_builder).to receive(:run)
+
+        Heroku.new(app_builder).set_heroku_backup_schedule
+
+        expect(app_builder).to have_backup_schedule("staging")
+        expect(app_builder).to have_backup_schedule("production")
+      end
+      
       it "sets the application host" do
         app_builder = double(app_name: app_name)
         allow(app_builder).to receive(:run)
@@ -47,6 +57,11 @@ module Suspenders
 
       def app_name
         SuspendersTestHelpers::APP_NAME
+      end
+      
+      def have_backup_schedule(remote_name)
+        have_received(:run).
+          with(/pg:backups:schedule DATABASE_URL --at '02:00 America\/Los_Angeles' --remote #{remote_name}/)
       end
 
       def have_configured_var(remote_name, var)

--- a/templates/bin_setup_review_app.erb
+++ b/templates/bin_setup_review_app.erb
@@ -11,6 +11,9 @@ fi
 
 PARENT_APP_NAME=<%= app_name.dasherize %>-staging
 APP_NAME=<%= app_name.dasherize %>-staging-pr-$1
+
+heroku pg:backups:capture --app $PARENT_APP_NAME
+
 URL=`heroku pg:backups public-url --app $PARENT_APP_NAME`
 
 heroku pg:backups restore $URL DATABASE_URL --confirm $APP_NAME --app $APP_NAME


### PR DESCRIPTION
When a PR Review environment is created, the latest backup is currently used. If no backups exist, or if the backup is old and outdated, recent data used for testing may not exist.

This forcibly creates a backup right before migration -- leading to the most recent data.

Another way to solve this would be to automatically add `pg:backups:schedule` on all staging environments on original app scaffolding, but that would be up to 24 hours difference.