### PR TITLE
Run 'bundle install' after adding new gems

### DIFF
--- a/lib/suspenders/generators/db_optimizations_generator.rb
+++ b/lib/suspenders/generators/db_optimizations_generator.rb
@@ -4,6 +4,7 @@ module Suspenders
   class DbOptimizationsGenerator < Rails::Generators::Base
     def add_bullet
       gem "bullet", group: %i(development test)
+      Bundler.with_clean_env { run "bundle install" }
     end
 
     def configure_bullet

--- a/lib/suspenders/generators/factories_generator.rb
+++ b/lib/suspenders/generators/factories_generator.rb
@@ -9,6 +9,7 @@ module Suspenders
 
     def add_factory_bot
       gem "factory_bot_rails", group: %i(development test)
+      Bundler.with_clean_env { run "bundle install" }
     end
 
     def set_up_factory_bot_for_rspec

--- a/lib/suspenders/generators/js_driver_generator.rb
+++ b/lib/suspenders/generators/js_driver_generator.rb
@@ -9,6 +9,7 @@ module Suspenders
 
     def add_gems
       gem "capybara-webkit", group: :test
+      Bundler.with_clean_env { run "bundle install" }
     end
 
     def configure_capybara_webkit


### PR DESCRIPTION
Fixes #910

Adding gems in a generator without rerunning `bundle install` can cause
problems. If the gems aren't already installed on the system, the
remaining generators will fail with a bundler error.