### PR TITLE
Change terminal symbol in README's deploying section

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -370,8 +370,8 @@ Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i
 If you have previously run the `./bin/setup` script,
 you can deploy to staging and production with:
 
-    $ ./bin/deploy staging
-    $ ./bin/deploy production
+    % ./bin/deploy staging
+    % ./bin/deploy production
       MARKDOWN
 
       append_file "README.md", instructions


### PR DESCRIPTION
Replace `$`with `%` (as the latter is used in the main README template) in order to improve consistency in the generated README. Currently, both symbols are used to indicate terminal commands, leading to this silliness:

![5017b6a798c20c118ff8499098fc9ac1 _screenshot-2017-02-25_17-10-06](https://cloud.githubusercontent.com/assets/2405802/23332704/4243a54a-fb7e-11e6-82fa-2adc26c60cb6.png)
 
Of course, this is far from a big deal – but I'm a man who prefers consistency, and I'm betting you are too.