### PR TITLE
Fix fatal git failures in tests

### DIFF
--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -47,7 +47,6 @@ module Suspenders
       invoke :remove_config_comment_lines
       invoke :remove_routes_comment_lines
       invoke :setup_dotfiles
-      invoke :setup_git
       invoke :setup_database
       invoke :create_local_heroku_setup
       invoke :create_heroku_apps
@@ -56,6 +55,7 @@ module Suspenders
       invoke :setup_bundler_audit
       invoke :setup_spring
       invoke :generate_default
+      invoke :setup_git
       invoke :outro
     end
 

--- a/spec/support/suspenders.rb
+++ b/spec/support/suspenders.rb
@@ -17,6 +17,12 @@ module SuspendersTestHelpers
         `
           #{suspenders_bin} #{APP_NAME} #{arguments}
         `
+        Dir.chdir(APP_NAME) do
+          with_env("HOME", tmp_path) do
+            `git add .`
+            `git commit -m 'Initial commit'`
+          end
+        end
       end
     end
   end
@@ -79,5 +85,15 @@ module SuspendersTestHelpers
 
   def root_path
     File.expand_path('../../../', __FILE__)
+  end
+
+  def with_env(name, new_value)
+    prior = ENV[name]
+    ENV[name] = new_value.to_s
+
+    yield
+
+  ensure
+    ENV[name] = prior
   end
 end


### PR DESCRIPTION
The tests had started printing git error messages:

```
fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree.
```

These were coming from three places:

- `suspenders.gemspec`, which collects all `Gem::Specification#files=`
  by shelling out to `git ls-files`.
- `suspenders.gemspec`, which collects all
  `Gem::Specification#test_files=` by shelling out to
  `git ls-files -- {test,spec,features}/*`.
- Honeybadger, which figures out which revision to tag the error with by
  invoking `rev-parse`:

      def from_git
        return nil unless File.directory?('.git')
        `git rev-parse HEAD`.strip rescue nil
      end

Although I am unsure why these things started to matter now, I found two
changes that improve the situation:

- In the test suite, make an initial commit after suspender'ing a
  project.
- When suspender'ing a project, make the git repo last.