### PR TITLE
Switch to ENV configuration of Rack::Timeout

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+* Bug fix: change production timeouts generator to use working configuration
+  method with latest version of Rack::Timeout
+
 1.47.0 (May 25, 2018)
 
 * Bug fix: normalize.css Sass import is concatenated with other styles now

--- a/lib/suspenders/generators/production/timeout_generator.rb
+++ b/lib/suspenders/generators/production/timeout_generator.rb
@@ -8,13 +8,13 @@ module Suspenders
       end
 
       def configure_rack_timeout
-        append_file "config/environments/production.rb", rack_timeout_config
+        append_file ".env", rack_timeout_config
       end
 
       private
 
       def rack_timeout_config
-        %{Rack::Timeout.timeout = ENV.fetch("RACK_TIMEOUT", 10).to_i}
+        %{RACK_TIMEOUT_SERVICE_TIMEOUT=10}
       end
     end
   end


### PR DESCRIPTION
Resolves #918

Rack::Timeout v0.5.0 removed legacy setter methods used for
configuration (https://github.com/heroku/rack-timeout/pull/125) such
that the configuration added by Suspenders causes a NoMethodError when
initializing Rails in the production environment (e.g. during Heroku
deployment). This PR switches to using environment variable-based
configuration of Rack::Timeout, matching the recommendations in the
README.