### PR TITLE
Configure TimeCop safe mode

### DIFF
--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -280,6 +280,11 @@ RSpec.describe "Suspend a new project with default configuration" do
     expect(app_js).not_to match(/turbolinks/)
   end
 
+  it "configures Timecop safe mode" do
+    spec_helper = read_project_file(%w(spec spec_helper.rb))
+    expect(spec_helper).to match(/Timecop.safe_mode = true/)
+  end
+
   def development_config
     @_development_config ||=
       read_project_file %w(config environments development.rb)

--- a/templates/spec_helper.rb
+++ b/templates/spec_helper.rb
@@ -10,6 +10,7 @@ if ENV.fetch("COVERAGE", false)
 end
 
 require "webmock/rspec"
+require "timecop"
 
 # http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
@@ -27,3 +28,6 @@ RSpec.configure do |config|
 end
 
 WebMock.disable_net_connect!(allow_localhost: true)
+
+# Only allow Timecop with block syntax
+Timecop.safe_mode = true


### PR DESCRIPTION
Safe mode forces you to use Timecop with the block syntax, which
always puts time back the way it was beforehand.

https://github.com/travisjeffery/timecop#timecopsafe_mode

This prevents accidentally writing tests where time is frozen but not reset to real time afterwards, which is a source of order dependent test failures.