### PR TITLE
Check for the environment, not DATABASE_URL

### DIFF
--- a/templates/rails_helper.rb
+++ b/templates/rails_helper.rb
@@ -1,7 +1,10 @@
 ENV["RACK_ENV"] = "test"
 
 require File.expand_path("../../config/environment", __FILE__)
-abort("DATABASE_URL environment variable is set") if ENV["DATABASE_URL"]
+
+if Rails.env.production?
+  abort("The Rails environment is running in production mode!")
+end
 
 require "rspec/rails"
 


### PR DESCRIPTION
Suspenders was checking for the presence of `DATABASE_URL` to see if it
was running in production. This isn't so reliable in practice as
`DATABASE_URL` can be used in other environments. The spirit of this was
originally to stop you truncating a production database, which checking
for the Rails environment acheives.

https://github.com/thoughtbot/suspenders/issues/872
https://github.com/rspec/rspec-rails/pull/1383