### PR TITLE
Strip extra newline from the production config

### DIFF
--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -48,8 +48,6 @@ module Suspenders
       invoke :configure_app
       invoke :copy_miscellaneous_files
       invoke :customize_error_pages
-      invoke :remove_config_comment_lines
-      invoke :remove_routes_comment_lines
       invoke :setup_dotfiles
       invoke :setup_database
       invoke :create_github_repo
@@ -60,6 +58,8 @@ module Suspenders
       invoke :create_local_heroku_setup
       invoke :create_heroku_apps
       invoke :generate_production_default
+      invoke :remove_config_comment_lines
+      invoke :remove_routes_comment_lines
       invoke :outro
     end
 


### PR DESCRIPTION
With e09a56d we are getting a failing spec because of an extra newline
in the production config. Removing comments later will take care of the
extra newlines, and I think may have made e09a56d unnecessary.