### PR TITLE
Use Release Phase for database migration

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -217,15 +217,7 @@ config.public_file_server.headers = {
     end
 
     def configure_automatic_deployment
-      deploy_command = <<-YML.strip_heredoc
-      deployment:
-        staging:
-          branch: master
-          commands:
-            - bin/deploy staging
-      YML
-
-      append_file "circle.yml", deploy_command
+      append_file "Procfile", "release: bin/auto_migrate"
     end
 
     def create_github_repo(repo_name)

--- a/lib/suspenders/generators/production/manifest_generator.rb
+++ b/lib/suspenders/generators/production/manifest_generator.rb
@@ -10,6 +10,7 @@ module Suspenders
           scripts: {},
           env: {
             APPLICATION_HOST: { required: true },
+            AUTO_MIGRATE_DB: { value: "true" },
             EMAIL_RECIPIENTS: { required: true },
             HEROKU_APP_NAME: { required: true },
             HEROKU_PARENT_APP_NAME: { required: true },

--- a/templates/bin_auto_migrate
+++ b/templates/bin_auto_migrate
@@ -1,0 +1,5 @@
+ set -e
+
+ if [ -n "$AUTO_MIGRATE_DB" ]; then
+   bundle exec rake db:migrate
+ fi

--- a/templates/bin_deploy
+++ b/templates/bin_deploy
@@ -8,5 +8,3 @@ branch="$(git symbolic-ref HEAD --short)"
 target="${1:-staging}"
 
 git push "$target" "$branch:master"
-heroku run rails db:migrate --exit-code --remote "$target"
-heroku restart --remote "$target"

--- a/templates/bin_setup_review_app.erb
+++ b/templates/bin_setup_review_app.erb
@@ -17,6 +17,5 @@ heroku pg:backups:capture --app $PARENT_APP_NAME
 URL=`heroku pg:backups public-url --app $PARENT_APP_NAME`
 
 heroku pg:backups restore $URL DATABASE_URL --confirm $APP_NAME --app $APP_NAME
-heroku run rails db:migrate --exit-code --app $APP_NAME
 heroku ps:scale worker=1 --app $APP_NAME
 heroku restart --app $APP_NAME


### PR DESCRIPTION
Heroku's [Release Phase](https://devcenter.heroku.com/articles/release-phase) feature provides a much better migration experience for a production deploy of a Rails application.

Without using a release phase task, here's how you migrate your database
in production:

1. Deploy your application via Git or pipeline promotion.
2. With the migration deployed, run `rake db:migrate`.
3. Immediately restart the application so that Rails is now aware of the
schema changes.

This process is awkward and can lengthen downtime in deploys. It results
in the application being restarted twice (once for the deployment of
code, and then again post-migration), and also may push application
logic that depends on the new code into production before the migration
has run or finished, which can lead to unnecessary exceptions.

There are strategies to mitigate these problems, but they generally
involve many small commits and deploys that must be carefully
orchestrated (not pushed all at once) that can be laborious and error
prone.

This commit leverages the Heroku Release Phase task to execute a
smoother migration. Here's how the process works:

1. Start your deploy with Git or a pipeline promotion
2. Heroku builds or promotes your application slug
3. Before deploying the application code to dynos, a run dyno is started
and it executes the release phase task. In this case, it's a shell
script that runs `rake db:migrate` if the application has an
`AUTO_MIGRATE_DB` environment variable set.
4. After the migration finishes, Heroku deploys the application and
restarts. If the release phase failed (migration problem), the deploy does not
proceed.

This process reduces the chance of new application code that depends on
the un-run migration being deployed and reduces the number of
application restarts from two to one. We've been using it at CommonLit
for several months now and noticed a dramatic downturn in
deployment-related downtime.