### PR TITLE
Use sassc-compatible versions of neat and bourbon

### DIFF
--- a/lib/suspenders/generators/stylesheet_base_generator.rb
+++ b/lib/suspenders/generators/stylesheet_base_generator.rb
@@ -7,8 +7,8 @@ module Suspenders
       File.dirname(__FILE__))
 
     def add_stylesheet_gems
-      gem "bourbon", "~> 5.0"
-      gem "neat", "~> 2.1"
+      gem "bourbon", ">= 5.0.1"
+      gem "neat", ">= 3.0.1"
       Bundler.with_clean_env { run "bundle install" }
     end
 


### PR DESCRIPTION
To merge #936, we need to make sure we have a version of bourbon with
https://github.com/thoughtbot/bourbon/commit/8257c683f8a250c06407f66d077dfbe6ce6595b0
and a version of neat with
https://github.com/thoughtbot/neat/commit/a092ff79a5f81be5a01328f9daa5e15f97b4a58a

I also got rid of the pessimistic version constraint so a fresh
suspenders run will always give us the latest versions of these gems.