### PR TITLE
Fix incorrect Timecop link

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ And testing gems like:
 * [RSpec Mocks](https://github.com/rspec/rspec-mocks) for stubbing and spying
 * [Shoulda Matchers](https://github.com/thoughtbot/shoulda-matchers) for common
   RSpec matchers
-* [Timecop](https://github.com/ferndopolis/timecop-console) for testing time
+* [Timecop](https://github.com/travisjeffery/timecop) for testing time
 
 ## Other goodies
 


### PR DESCRIPTION
Seems this was pointed to the wrong repo in a236ae4bb3d8c7f4858a36e13a00ca3244bf4a97.