### PR TITLE
Drop jquery-rails gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ It includes application gems like:
   helpers
 * [High Voltage](https://github.com/thoughtbot/high_voltage) for static pages
 * [Honeybadger](https://honeybadger.io) for exception notification
-* [jQuery Rails](https://github.com/rails/jquery-rails) for jQuery
 * [Neat](https://github.com/thoughtbot/neat) for semantic grids
 * [Normalize](https://necolas.github.io/normalize.css/) for resetting browser styles
 * [Postgres](https://github.com/ged/ruby-pg) for access to the Postgres database

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -9,7 +9,6 @@ ruby "<%= Suspenders::RUBY_VERSION %>"
 
 gem "autoprefixer-rails"
 gem "honeybadger"
-gem "jquery-rails"
 gem "pg"
 gem "puma"
 gem "rack-canonical-host"

--- a/templates/_javascript.html.erb
+++ b/templates/_javascript.html.erb
@@ -1,10 +1,3 @@
 <%= javascript_include_tag :application %>
 
 <%= yield :javascript %>
-
-<% if Rails.env.test? %>
-  <%= javascript_tag do %>
-    $.fx.off = true;
-    $.ajaxSetup({ async: false });
-  <% end %>
-<% end %>


### PR DESCRIPTION
Rails dropped jQuery as a dependency back in
https://github.com/rails/rails/pull/27113. That commit removed
'jquery-ujs' from the application.js and replaced it with 'rails-ujs'.
Since we aren't using 'jquery-ujs', we don't need the 'jquery-rails'
gem.

As for the test JS, `$.fx.off = true` shouldn't be necessary if
we aren't using jQuery, and `$.ajaxSetup({ async: false });` seems
to have been for Akephalos, which we no longer use.

For your amusement: https://robots.thoughtbot.com/thoughtbot-and-the-holy-grail