### PR TITLE
Suspenders::Generators::Base base class

### DIFF
--- a/lib/suspenders/generators/analytics_generator.rb
+++ b/lib/suspenders/generators/analytics_generator.rb
@@ -1,12 +1,7 @@
-require "rails/generators"
+require_relative "base"
 
 module Suspenders
-  class AnalyticsGenerator < Rails::Generators::Base
-    source_root File.expand_path(
-      File.join("..", "..", "..", "templates"),
-      File.dirname(__FILE__),
-    )
-
+  class AnalyticsGenerator < Generators::Base
     def install_partial
       copy_file "_analytics.html.erb",
         "app/views/application/_analytics.html.erb"

--- a/lib/suspenders/generators/base.rb
+++ b/lib/suspenders/generators/base.rb
@@ -1,0 +1,20 @@
+require "rails/generators"
+require_relative "../actions"
+
+module Suspenders
+  module Generators
+    class Base < Rails::Generators::Base
+      include Suspenders::Actions
+
+      def self.default_source_root
+        File.expand_path(File.join("..", "..", "..", "templates"), __dir__)
+      end
+
+      private
+
+      def app_name
+        Rails.app_class.parent_name.demodulize.underscore.dasherize
+      end
+    end
+  end
+end

--- a/lib/suspenders/generators/ci_generator.rb
+++ b/lib/suspenders/generators/ci_generator.rb
@@ -1,11 +1,7 @@
-require "rails/generators"
+require_relative "base"
 
 module Suspenders
-  class CiGenerator < Rails::Generators::Base
-    source_root File.expand_path(
-      File.join("..", "..", "..", "templates"),
-      File.dirname(__FILE__))
-
+  class CiGenerator < Generators::Base
     def simplecov_test_integration
       inject_into_file "spec/spec_helper.rb", before: 'SimpleCov.start "rails"' do
         <<-RUBY

--- a/lib/suspenders/generators/db_optimizations_generator.rb
+++ b/lib/suspenders/generators/db_optimizations_generator.rb
@@ -1,7 +1,7 @@
-require "rails/generators"
+require_relative "base"
 
 module Suspenders
-  class DbOptimizationsGenerator < Rails::Generators::Base
+  class DbOptimizationsGenerator < Generators::Base
     def add_bullet
       gem "bullet", group: %i(development test)
       Bundler.with_clean_env { run "bundle install" }

--- a/lib/suspenders/generators/factories_generator.rb
+++ b/lib/suspenders/generators/factories_generator.rb
@@ -1,12 +1,7 @@
-require "rails/generators"
+require_relative "base"
 
 module Suspenders
-  class FactoriesGenerator < Rails::Generators::Base
-    source_root File.expand_path(
-      File.join("..", "..", "..", "templates"),
-      File.dirname(__FILE__),
-    )
-
+  class FactoriesGenerator < Generators::Base
     def add_factory_bot
       gem "factory_bot_rails", group: %i(development test)
       Bundler.with_clean_env { run "bundle install" }

--- a/lib/suspenders/generators/forms_generator.rb
+++ b/lib/suspenders/generators/forms_generator.rb
@@ -1,7 +1,7 @@
-require "rails/generators"
+require_relative "base"
 
 module Suspenders
-  class FormsGenerator < Rails::Generators::Base
+  class FormsGenerator < Generators::Base
     def add_simple_form
       gem "simple_form"
       Bundler.with_clean_env { run "bundle install" }

--- a/lib/suspenders/generators/jobs_generator.rb
+++ b/lib/suspenders/generators/jobs_generator.rb
@@ -1,17 +1,7 @@
-require "rails/generators"
-require_relative "../actions"
+require_relative "base"
 
 module Suspenders
-  class JobsGenerator < Rails::Generators::Base
-    include Suspenders::Actions
-
-    source_root(
-      File.expand_path(
-        File.join("..", "..", "..", "templates"),
-        File.dirname(__FILE__),
-      ),
-    )
-
+  class JobsGenerator < Generators::Base
     def add_jobs_gem
       gem "delayed_job_active_record"
       Bundler.with_clean_env { run "bundle install" }

