### PR TITLE
A few things around tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_install:
   - "echo '--colour' > ~/.rspec"
   - git config --global user.name 'Travis CI'
   - git config --global user.email 'travis-ci@example.com'
+  - gem install bundler
   - gem update --system
 install: bundle install
 notifications:

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -184,7 +184,9 @@ module Suspenders
       generate("suspenders:testing")
       generate("suspenders:ci")
       generate("suspenders:js_driver")
-      generate("suspenders:forms")
+      unless options[:api]
+        generate("suspenders:forms")
+      end
       generate("suspenders:db_optimizations")
       generate("suspenders:factories")
       generate("suspenders:lint")

--- a/suspenders.gemspec
+++ b/suspenders.gemspec
@@ -32,4 +32,9 @@ rush to build something amazing; don't use it if you like missing deadlines.
   s.add_dependency 'rails', Suspenders::RAILS_VERSION
 
   s.add_development_dependency 'rspec', '~> 3.2'
+
+  # Needed by the tests themselves
+  s.add_development_dependency 'capybara-webkit'
+  s.add_development_dependency 'factory_bot_rails'
+  s.add_development_dependency 'bullet'
 end


### PR DESCRIPTION
- Ruby upgrade, in which I learn that there are at least two additional
dev dependencies because of the nature of the beast.
- Silence simple_form when the --api flag is passed, thanks to a test
introduced in #902.
- Manually install bundler on Travis due to an [incompatibility] within a
smattering of tools.

[incompatibility]: https://github.com/travis-ci/travis-ci/issues/9333