### PR TITLE
Remove vestigial `staging` references

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,6 @@ This:
 
 * Creates a staging and production Heroku app
 * Sets them as `staging` and `production` Git remotes
-* Configures staging with `RACK_ENV` environment variable set
-  to `staging`
 * Creates a [Heroku Pipeline] for review apps
 * Schedules automated backups for 10AM UTC for both `staging` and `production`
 

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -30,6 +30,7 @@ gem "webpacker"
 
 group :development do
   gem "listen"
+  gem "rack-mini-profiler", require: false
   gem "spring"
   gem "spring-commands-rspec"
   gem "web-console"
@@ -46,10 +47,6 @@ group :development, :test do
   gem "rspec-rails", "~> 3.6"
 end
 
-group :development, :staging do
-  gem "rack-mini-profiler", require: false
-end
-
 group :test do
   gem "capybara-webkit"
   gem "database_cleaner"
@@ -61,6 +58,6 @@ group :test do
   gem "webmock"
 end
 
-group :staging, :production do
+group :production do
   gem "rack-timeout"
 end

--- a/templates/postgresql_database.yml.erb
+++ b/templates/postgresql_database.yml.erb
@@ -17,5 +17,3 @@ production: &deploy
   pool: <%%= [Integer(ENV.fetch("MAX_THREADS", 5)), Integer(ENV.fetch("DB_POOL", 5))].max %>
   timeout: 5000
   url:  <%%= ENV.fetch("DATABASE_URL", "") %>
-
-staging: *deploy

--- a/templates/secrets.yml
+++ b/templates/secrets.yml
@@ -5,6 +5,4 @@ development:
 
 test:
 
-staging:
-
 production:


### PR DESCRIPTION
The staging environment is set to production as of
ffa20dbeec382d6a78704be15881d5dd1248d9df in order to:

* Simplify configuration
* Enforce staging/production parity
* Follow Heroku recommendations
  https://devcenter.heroku.com/articles/multiple-environments

For Honeybadger, we set a config variable `HONEYBADGER_ENV=staging`.

Related:

https://github.com/thoughtbot/suspenders/pull/743