### PR TITLE
.git/safe is opt-in

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 `master`
 
+* No longer generate `mkdir -p .git/safe` as part of `bin/setup`
 * Update Bitters to 1.7
 * Update Neat to 2.1
 * Update Bourbon to 5.0.0.beta.8

--- a/templates/bin_setup
+++ b/templates/bin_setup
@@ -13,8 +13,12 @@ bundle check || bundle install
 # Set up database and add any development seed data
 bin/rails dev:prime
 
-# Add binstubs to PATH via export PATH=".git/safe/../../bin:$PATH" in ~/.zshenv
-mkdir -p .git/safe
+if [ ! -d .git/safe ] && echo $PATH | grep .git/safe > /dev/null; then
+  echo "-----------------------------------------------------------------------"
+  echo
+  echo "-> When you trust this repo, remember to run: mkdir -p .git/safe"
+  echo
+fi
 
 # Only if this isn't CI
 # if [ -z "$CI" ]; then


### PR DESCRIPTION
The idea behind the .git/safe is that I run it manually and explicitly
after I trust the directoy and the team behind the project.

Creating it as part of the setup script defeats the point of that. Doing
so without explcitly telling the user comes across as sneaky, perhaps.
(I do expect all devs to read setup scripts before running them -- but I
also know that they do not!)

Switch this script to inform the user that they have no `.git/safe`
directory but might like to make one.