### PR TITLE
Enforce SSL in production environment

### DIFF
--- a/lib/suspenders.rb
+++ b/lib/suspenders.rb
@@ -1,5 +1,6 @@
 require 'suspenders/version'
 require 'suspenders/generators/app_generator'
+require "suspenders/generators/enforce_ssl_generator"
 require 'suspenders/generators/static_generator'
 require 'suspenders/generators/stylesheet_base_generator'
 require 'suspenders/actions'

--- a/lib/suspenders/actions.rb
+++ b/lib/suspenders/actions.rb
@@ -30,7 +30,7 @@ module Suspenders
     def configure_environment(rails_env, config)
       inject_into_file(
         "config/environments/#{rails_env}.rb",
-        "\n\n  #{config}",
+        "\n  #{config}",
         before: "\nend"
       )
     end

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -150,11 +150,7 @@ module Suspenders
   config.middleware.use Rack::CanonicalHost, ENV.fetch("APPLICATION_HOST")
       RUBY
 
-      inject_into_file(
-        "config/environments/production.rb",
-        config,
-        after: "Rails.application.configure do",
-      )
+      configure_environment "production", config
     end
 
     def enable_rack_deflater

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -217,6 +217,7 @@ module Suspenders
 
     def generate_default
       run("spring stop")
+      generate("suspenders:enforce_ssl")
       generate("suspenders:static")
       generate("suspenders:stylesheet_base")
     end

--- a/lib/suspenders/generators/enforce_ssl_generator.rb
+++ b/lib/suspenders/generators/enforce_ssl_generator.rb
@@ -1,0 +1,12 @@
+require "rails/generators"
+require_relative "../actions"
+
+module Suspenders
+  class EnforceSslGenerator < Rails::Generators::Base
+    include Suspenders::Actions
+
+    def enforce_ssl
+      configure_environment "production", "config.force_ssl = true"
+    end
+  end
+end

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -132,6 +132,12 @@ RSpec.describe "Suspend a new project with default configuration" do
     )
   end
 
+  it "configures production environment to enforce SSL" do
+    expect(production_config).to match(
+      /^ +config.force_ssl = true/,
+    )
+  end
+
   it "raises on missing translations in development and test" do
     [development_config, test_config].each do |environment_file|
       expect(environment_file).to match(


### PR DESCRIPTION
This setting has been on for every thoughtbot Rails app I've touched
in the past year or two (maybe a dozen?).

* Use `configure_environment` helper method more consistently.
* Fixes https://github.com/thoughtbot/suspenders/issues/781

More about the pervasiveness of SSL in our ecosystem:

https://blog.heroku.com/announcing_heroku_free_ssl_beta_and_flexible_dyno_hours
https://letsencrypt.org/