### PR TITLE
Fix mysql and sqlite3 database option bug

### DIFF
--- a/spec/features/database_spec.rb
+++ b/spec/features/database_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
-RSpec.shared_context 'Project Setup Hook' do |option|
+RSpec.shared_context "Project Setup Hook" do |option|
   before :context do
     drop_dummy_database
     remove_project_directory
@@ -11,21 +11,21 @@ RSpec.shared_context 'Project Setup Hook' do |option|
   end
 end
 
-RSpec.describe 'Suspend a new project with custom database option' do
-  context '--database=sqlite3' do
-    include_context 'Project Setup Hook', '--database=sqlite3'
+RSpec.describe "Suspend a new project with custom database option" do
+  context "--database=sqlite3" do
+    include_context "Project Setup Hook", "--database=sqlite3"
 
-    it 'adds sqlite3 to Gemfile' do
+    it "adds sqlite3 to Gemfile" do
       gemfile = IO.read "#{project_path}/Gemfile"
 
       expect(gemfile).to match(/sqlite3/)
     end
   end
 
-  context '--database=mysql' do
-    include_context 'Project Setup Hook', '--database=mysql'
+  context "--database=mysql" do
+    include_context "Project Setup Hook", "--database=mysql"
 
-    it 'adds mysql2 to Gemfile' do
+    it "adds mysql2 to Gemfile" do
       gemfile = IO.read "#{project_path}/Gemfile"
 
       expect(gemfile).to match(/mysql2/)

--- a/spec/features/database_spec.rb
+++ b/spec/features/database_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.shared_context 'Project Setup Hook' do |option|
+  before :context do
+    drop_dummy_database
+    remove_project_directory
+    run_suspenders option
+    setup_app_dependencies
+  end
+end
+
+RSpec.describe 'Suspend a new project with custom database option' do
+  context '--database=sqlite3' do
+    include_context 'Project Setup Hook', '--database=sqlite3'
+
+    it 'adds sqlite3 to Gemfile' do
+      gemfile = IO.read "#{project_path}/Gemfile"
+
+      expect(gemfile).to match(/sqlite3/)
+    end
+  end
+
+  context '--database=mysql' do
+    include_context 'Project Setup Hook', '--database=mysql'
+
+    it 'adds mysql2 to Gemfile' do
+      gemfile = IO.read "#{project_path}/Gemfile"
+
+      expect(gemfile).to match(/mysql2/)
+    end
+  end
+end

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -11,7 +11,13 @@ gem "autoprefixer-rails"
 gem "flutie"
 gem "honeybadger"
 gem "jquery-rails"
+<% if "sqlite3" == options[:database] %>
+gem "sqlite3", "~> 1.3"
+<% elsif "mysql" == options[:database] %>
+gem "mysql2", "~> 0.5.2"
+<% else %>
 gem "pg", "~> 0.18"
+<% end %>
 gem "puma"
 gem "rack-canonical-host"
 gem "rails", "<%= Suspenders::RAILS_VERSION %>"


### PR DESCRIPTION
Resolves #893 and adds support for mysql.

Running `suspenders` with the `--database` option set to anything other than the default caused the following error to occur:
````
Specified 'some_other_database' for database adapter, but the gem is not loaded. Add `gem 'some_other_database_gem'` to your Gemfile (and ensure its version is at the minimum required by ActiveRecord).
````

This PR adds conditional statements to the Gemfile.erb template in order to add the appropriate gem to the Gemfile.