### PR TITLE
Fix for action mailer asset_host: it should be a string, not an hash

### DIFF
--- a/lib/suspenders/actions.rb
+++ b/lib/suspenders/actions.rb
@@ -15,7 +15,7 @@ module Suspenders
     end
 
     def action_mailer_asset_host(rails_env, host)
-      config = "config.action_mailer.asset_host = { host: #{host} }"
+      config = "config.action_mailer.asset_host = #{host}"
       configure_environment(rails_env, config)
     end
 

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -299,9 +299,9 @@ Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i
 
     def configure_action_mailer
       action_mailer_host "development", %{"localhost:3000"}
-      action_mailer_asset_host "development", %{"localhost:3000"}
+      action_mailer_asset_host "development", %{"http://localhost:3000"}
       action_mailer_host "test", %{"www.example.com"}
-      action_mailer_asset_host "test", %{"www.example.com"}
+      action_mailer_asset_host "test", %{"http://www.example.com"}
       action_mailer_host "production", %{ENV.fetch("APPLICATION_HOST")}
       action_mailer_asset_host(
         "production",

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe "Suspend a new project with default configuration" do
   it "sets action mailer default host and asset host" do
     config_key = 'config\.action_mailer\.asset_host'
     config_value =
-      '{ host: ENV\.fetch\("ASSET_HOST", ENV\.fetch\("APPLICATION_HOST"\)\) }'
+      %q{ENV\.fetch\("ASSET_HOST", ENV\.fetch\("APPLICATION_HOST"\)\)}
     expect(production_config).to match(/#{config_key} = #{config_value}/)
   end
 


### PR DESCRIPTION
This PR fixes a problem introduced in https://github.com/thoughtbot/suspenders/pull/853 and regarding https://github.com/thoughtbot/suspenders/issues/843.

`config.action_mailer.asset_host` accepts a plain string, not an hash like its cousin `config.action_mailer.default_url_options` does.

Plus, I had to add the protocol (`http` for `development` and `test`). Rails would not add the protocol for you and so if you have a logo in your email its url would be something like `//localhost:3000/assets/logo.png`. If you open the email in your native mail client, for instance, it won't load the image. This is why I had to specificy `http:` for `asset_host`.

How to manage this protocol problem in production? In my last application, I defined an `ASSET_HOST` env variable to be like my `APPLICATION_HOST` env variable with the protocol at the beginning. So `ASSET_HOST` is now a mandatory env variable for my project, and I think it's not what `suspenders` wants. Any idea? Shall I presume every assets hosts respond to https, like so?:

`config.action_mailer.asset_host = "https://#{ENV.fetch('ASSET_HOST', ENV.fetch('APPLICATION_HOST'))}"`
