### PR TITLE
Use bundle-audit rake task from the gem

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -401,7 +401,7 @@ you can deploy to staging and production with:
 
     def setup_bundler_audit
       copy_file "bundler_audit.rake", "lib/tasks/bundler_audit.rake"
-      append_file "Rakefile", %{\ntask default: "bundler:audit"\n}
+      append_file "Rakefile", %{\ntask default: "bundle:audit"\n}
     end
 
     def setup_spring

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -29,6 +29,14 @@ RSpec.describe "Suspend a new project with default configuration" do
     end
   end
 
+  it "includes the bundle:audit task" do
+    Dir.chdir(project_path) do
+      Bundler.with_clean_env do
+        expect(`rake -T`).to include('rake bundle:audit')
+      end
+    end
+  end
+
   it "creates .ruby-version from Suspenders .ruby-version" do
     ruby_version_file = IO.read("#{project_path}/.ruby-version")
 

--- a/templates/bundler_audit.rake
+++ b/templates/bundler_audit.rake
@@ -1,12 +1,4 @@
 if Rails.env.development? || Rails.env.test?
-  require "bundler/audit/cli"
-
-  namespace :bundler do
-    desc "Updates the ruby-advisory-db and runs audit"
-    task :audit do
-      %w(update check).each do |command|
-        Bundler::Audit::CLI.start [command]
-      end
-    end
-  end
+  require "bundler/audit/task"
+  Bundler::Audit::Task.new
 end


### PR DESCRIPTION
Instead of defining the audit task from scratch, we can now import the task from the gem itself.

One caveat: The task name changes from `bundler:audit` to `bundle:audit` as defined by the gem. We could make an alias between the old & new command but I suspect most use is just via the default Rake task.