### PR TITLE
Replace feature specs with system specs

### DIFF
--- a/lib/suspenders/generators/testing_generator.rb
+++ b/lib/suspenders/generators/testing_generator.rb
@@ -28,9 +28,9 @@ module Suspenders
       )
     end
 
-    def configure_spec_support_features
-      empty_directory_with_keep_file "spec/features"
-      empty_directory_with_keep_file "spec/support/features"
+    def configure_system_tests
+      empty_directory_with_keep_file "spec/system"
+      empty_directory_with_keep_file "spec/support/system"
     end
 
     def configure_i18n_for_test_environment

--- a/templates/rails_helper.rb
+++ b/templates/rails_helper.rb
@@ -7,13 +7,13 @@ require "rspec/rails"
 
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |file| require file }
 
-module Features
-  # Extend this module in spec/support/features/*.rb
+module SystemTestHelper
+  # Extend this module in spec/support/system/*.rb
   include Formulaic::Dsl
 end
 
 RSpec.configure do |config|
-  config.include Features, type: :feature
+  config.include SystemTestHelper, type: :system
   config.infer_base_class_for_anonymous_controllers = false
   config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = true


### PR DESCRIPTION
RSpec [suggests using system tests over feature specs][rspec]. Starting
a new project with suspenders I was surprised that I did not have access
to the Formulaic::Dsl available in my system specs.

This commit replaces the old feature spec setup with an equivalent
system spec setup, allowing system tests to have access to the
Formulaic::Dsl

[rspec]: https://rspec.info/blog/2017/10/rspec-3-7-has-been-released/#rails-actiondispatchsystemtest-integration-system-specs