--- a/lib/suspenders/generators/js_driver_generator.rb
+++ b/lib/suspenders/generators/js_driver_generator.rb
@@ -1,12 +1,7 @@
-require "rails/generators"
+require_relative "base"
 
 module Suspenders
-  class JsDriverGenerator < Rails::Generators::Base
-    source_root File.expand_path(
-      File.join("..", "..", "..", "templates"),
-      File.dirname(__FILE__),
-    )
-
+  class JsDriverGenerator < Generators::Base
     def add_gems
       gem "capybara-selenium", group: :test
       gem "chromedriver-helper", group: :test

--- a/lib/suspenders/generators/json_generator.rb
+++ b/lib/suspenders/generators/json_generator.rb
@@ -1,7 +1,7 @@
-require "rails/generators"
+require_relative "base"
 
 module Suspenders
-  class JsonGenerator < Rails::Generators::Base
+  class JsonGenerator < Generators::Base
     def add_oj
       gem "oj"
       Bundler.with_clean_env { run "bundle install" }

--- a/lib/suspenders/generators/lint_generator.rb
+++ b/lib/suspenders/generators/lint_generator.rb
@@ -1,12 +1,7 @@
-require "rails/generators"
+require_relative "base"
 
 module Suspenders
-  class LintGenerator < Rails::Generators::Base
-    source_root File.expand_path(
-      File.join("..", "..", "..", "templates"),
-      File.dirname(__FILE__),
-    )
-
+  class LintGenerator < Generators::Base
     def set_up_hound
       copy_file "hound.yml", ".hound.yml"
     end

--- a/lib/suspenders/generators/production/deployment_generator.rb
+++ b/lib/suspenders/generators/production/deployment_generator.rb
@@ -1,13 +1,8 @@
-require "rails/generators"
+require_relative "../base"
 
 module Suspenders
   module Production
-    class DeploymentGenerator < Rails::Generators::Base
-      source_root File.expand_path(
-        File.join("..", "..", "..", "..", "templates"),
-        File.dirname(__FILE__),
-      )
-
+    class DeploymentGenerator < Generators::Base
       def copy_script
         copy_file "bin_deploy", "bin/deploy"
         chmod "bin/deploy", 0o755

--- a/lib/suspenders/generators/production/email_generator.rb
+++ b/lib/suspenders/generators/production/email_generator.rb
@@ -1,16 +1,8 @@
-require "rails/generators"
-require_relative "../../actions"
+require_relative "../base"
 
 module Suspenders
   module Production
-    class EmailGenerator < Rails::Generators::Base
-      include Suspenders::Actions
-
-      source_root File.expand_path(
-        File.join("..", "..", "..", "..", "templates"),
-        File.dirname(__FILE__),
-      )
-
+    class EmailGenerator < Generators::Base
       def smtp_configuration
         copy_file "smtp.rb", "config/smtp.rb"
 

--- a/lib/suspenders/generators/production/force_tls_generator.rb
+++ b/lib/suspenders/generators/production/force_tls_generator.rb
@@ -1,11 +1,8 @@
-require "rails/generators"
-require_relative "../../actions"
+require_relative "../base"
 
 module Suspenders
   module Production
-    class ForceTlsGenerator < Rails::Generators::Base
-      include Suspenders::Actions
-
+    class ForceTlsGenerator < Generators::Base
       def config_enforce_ssl
         configure_environment "production", "config.force_ssl = true"
       end

--- a/lib/suspenders/generators/production/manifest_generator.rb
+++ b/lib/suspenders/generators/production/manifest_generator.rb
@@ -1,11 +1,8 @@
-require "rails/generators"
-require_relative "../../actions"
+require_relative "../base"
 
 module Suspenders
   module Production
-    class ManifestGenerator < Rails::Generators::Base
-      include Suspenders::Actions
-
+    class ManifestGenerator < Generators::Base
       def render_manifest
         expand_json(
           "app.json",
@@ -21,12 +18,6 @@ module Suspenders
           },
           addons: ["heroku-postgresql"],
         )
