### PR TITLE
Introduce an email generator

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -94,20 +94,8 @@ module Suspenders
       inject_into_class 'config/application.rb', 'Application', config
     end
 
-    def configure_smtp
-      copy_file 'smtp.rb', 'config/smtp.rb'
-
-      prepend_file 'config/environments/production.rb',
-        %{require Rails.root.join("config/smtp")\n}
-
-      config = <<-RUBY
-
-  config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = SMTP_SETTINGS
-      RUBY
-
-      inject_into_file 'config/environments/production.rb', config,
-        after: "config.action_mailer.raise_delivery_errors = false"
+    def configure_local_mail
+      copy_file "email.rb", "config/initializers/email.rb"
     end
 
     def enable_rack_canonical_host

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -80,6 +80,7 @@ module Suspenders
 
     def setup_development_environment
       say 'Setting up the development environment'
+      build :configure_local_mail
       build :raise_on_missing_assets_in_test
       build :raise_on_delivery_errors
       build :set_test_delivery_method
@@ -92,7 +93,6 @@ module Suspenders
 
     def setup_production_environment
       say 'Setting up the production environment'
-      build :configure_smtp
       build :configure_rack_timeout
       build :enable_rack_canonical_host
       build :enable_rack_deflater
@@ -193,6 +193,7 @@ module Suspenders
       generate("suspenders:jobs")
       generate("suspenders:analytics")
       generate("suspenders:views")
+      generate("suspenders:production:email")
     end
 
     def outro

--- a/lib/suspenders/generators/production/email_generator.rb
+++ b/lib/suspenders/generators/production/email_generator.rb
@@ -1,0 +1,30 @@
+require "rails/generators"
+
+module Suspenders
+  module Production
+    class EmailGenerator < Rails::Generators::Base
+      source_root File.expand_path(
+        File.join("..", "..", "..", "templates"),
+        File.dirname(__FILE__),
+      )
+
+      def smtp_configuration
+        copy_file "smtp.rb", "config/smtp.rb"
+
+        prepend_file "config/environments/production.rb",
+          %{require Rails.root.join("config/smtp")\n\n}
+      end
+
+      def use_smtp
+        config = <<-RUBY
+
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = SMTP_SETTINGS
+        RUBY
+
+        inject_into_file "config/environments/production.rb", config,
+          after: "config.action_mailer.raise_delivery_errors = false"
+      end
+    end
+  end
+end

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -178,10 +178,12 @@ RSpec.describe "Suspend a new project with default configuration" do
     expect(production_config).not_to match(/"HOST"/)
   end
 
-  it "configures email interceptor in smtp config" do
-    smtp_file = IO.read("#{project_path}/config/smtp.rb")
-    expect(smtp_file).
-      to match(/RecipientInterceptor.new\(ENV\["EMAIL_RECIPIENTS"\]\)/)
+  it "configures email interceptor" do
+    email_file = File.join(project_path, "config", "initializers", "email.rb")
+    email_config = IO.read(email_file)
+
+    expect(email_config).
+      to include(%{RecipientInterceptor.new(ENV["EMAIL_RECIPIENTS"])})
   end
 
   it "configures language in html element" do

--- a/templates/email.rb
+++ b/templates/email.rb
@@ -1,0 +1,3 @@
+if ENV["EMAIL_RECIPIENTS"].present?
+  Mail.register_interceptor RecipientInterceptor.new(ENV["EMAIL_RECIPIENTS"])
+end

--- a/templates/smtp.rb
+++ b/templates/smtp.rb
@@ -7,7 +7,3 @@ SMTP_SETTINGS = {
   port: "587",
   user_name: ENV.fetch("SMTP_USERNAME")
 }
-
-if ENV["EMAIL_RECIPIENTS"].present?
-  Mail.register_interceptor RecipientInterceptor.new(ENV["EMAIL_RECIPIENTS"])
-end


### PR DESCRIPTION
This introduces `suspenders:production:email`, a generator that installs
our email settings for production. In this case it sets up SMTP with
variables based on environment variables.

I separated out the RecipientInterceptor configuration, since that is a
development- and testing-related configuration.