### PR TITLE
Let `suspenders --api` work

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -120,7 +120,7 @@ module Suspenders
         "# config.action_controller.asset_host = 'http://assets.example.com'",
         'config.action_controller.asset_host = ENV.fetch("ASSET_HOST", ENV.fetch("APPLICATION_HOST"))'
 
-      if File.exist?('config/initializers/assets.rb')
+      if File.exist?("config/initializers/assets.rb")
         replace_in_file 'config/initializers/assets.rb',
           "config.assets.version = '1.0'",
           'config.assets.version = (ENV["ASSETS_VERSION"] || "1.0")'

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -120,9 +120,11 @@ module Suspenders
         "# config.action_controller.asset_host = 'http://assets.example.com'",
         'config.action_controller.asset_host = ENV.fetch("ASSET_HOST", ENV.fetch("APPLICATION_HOST"))'
 
-      replace_in_file 'config/initializers/assets.rb',
-        "config.assets.version = '1.0'",
-        'config.assets.version = (ENV["ASSETS_VERSION"] || "1.0")'
+      if File.exist?('config/initializers/assets.rb')
+        replace_in_file 'config/initializers/assets.rb',
+          "config.assets.version = '1.0'",
+          'config.assets.version = (ENV["ASSETS_VERSION"] || "1.0")'
+      end
 
       config = <<-EOD
 config.public_file_server.headers = {
@@ -278,8 +280,11 @@ you can deploy to staging and production with:
       EOS
 
       %w(500 404 422).each do |page|
-        inject_into_file "public/#{page}.html", meta_tags, after: "<head>\n"
-        replace_in_file "public/#{page}.html", /<!--.+-->\n/, ''
+        path = "public/#{page}.html"
+        if File.exist?(path)
+          inject_into_file path, meta_tags, after: "<head>\n"
+          replace_in_file path, /<!--.+-->\n/, ''
+        end
       end
     end
 

--- a/spec/features/api_spec.rb
+++ b/spec/features/api_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Suspend a new project with --api flag" do
 
     Dir.chdir(project_path) do
       Bundler.with_clean_env do
-        expect(`rake`).to include('0 failures')
+        expect(`rake`).to include("0 failures")
       end
     end
   end

--- a/spec/features/api_spec.rb
+++ b/spec/features/api_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+RSpec.describe "Suspend a new project with --api flag" do
+  before(:all) do
+    drop_dummy_database
+    remove_project_directory
+  end
+
+  it "ensures project specs pass" do
+    run_suspenders("--api")
+
+    Dir.chdir(project_path) do
+      Bundler.with_clean_env do
+        expect(`rake`).to include('0 failures')
+      end
+    end
+  end
+end


### PR DESCRIPTION
When running `suspenders --api`, there are some missing files in the
generated API-only Rails app compared to the non-API version, which
causes the suspenders generator to crash.

To fix this, just don't do anything when those files aren't found.

* There are no HTTP error pages, so `customize_error_pages` fails
* `config/initializers/assets.rb` is removed by the API generator, leading to this error:

```
    Setting up the production environment
          create  config/smtp.rb
        prepend  config/environments/production.rb
          insert  config/environments/production.rb
          append  config/environments/production.rb
          insert  config/environments/production.rb
          insert  config/environments/production.rb
    Traceback (most recent call last):
            25: from /Users/gabe/.rbenv/versions/2.5.0/bin/suspenders:23:in `<main>'
            24: from /Users/gabe/.rbenv/versions/2.5.0/bin/suspenders:23:in `load'
            23: from /Users/gabe/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/suspenders-1.46.0/bin/suspenders:23:in `<top (required)>'
            22: from /Users/gabe/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/thor-0.20.0/lib/thor/base.rb:466:in `start'
            21: from /Users/gabe/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/thor-0.20.0/lib/thor/group.rb:232:in `dispatch'
            20: from /Users/gabe/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/thor-0.20.0/lib/thor/invocation.rb:133:in `invoke_all'
            19: from /Users/gabe/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/thor-0.20.0/lib/thor/invocation.rb:133:in `map'
            18: from /Users/gabe/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/thor-0.20.0/lib/thor/invocation.rb:133:in `each'
            17: from /Users/gabe/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/thor-0.20.0/lib/thor/invocation.rb:133:in `block in invoke_all'
            16: from /Users/gabe/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
            15: from /Users/gabe/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
            14: from /Users/gabe/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/suspenders-1.46.0/lib/suspenders/generators/app_generator.rb:39:in `finish_template'
            13: from /Users/gabe/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/thor-0.20.0/lib/thor/invocation.rb:115:in `invoke'
            12: from /Users/gabe/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/thor-0.20.0/lib/thor/group.rb:230:in `dispatch'
            11: from /Users/gabe/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
            10: from /Users/gabe/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
            9: from /Users/gabe/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/suspenders-1.46.0/lib/suspenders/generators/app_generator.rb:46:in `suspenders_customization'
            8: from /Users/gabe/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/thor-0.20.0/lib/thor/invocation.rb:115:in `invoke'
            7: from /Users/gabe/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/thor-0.20.0/lib/thor/group.rb:230:in `dispatch'
            6: from /Users/gabe/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
            5: from /Users/gabe/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
            4: from /Users/gabe/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/suspenders-1.46.0/lib/suspenders/generators/app_generator.rb:99:in `setup_production_environment'
            3: from /Users/gabe/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/railties-5.1.5/lib/rails/generators/app_base.rb:151:in `build'
            2: from /Users/gabe/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/suspenders-1.46.0/lib/suspenders/app_builder.rb:135:in `setup_asset_host'
            1: from /Users/gabe/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/suspenders-1.46.0/lib/suspenders/actions.rb:5:in `replace_in_file'
    /Users/gabe/.rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/suspenders-1.46.0/lib/suspenders/actions.rb:5:in `read': No such file or directory @ rb_sysopen - /Users/gabe/code/personal/friendlyvents/config/initializers/assets.rb (Errno::ENOENT)
```