-      end
-
-      private
-
-      def app_name
-        Rails.application.class.parent_name.demodulize.underscore.dasherize
       end
     end
   end

--- a/lib/suspenders/generators/production/timeout_generator.rb
+++ b/lib/suspenders/generators/production/timeout_generator.rb
@@ -1,8 +1,8 @@
-require "rails/generators"
+require_relative "../base"
 
 module Suspenders
   module Production
-    class TimeoutGenerator < Rails::Generators::Base
+    class TimeoutGenerator < Generators::Base
       def add_gem
         gem "rack-timeout", group: :production
       end

--- a/lib/suspenders/generators/staging/pull_requests_generator.rb
+++ b/lib/suspenders/generators/staging/pull_requests_generator.rb
@@ -1,16 +1,8 @@
-require "rails/generators"
-require_relative "../../actions"
+require_relative "../base"
 
 module Suspenders
   module Staging
-    class PullRequestsGenerator < Rails::Generators::Base
-      include Suspenders::Actions
-
-      source_root File.expand_path(
-        File.join("..", "..", "..", "..", "templates"),
-        File.dirname(__FILE__),
-      )
-
+    class PullRequestsGenerator < Generators::Base
       def configure_heroku_staging_pr_pipeline_host
         config = <<-RUBY
 
@@ -35,12 +27,6 @@ module Suspenders
         )
 
         run "chmod a+x bin/setup_review_app"
-      end
-
-      private
-
-      def app_name
-        Rails.application.class.parent_name.demodulize.underscore.dasherize
       end
     end
   end

--- a/lib/suspenders/generators/static_generator.rb
+++ b/lib/suspenders/generators/static_generator.rb
@@ -1,7 +1,7 @@
-require "rails/generators"
+require_relative "base"
 
 module Suspenders
-  class StaticGenerator < Rails::Generators::Base
+  class StaticGenerator < Generators::Base
     def add_high_voltage
       gem "high_voltage"
       Bundler.with_clean_env { run "bundle install" }

--- a/lib/suspenders/generators/stylesheet_base_generator.rb
+++ b/lib/suspenders/generators/stylesheet_base_generator.rb
@@ -1,11 +1,7 @@
-require "rails/generators"
+require_relative "base"
 
 module Suspenders
-  class StylesheetBaseGenerator < Rails::Generators::Base
-    source_root File.expand_path(
-      File.join("..", "..", "..", "templates"),
-      File.dirname(__FILE__))
-
+  class StylesheetBaseGenerator < Generators::Base
     def add_stylesheet_gems
       gem "bourbon", ">= 5.0.1"
       gem "neat", ">= 3.0.1"

--- a/lib/suspenders/generators/testing_generator.rb
+++ b/lib/suspenders/generators/testing_generator.rb
@@ -1,12 +1,7 @@
-require "rails/generators"
+require_relative "base"
 
 module Suspenders
-  class TestingGenerator < Rails::Generators::Base
-    source_root File.expand_path(
-      File.join("..", "..", "..", "templates"),
-      File.dirname(__FILE__),
-    )
-
+  class TestingGenerator < Generators::Base
     def add_testing_gems
       gem "spring-commands-rspec", group: :development
       gem "rspec-rails", "~> 3.6", group: %i(development test)

--- a/lib/suspenders/generators/views_generator.rb
+++ b/lib/suspenders/generators/views_generator.rb
@@ -1,12 +1,7 @@
-require "rails/generators"
+require_relative "base"
 
 module Suspenders
-  class ViewsGenerator < Rails::Generators::Base
-    source_root File.expand_path(
-      File.join("..", "..", "..", "templates"),
-      File.dirname(__FILE__),
-    )
-
+  class ViewsGenerator < Generators::Base
     def create_partials_directory
       empty_directory "app/views/application"
     end


### PR DESCRIPTION
We keep repeating the same code; time to extract it into a shared
object. Since Thor pulls us into inheritance, use a superclass.

This superclass includes our custom actions, defines an app name, and
sets the source root. I could not figure out how to use the
`source_root` class method; since we're inheriting from the
Rails::Generators::Base we can override the `default_source_root` class
method instead to achieve the same effect.