### PR TITLE
We need to install JS dependencies in setup

### DIFF
--- a/templates/bin_setup
+++ b/templates/bin_setup
@@ -10,6 +10,9 @@ set -e
 gem install bundler --conservative
 bundle check || bundle install
 
+# Install JavaScript dependencies
+bin/yarn
+
 # Set up database and add any development seed data
 bin/rails dev:prime
 


### PR DESCRIPTION
This gets run when first creating a Suspenders project but not on setup. It should be.