### PR TITLE
Add tzinfo-data on Windows

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -20,6 +20,7 @@ gem "sass-rails", "~> 5.0"
 gem "skylight"
 gem "sprockets", ">= 3.0.0"
 gem "title"
+gem "tzinfo-data", platforms: [:mingw, :x64_mingw, :mswin, :jruby]
 gem "uglifier"
 gem "bootsnap", require: false
 <% if options[:webpack] %>


### PR DESCRIPTION
On Windows, the tzinfo-data gem is required, and Rails fails with an error if it is started without it. This PR adds it to the default Gemfile.