### PR TITLE
Use parent strategy for factories

### DIFF
--- a/templates/factory_bot_rspec.rb
+++ b/templates/factory_bot_rspec.rb
@@ -1,3 +1,5 @@
+FactoryBot.use_parent_strategy = true
+
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION
Setting `FactoryBot.use_parent_strategy = true` allows objects made with
the build strategy to use `build` instead of `create` for any
associations. Using this setting will generally reduce the number of
calls to `create`, and makes `build` generally
[a little faster](https://gist.github.com/composerinteralia/d4796df9140f431e36f88dfb6fe9733a) than `build_stubbed`.