### PR TITLE
Fix email generator

### DIFF
--- a/lib/suspenders/generators/production/email_generator.rb
+++ b/lib/suspenders/generators/production/email_generator.rb
@@ -26,7 +26,7 @@ module Suspenders
         RUBY
 
         inject_into_file "config/environments/production.rb", config,
-          after: "config.action_mailer.raise_delivery_errors = false"
+          after: "config.action_mailer.perform_caching = false"
       end
 
       def env_vars


### PR DESCRIPTION
The email generator attempts to inject SMTP config into `config/environments/production.rb` after the line `config.action_mailer.raise_delivery_errors = false`. This line is not found anymore and thus fails (NB: find reference).

I propose the code is injected after `config.action_mailer.perform_caching = false` instead.

In production, you may experience the following error as action mailer attempts to use the default port 25:

```
Connection refused - connect(2) for "localhost" port 25
/app/vendor/ruby-2.5.1/lib/ruby/2.5.0/net/smtp.rb:539:in `initialize'
/app/vendor/ruby-2.5.1/lib/ruby/2.5.0/net/smtp.rb:539:in `open'
/app/vendor/ruby-2.5.1/lib/ruby/2.5.0/net/smtp.rb:539:in `tcp_socket'
/app/vendor/ruby-2.5.1/lib/ruby/2.5.0/net/smtp.rb:549:in `block in do_start'
/app/vendor/ruby-2.5.1/lib/ruby/2.5.0/timeout.rb:93:in `block in timeout'
/app/vendor/ruby-2.5.1/lib/ruby/2.5.0/timeout.rb:103:in `timeout'
/app/vendor/ruby-2.5.1/lib/ruby/2.5.0/net/smtp.rb:548:in `do_start'
/app/vendor/ruby-2.5.1/lib/ruby/2.5.0/net/smtp.rb:518:in `start'
...
...
```