### PR TITLE
Move the review app check before asset host

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -102,6 +102,7 @@ module Suspenders
       config = <<-RUBY
   if ENV.fetch("HEROKU_APP_NAME", "").include?("staging-pr-")
     ENV["APPLICATION_HOST"] = ENV["HEROKU_APP_NAME"] + ".herokuapp.com"
+    ENV["ASSET_HOST"] = ENV["HEROKU_APP_NAME"] + ".herokuapp.com"
   end
       RUBY
 

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -98,13 +98,22 @@ module Suspenders
       copy_file "email.rb", "config/initializers/email.rb"
     end
 
-    def enable_rack_canonical_host
+    def set_application_host_for_review_apps
       config = <<-RUBY
-
   if ENV.fetch("HEROKU_APP_NAME", "").include?("staging-pr-")
     ENV["APPLICATION_HOST"] = ENV["HEROKU_APP_NAME"] + ".herokuapp.com"
   end
+      RUBY
 
+      inject_into_file(
+        "config/environments/production.rb",
+        config,
+        after: "Rails.application.configure do\n",
+      )
+    end
+
+    def enable_rack_canonical_host
+      config = <<-RUBY
   config.middleware.use Rack::CanonicalHost, ENV.fetch("APPLICATION_HOST")
       RUBY
 

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -93,6 +93,7 @@ module Suspenders
 
     def setup_production_environment
       say 'Setting up the production environment'
+      build :set_application_host_for_review_apps
       build :enable_rack_canonical_host
       build :enable_rack_deflater
       build :setup_asset_host


### PR DESCRIPTION
The ASSET_HOST environment variable needs to be set correctly on Heroku review apps. Before this change the review app check was happening *after* the setting of the asset host and consequently assets weren't loading.

This moves the review app check to the top of the config file so the ASSET_HOST gets set correctly on review apps.