### PR TITLE
Fix ExpandJson merging

### DIFF
--- a/lib/suspenders/actions.rb
+++ b/lib/suspenders/actions.rb
@@ -39,7 +39,7 @@ module Suspenders
       end
 
       def invoke!
-        write_out { |existing_json| existing_json.merge(data) }
+        write_out { |existing_json| existing_json.deep_merge(data) }
       end
 
       def revoke!
@@ -60,7 +60,7 @@ module Suspenders
       end
 
       def existing_json
-        JSON.parse(IO.read(destination_file))
+        JSON.parse(IO.read(destination_file), symbolize_names: true)
       rescue Errno::ENOENT
         {}
       end

--- a/spec/expand_json_spec.rb
+++ b/spec/expand_json_spec.rb
@@ -1,0 +1,89 @@
+require "spec_helper"
+
+RSpec.describe Suspenders::Actions::ExpandJson do
+  let(:destination_root) { File.join(root_path, "tmp") }
+  let(:destination_file_name) { "app.json" }
+  let(:destination_path) { File.join(destination_root, destination_file_name) }
+
+  before do
+    FileUtils.rm destination_path if File.exist?(destination_path)
+  end
+
+  describe "#invoke!" do
+    context "when calling multiple times with the same root key" do
+      before do
+        described_class.new(
+          destination_root,
+          destination_file_name,
+          env: {
+            SMTP_ADDRESS: { required: true },
+          },
+        ).invoke!
+      end
+
+      it "deep merges the hash" do
+        described_class.new(
+          destination_root,
+          destination_file_name,
+          env: {
+            HEROKU_APP_NAME: { required: true },
+          },
+        ).invoke!
+
+        expected = <<~JSON
+          {
+            "env": {
+              "SMTP_ADDRESS": {
+                "required": true
+              },
+              "HEROKU_APP_NAME": {
+                "required": true
+              }
+            }
+          }
+        JSON
+        expect(existing_json).to eq(expected.chomp)
+      end
+    end
+  end
+
+  describe "#revoke!" do
+    before do
+      described_class.new(
+        destination_root,
+        destination_file_name,
+        env: {
+          foo: { required: true },
+          bar: { required: true },
+        },
+      ).invoke!
+    end
+
+    it "removes data from the JSON" do
+      described_class.new(
+        destination_root,
+        destination_file_name,
+        env: {
+          foo: { required: true },
+        },
+      ).revoke!
+
+      expected = <<~JSON
+        {
+          "env": {
+            "bar": {
+              "required": true
+            }
+          }
+        }
+      JSON
+      expect(existing_json).to eq(expected.chomp)
+    end
+  end
+
+  private
+
+  def existing_json
+    IO.read(destination_path)
+  end
+end


### PR DESCRIPTION
When running suspenders 1.50.0 I get this `app.json` file:

```json
{
  "name": "cccc",
  "scripts": {
  },
  "env": {
    "APPLICATION_HOST": {
      "required": true
    },
    "EMAIL_RECIPIENTS": {
      "required": true
    },
    "HEROKU_APP_NAME": {
      "required": true
    },
    "HEROKU_PARENT_APP_NAME": {
      "required": true
    },
    "RACK_ENV": {
      "required": true
    },
    "SECRET_KEY_BASE": {
      "generator": "secret"
    }
  },
  "addons": [
    "heroku-postgresql"
  ],
  "env": {
    "SMTP_ADDRESS": {
      "required": true
    },
    "SMTP_DOMAIN": {
      "required": true
    },
    "SMTP_PASSWORD": {
      "required": true
    },
    "SMTP_USERNAME": {
      "required": true
    }
  }
}
```

As you can see there are 2 `env` keys. I think we should have only one `env` key. Am I right?

This happens because [`ExpandJson`](https://github.com/thoughtbot/suspenders/blob/master/lib/suspenders/actions.rb#L34) class thinks to work always with `symbol`s ([here](https://github.com/thoughtbot/suspenders/blob/master/lib/suspenders/generators/production/manifest_generator.rb#L11) and [here](https://github.com/thoughtbot/suspenders/blob/master/lib/suspenders/generators/production/email_generator.rb#L27)) but when you save an hash as JSON and you parse it back ([here](https://github.com/thoughtbot/suspenders/blob/master/lib/suspenders/actions.rb#L63)), the `symbol`s are gone: the keys are strings.

Plus we need a `deep_merge` and not only a `merge`, otherwise we won't be able to edit a 2nd level hash.

This PR is a WIP because I don't know if I found a bug or if I completely misunderstood `ExpandJson` class. Can you please tell me? :)

Thank you!