### PR TITLE
Downgrade Bundler on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,10 @@ rvm: 2.5.3
 cache: bundler
 sudo: false
 before_install:
-  - "echo '--colour' > ~/.rspec"
   - git config --global user.name 'Travis CI'
   - git config --global user.email 'travis-ci@example.com'
-  - gem install bundler
   - gem update --system
+  - gem install bundler -v '< 2'
 install: bundle install
 notifications:
   email: false


### PR DESCRIPTION
Bundler 2.0.1 works with Rails, but [the released version of
bundler-audit hardcodes a dependency on 1.x]. [Downgrade Bundler on Travis]
until [the new bundler-audit] is out.

[the released version of bundler-audit hardcodes a dependency on 1.x]: https://github.com/rubysec/bundler-audit/issues/202
[Downgrade Bundler on Travis]: https://docs.travis-ci.com/user/languages/ruby/#bundler-20
[the new bundler-audit]: https://github.com/rubysec/bundler-audit/pull/203