### PR TITLE
Switch hound file to target sass-lint

### DIFF
--- a/templates/hound.yml
+++ b/templates/hound.yml
@@ -10,5 +10,8 @@ ruby:
   # config_file: .ruby-style.yml
   enabled: true
 scss:
-  # config_file: .scss-style.yml
+  enabled: false
+sass:
+#   config_file: .sass-lint.yml
   enabled: true
+  


### PR DESCRIPTION
`scss-lint` is no longer maintained, and has been supplanted by `sass-lint`
Repo: https://github.com/sasstools/sass-lint