### PR TITLE
Remove noodp robots meta tag from error pages

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -275,7 +275,6 @@ you can deploy to staging and production with:
     def customize_error_pages
       meta_tags =<<-EOS
   <meta charset="utf-8" />
-  <meta name="ROBOTS" content="NOODP" />
   <meta name="viewport" content="initial-scale=1" />
       EOS
 


### PR DESCRIPTION
Related to #933 - The Open Directory Project has closed down.