### PR TITLE
suspenders:production:email can control app.json

### DIFF
--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -59,6 +59,7 @@ module Suspenders
       invoke :setup_default_directories
       invoke :create_local_heroku_setup
       invoke :create_heroku_apps
+      invoke :generate_production_default
       invoke :outro
     end
 
@@ -192,6 +193,9 @@ module Suspenders
       generate("suspenders:jobs")
       generate("suspenders:analytics")
       generate("suspenders:views")
+    end
+
+    def generate_production_default
       generate("suspenders:production:force_tls")
       generate("suspenders:production:email")
       generate("suspenders:production:timeout")

--- a/lib/suspenders/generators/production/email_generator.rb
+++ b/lib/suspenders/generators/production/email_generator.rb
@@ -1,8 +1,11 @@
 require "rails/generators"
+require_relative "../../actions"
 
 module Suspenders
   module Production
     class EmailGenerator < Rails::Generators::Base
+      include Suspenders::Actions
+
       source_root File.expand_path(
         File.join("..", "..", "..", "..", "templates"),
         File.dirname(__FILE__),
@@ -24,6 +27,18 @@ module Suspenders
 
         inject_into_file "config/environments/production.rb", config,
           after: "config.action_mailer.raise_delivery_errors = false"
+      end
+
+      def env_vars
+        expand_json(
+          "app.json",
+          env: {
+            SMTP_ADDRESS: { required: true },
+            SMTP_DOMAIN: { required: true },
+            SMTP_PASSWORD: { required: true },
+            SMTP_USERNAME: { required: true },
+          },
+        )
       end
     end
   end

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -276,7 +276,7 @@ RSpec.describe "Suspend a new project with default configuration" do
   it "creates heroku application manifest file with application name in it" do
     app_json_file = IO.read("#{project_path}/app.json")
 
-    expect(app_json_file).to match(/"name":"#{app_name.dasherize}"/)
+    expect(app_json_file).to match(/"name":\s*"#{app_name.dasherize}"/)
   end
 
   def app_name

--- a/spec/features/production/email_spec.rb
+++ b/spec/features/production/email_spec.rb
@@ -5,11 +5,43 @@ RSpec.describe "suspenders:production:email" do
     with_app { generate("suspenders:production:email") }
 
     expect("config/smtp.rb").to match_contents(%r{SMTP_SETTINGS\s*=})
+
     expect("config/environments/production.rb").to \
       match_contents(%r{require.+config/smtp})
     expect("config/environments/production.rb").to \
       match_contents(%r{action_mailer.delivery_method\s*=\s*:smtp})
     expect("config/environments/production.rb").to \
       match_contents(%r{action_mailer.smtp_settings\s*=\s*SMTP_SETTINGS})
+
+    expect("app.json").to contain_json(
+      env: {
+        SMTP_ADDRESS: { required: true },
+        SMTP_DOMAIN: { required: true },
+        SMTP_PASSWORD: { required: true },
+        SMTP_USERNAME: { required: true },
+      },
+    )
+  end
+
+  it "destroys the configuration for a production email deployment" do
+    with_app { destroy("suspenders:production:email") }
+
+    expect("config/smtp.rb").not_to exist_as_a_file
+
+    expect("config/environments/production.rb").not_to \
+      match_contents(%r{require.+config/smtp})
+    expect("config/environments/production.rb").not_to \
+      match_contents(%r{action_mailer.delivery_method\s*=\s*:smtp})
+    expect("config/environments/production.rb").not_to \
+      match_contents(%r{action_mailer.smtp_settings\s*=\s*SMTP_SETTINGS})
+
+    expect("app.json").not_to contain_json(
+      env: {
+        SMTP_ADDRESS: { required: true },
+        SMTP_DOMAIN: { required: true },
+        SMTP_PASSWORD: { required: true },
+        SMTP_USERNAME: { required: true },
+      },
+    )
   end
 end

--- a/spec/support/contain_json_matcher.rb
+++ b/spec/support/contain_json_matcher.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "json"
+
+RSpec::Matchers.define :contain_json do
+  match do
+    sub_json = expected
+    filename = actual
+
+    filepath = File.join(project_path, filename)
+    json = JSON.parse(IO.read(filepath), symbolize_names: true)
+    sub_json <= json
+  end
+
+  failure_message do
+    sub_json = expected
+    filename = actual
+
+    filepath = File.join(project_path, filename)
+    json = JSON.parse(IO.read(filepath), symbolize_names: true)
+
+    "in #{filename}, expected to find\n#{sub_json.inspect}\nin\n#{json.inspect}"
+  end
+end

--- a/spec/support/exist_as_a_file_matcher.rb
+++ b/spec/support/exist_as_a_file_matcher.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :exist_as_a_file do
+  match do |filename|
+    File.exist?(File.join(project_path, filename))
+  end
+end

--- a/spec/support/suspenders.rb
+++ b/spec/support/suspenders.rb
@@ -66,6 +66,15 @@ module SuspendersTestHelpers
     end
   end
 
+  def destroy(generator)
+    run_in_project do
+      with_revision_for_honeybadger do
+        `bin/spring stop`
+        `#{project_rails_bin} destroy #{generator}`
+      end
+    end
+  end
+
   def suspenders_help_command
     run_in_tmp do
       debug `#{suspenders_bin} -h`

--- a/templates/app.json.erb
+++ b/templates/app.json.erb
@@ -19,18 +19,6 @@
     },
     "SECRET_KEY_BASE":{
       "generator":"secret"
-    },
-    "SMTP_ADDRESS":{
-      "required":true
-    },
-    "SMTP_DOMAIN":{
-      "required":true
-    },
-    "SMTP_PASSWORD":{
-      "required":true
-    },
-    "SMTP_USERNAME":{
-      "required":true
     }
   },
   "addons":[


### PR DESCRIPTION
The `SMTP_ADDRESS`, `SMTP_DOMAIN`, `SMTP_PASSWORD`, and `SMTP_USERNAME`
variables are only required when dealing with emails in production, so
reflect that in our `app.json` and the `suspenders:production:email`
generator.

This introduces our first test for destroying a generator. It also
introduces some awesome code for un-merging a Hash from another Hash.

The Heroku actions create the `app.json`, so make sure they run before
we modify it. It makes sense to run all production generators after the
Heroku-specific actions, so make that clumping happen.