### PR TITLE
Avoid installing autoprefixer in api mode

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -7,7 +7,9 @@ end
 
 ruby "<%= Suspenders::RUBY_VERSION %>"
 
+<% unless options[:api] %>
 gem "autoprefixer-rails"
+<% end %>
 gem "honeybadger"
 gem "pg"
 gem "puma"


### PR DESCRIPTION
spec/features/api_spec.rb is failing on CI because Rails 5.2.3 in API
mode isn't playing well with autoprefixer-rails. It doesn't really make
sense to have a gem for CSS in API mode.