### PR TITLE
Remove body_class helper and Flutie

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -8,7 +8,6 @@ end
 ruby "<%= Suspenders::RUBY_VERSION %>"
 
 gem "autoprefixer-rails"
-gem "flutie"
 gem "honeybadger"
 gem "jquery-rails"
 gem "pg", "~> 0.18"

--- a/templates/suspenders_layout.html.erb.erb
+++ b/templates/suspenders_layout.html.erb.erb
@@ -13,7 +13,7 @@
   <%%= stylesheet_link_tag :application, media: "all" %>
   <%%= csrf_meta_tags %>
 </head>
-<body class="<%%= body_class %>">
+<body>
   <%%= render "flashes" -%>
   <%%= yield %>
   <%%= render "javascript" %>


### PR DESCRIPTION
Having body classes creates a slippery slope to page-based styling,
rather than object-oriented styling.