### PR TITLE
Use HTTPS url for Github Hub script

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ bypass this with the `--skip-git` option:
 You can optionally create a GitHub repository for the suspended Rails app. It
 requires that you have [Hub](https://github.com/github/hub) on your system:
 
-    curl http://hub.github.com/standalone -sLo ~/bin/hub && chmod +x ~/bin/hub
+    curl https://hub.github.com/standalone -sLo ~/bin/hub && chmod +x ~/bin/hub
     suspenders app --github organization/project
 
 This has the same effect as running:


### PR DESCRIPTION
To prevent MITM attacks and to follow general best practices, change the `hub` url from `http://hub.github.com/standalone` to `https://hub.github.com/standalone`