### PR TITLE
Fix normalize.css Sass import

### DIFF
--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -300,7 +300,7 @@ RSpec.describe "Suspend a new project with default configuration" do
 
     app_css = read_project_file(%w(app assets stylesheets application.scss))
     expect(app_css).to match(
-      /normalize\.css\/normalize\.css.*bourbon.*neat.*base.*refills/m,
+      /normalize\.css\/normalize.*bourbon.*neat.*base.*refills/m,
     )
   end
 

--- a/templates/application.scss
+++ b/templates/application.scss
@@ -1,6 +1,6 @@
 @charset "utf-8";
 
-@import "normalize.css/normalize.css";
+@import "normalize.css/normalize";
 
 @import "bourbon";
 @import "neat";


### PR DESCRIPTION
When an `@import` in Sass ends with `.css`, Sass doesn't pull that file
in as a partial and concatenate those styles with the rest of the
manifest. Rather, it outputs a CSS `@import`, which we don't want here.