### PR TITLE
Update to Rails 5.2.0

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -162,7 +162,7 @@ config.public_file_server.headers = {
       end
     end
 
-    def set_ruby_to_version_being_used
+    def ruby_version
       create_file '.ruby-version', "#{Suspenders::RUBY_VERSION}\n"
     end
 

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -64,7 +64,6 @@ module Suspenders
 
     def customize_gemfile
       build :replace_gemfile, options[:path]
-      build :set_ruby_to_version_being_used
       bundle_command 'install'
     end
 

--- a/lib/suspenders/version.rb
+++ b/lib/suspenders/version.rb
@@ -1,5 +1,5 @@
 module Suspenders
-  RAILS_VERSION = "~> 5.1.6".freeze
+  RAILS_VERSION = "~> 5.2.0".freeze
   RUBY_VERSION = IO.
     read("#{File.dirname(__FILE__)}/../../.ruby-version").
     strip.

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -21,6 +21,7 @@ gem "skylight"
 gem "sprockets", ">= 3.0.0"
 gem "title"
 gem "uglifier"
+gem "bootsnap", require: false
 <% if options[:webpack] %>
 gem "webpacker"
 <% end %>


### PR DESCRIPTION
Rails 5.2.0 will give us ActiveStorage and all sorts of other goodies:
http://edgeguides.rubyonrails.org/5_2_release_notes.html

rails/rails#30016 introduced `Rails::AppBuilder#ruby_version` to create
a .ruby_version file. To avoid getting stuck in an overwrite prompt
when we try to create our own .ruby_version file based on
`Suspenders::RUBY_VERSION`, I overrode `#ruby_version`.

Rails 5.2.0 adds bootsnap to the Gemfile and to config/boot.rb. I added it
to our Gemfile, but we could also `skip_bootsnap` by default if we don't
want to use it.