### PR TITLE
`bin/setup`: Join with `heroku apps:info`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+Unreleased
+
+* Changed: replace `heroku join` calls with `heroku apps:info` in `bin/setup`
+
 1.53.0 (August 23, 2019)
 * Upgraded: Rails 6.0.
 * New generator: `suspenders:inline_svg` for setting up the inline_svg gem.

--- a/lib/suspenders/adapters/heroku.rb
+++ b/lib/suspenders/adapters/heroku.rb
@@ -92,7 +92,7 @@ module Suspenders
         heroku_app_name = heroku_app_name_for(environment)
         <<~SHELL
 
-          if heroku join --app #{heroku_app_name} > /dev/null 2>&1; then
+          if heroku apps:info --app #{heroku_app_name} > /dev/null 2>&1; then
             git remote add #{environment} git@heroku.com:#{heroku_app_name}.git || true
             printf 'You are a collaborator on the "#{heroku_app_name}" Heroku app\n'
           else

--- a/spec/adapters/heroku_spec.rb
+++ b/spec/adapters/heroku_spec.rb
@@ -11,9 +11,9 @@ module Suspenders
         Heroku.new(app_builder).set_heroku_remotes
 
         expect(app_builder).to have_received(:append_file).
-          with(setup_file, /heroku join --app #{app_name.dasherize}-production/)
+          with(setup_file, /heroku apps:info --app #{app_name.dasherize}-production/)
         expect(app_builder).to have_received(:append_file).
-          with(setup_file, /heroku join --app #{app_name.dasherize}-staging/)
+          with(setup_file, /heroku apps:info --app #{app_name.dasherize}-staging/)
       end
 
       it "sets the heroku rails secrets" do

--- a/spec/features/heroku_spec.rb
+++ b/spec/features/heroku_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe "Heroku" do
       bin_setup_path = "#{project_path}/bin/setup"
       bin_setup = IO.read(bin_setup_path)
 
-      expect(bin_setup).to match(/^if heroku join --app #{app_name}-production/)
-      expect(bin_setup).to match(/^if heroku join --app #{app_name}-staging/)
+      expect(bin_setup).to assert_access_to_heroku_app("#{app_name}-production")
+      expect(bin_setup).to assert_access_to_heroku_app("#{app_name}-staging")
       expect(bin_setup).to match(/^git config heroku.remote staging/)
       expect("bin/setup").to be_executable
 
@@ -50,6 +50,10 @@ RSpec.describe "Heroku" do
       expect(FakeHeroku).to have_created_app_for("staging", "--region eu")
       expect(FakeHeroku).to have_created_app_for("production", "--region eu")
     end
+  end
+
+  def assert_access_to_heroku_app(app_name)
+    match(/^if heroku apps:info --app #{app_name}/)
   end
 
   def clean_up


### PR DESCRIPTION
Adding a local remote for the Heroku environments with `heroku join`
consistently fails. In the time since this line was first introduced,
the semantics of the CLI's heroku join call might have changed.

Since this line serves as a guard to ensure that the local machine has
proper access to the Heroku application, replace `heroku join` with
`heroku apps:info` to check for whether or not the command line has
access to the deployment's metadata.

Since we're interested in the exit code of `heroku apps:info` and not
the content, pipe the output to `/dev/null`.