### PR TITLE
Use Heroku's release stage

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
+* Automatically db:migrate on Heroku releases
+* Don't override CircleCI deploys
 * Upgrade: Update to Ruby 2.5.1
 * Upgrade: Update to Rails 5.1.6
-
 
 1.46.0 (January 26, 2018)
 

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -243,7 +243,7 @@ you can deploy to staging and production with:
 
     def configure_automatic_deployment
       deploy_command = <<-EOS
-      release: bundle exec rails db:migrate
+release: bundle exec rails db:migrate
       EOS
 
       append_file "Procfile", deploy_command

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -242,15 +242,11 @@ you can deploy to staging and production with:
     end
 
     def configure_automatic_deployment
-      deploy_command = <<-YML.strip_heredoc
-      deployment:
-        staging:
-          branch: master
-          commands:
-            - bin/deploy staging
-      YML
+      deploy_command = <<-EOS
+      release: bundle exec rails db:migrate
+      EOS
 
-      append_file "circle.yml", deploy_command
+      append_file "Procfile", deploy_command
     end
 
     def create_github_repo(repo_name)

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -242,11 +242,7 @@ you can deploy to staging and production with:
     end
 
     def configure_automatic_deployment
-      deploy_command = <<-RELEASE
-release: bundle exec rails db:migrate
-      RELEASE
-
-      append_file "Procfile", deploy_command
+      append_file "Procfile", "release: bundle exec rails db:migrate"
     end
 
     def create_github_repo(repo_name)

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -242,9 +242,9 @@ you can deploy to staging and production with:
     end
 
     def configure_automatic_deployment
-      deploy_command = <<-EOS
+      deploy_command = <<-RELEASE
 release: bundle exec rails db:migrate
-      EOS
+      RELEASE
 
       append_file "Procfile", deploy_command
     end

--- a/spec/features/heroku_spec.rb
+++ b/spec/features/heroku_spec.rb
@@ -39,9 +39,7 @@ RSpec.describe "Heroku" do
 
       procfile = IO.read("#{project_path}/Procfile")
 
-      expect(procfile).to include <<-RELEASE
-release: bundle exec rails db:migrate
-      RELEASE
+      expect(procfile).to include("release: bundle exec rails db:migrate")
     end
   end
 

--- a/spec/features/heroku_spec.rb
+++ b/spec/features/heroku_spec.rb
@@ -39,9 +39,9 @@ RSpec.describe "Heroku" do
 
       procfile = IO.read("#{project_path}/Procfile")
 
-      expect(procfile).to include <<-EOS
-      release: bundle exec rails db:migrate
-      EOS
+      expect(procfile).to include <<-RELEASE
+release: bundle exec rails db:migrate
+      RELEASE
     end
   end
 

--- a/spec/features/heroku_spec.rb
+++ b/spec/features/heroku_spec.rb
@@ -37,16 +37,11 @@ RSpec.describe "Heroku" do
       expect(readme).to include("./bin/deploy staging")
       expect(readme).to include("./bin/deploy production")
 
-      circle_yml_path = "#{project_path}/circle.yml"
-      circle_yml = IO.read(circle_yml_path)
+      procfile = IO.read("#{project_path}/Procfile")
 
-      expect(circle_yml).to include <<-YML.strip_heredoc
-      deployment:
-        staging:
-          branch: master
-          commands:
-            - bin/deploy staging
-      YML
+      expect(procfile).to include <<-EOS
+      release: bundle exec rails db:migrate
+      EOS
     end
   end
 

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -257,8 +257,6 @@ RSpec.describe "Suspend a new project with default configuration" do
 
     expect(bin_setup).to include("PARENT_APP_NAME=#{app_name.dasherize}-staging")
     expect(bin_setup).to include("APP_NAME=#{app_name.dasherize}-staging-pr-$1")
-    expect(bin_setup).
-      to include("heroku run rails db:migrate --exit-code --app $APP_NAME")
     expect(bin_setup).to include("heroku ps:scale worker=1 --app $APP_NAME")
     expect(bin_setup).to include("heroku restart --app $APP_NAME")
 
@@ -269,7 +267,6 @@ RSpec.describe "Suspend a new project with default configuration" do
     bin_deploy_path = "#{project_path}/bin/deploy"
     bin_deploy = IO.read(bin_deploy_path)
 
-    expect(bin_deploy).to include("heroku run rails db:migrate --exit-code")
     expect(File.stat(bin_deploy_path)).to be_executable
   end
 

--- a/templates/bin_deploy
+++ b/templates/bin_deploy
@@ -8,5 +8,4 @@ branch="$(git symbolic-ref HEAD --short)"
 target="${1:-staging}"
 
 git push "$target" "$branch:master"
-heroku run rails db:migrate --exit-code --remote "$target"
 heroku restart --remote "$target"

--- a/templates/bin_setup_review_app.erb
+++ b/templates/bin_setup_review_app.erb
@@ -17,6 +17,5 @@ heroku pg:backups:capture --app $PARENT_APP_NAME
 URL=`heroku pg:backups public-url --app $PARENT_APP_NAME`
 
 heroku pg:backups restore $URL DATABASE_URL --confirm $APP_NAME --app $APP_NAME
-heroku run rails db:migrate --exit-code --app $APP_NAME
 heroku ps:scale worker=1 --app $APP_NAME
 heroku restart --app $APP_NAME


### PR DESCRIPTION
Heroku supports a `release` stage via Procfile which allows for custom commands to be run on deploy.

This allows us to remove repeated `db:migrate` statements from several places where our app interacts with Heroku.

Furthermore, it fixes https://github.com/thoughtbot/suspenders/issues/863 by avoiding using `bin/deploy` from CircleCI, allowing us to drop the custom CI build script from `circle.yml`.

Lastly, it paves the way for https://github.com/thoughtbot/suspenders/pull/859, by cleaning up the review app process.