### PR TITLE
Introduce a CI generator

### DIFF
--- a/lib/suspenders.rb
+++ b/lib/suspenders.rb
@@ -4,6 +4,7 @@ require "suspenders/generators/enforce_ssl_generator"
 require "suspenders/generators/initialize_active_job_generator"
 require 'suspenders/generators/static_generator'
 require 'suspenders/generators/stylesheet_base_generator'
+require 'suspenders/generators/ci_generator'
 require 'suspenders/actions'
 require "suspenders/adapters/heroku"
 require 'suspenders/app_builder'

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -254,10 +254,6 @@ config.public_file_server.headers = {
       copy_file "spec_helper.rb", "spec/spec_helper.rb"
     end
 
-    def configure_ci
-      template "circle.yml.erb", "circle.yml"
-    end
-
     def configure_i18n_for_test_environment
       copy_file "i18n.rb", "spec/support/i18n.rb"
     end

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -54,14 +54,14 @@ module Suspenders
       invoke :remove_routes_comment_lines
       invoke :setup_dotfiles
       invoke :setup_database
-      invoke :create_local_heroku_setup
-      invoke :create_heroku_apps
       invoke :create_github_repo
       invoke :setup_segment
       invoke :setup_bundler_audit
       invoke :setup_spring
       invoke :generate_default
       invoke :setup_default_directories
+      invoke :create_local_heroku_setup
+      invoke :create_heroku_apps
       invoke :outro
     end
 
@@ -221,6 +221,7 @@ module Suspenders
       generate("suspenders:enforce_ssl")
       generate("suspenders:static")
       generate("suspenders:stylesheet_base")
+      generate("suspenders:ci")
     end
 
     def outro

--- a/lib/suspenders/generators/ci_generator.rb
+++ b/lib/suspenders/generators/ci_generator.rb
@@ -1,0 +1,26 @@
+require "rails/generators"
+
+module Suspenders
+  class CiGenerator < Rails::Generators::Base
+    source_root File.expand_path(
+      File.join("..", "..", "..", "templates"),
+      File.dirname(__FILE__))
+
+    def simplecov_test_integration
+      inject_into_file "spec/spec_helper.rb", before: 'SimpleCov.start "rails"' do
+        <<-RUBY
+
+  if ENV["CIRCLE_ARTIFACTS"]
+    dir = File.join(ENV["CIRCLE_ARTIFACTS"], "coverage")
+    SimpleCov.coverage_dir(dir)
+  end
+
+        RUBY
+      end
+    end
+
+    def configure_ci
+      template "circle.yml.erb", "circle.yml"
+    end
+  end
+end

--- a/templates/spec_helper.rb
+++ b/templates/spec_helper.rb
@@ -1,11 +1,6 @@
 if ENV.fetch("COVERAGE", false)
   require "simplecov"
 
-  if ENV["CIRCLE_ARTIFACTS"]
-    dir = File.join(ENV["CIRCLE_ARTIFACTS"], "coverage")
-    SimpleCov.coverage_dir(dir)
-  end
-
   SimpleCov.start "rails"
 end
 


### PR DESCRIPTION
This introduces the `suspenders:ci` generator, which sets us up with a
continuous integration configuration. In this case, Circle CI 1.0.

This is 1.0 and not 2.0 because this is a refactoring, not a feature
change.

Move the Heroku configuration to the end so that we can be sure that
`circle.yml` exists by the time it runs.

---

This is a continuation from #511, in which we decided that all parts of Suspenders should move into generators. The battle is long but we will get this.

This is inspired by #844, which presents a solution that is orthogonal to our long-term goals set from #511. This replaces #844 (or certainly redefines it).