### PR TITLE
Silence Puma's startup messages in JS specs

### DIFF
--- a/lib/suspenders/generators/js_driver_generator.rb
+++ b/lib/suspenders/generators/js_driver_generator.rb
@@ -8,8 +8,12 @@ module Suspenders
       Bundler.with_clean_env { run "bundle install" }
     end
 
-    def configure_chromedriver
+    def configure_capybara
       copy_file "chromedriver.rb", "spec/support/chromedriver.rb"
+      copy_file(
+        "capybara_silence_puma.rb",
+        "spec/support/capybara_silence_puma.rb",
+      )
     end
   end
 end

--- a/templates/capybara_silence_puma.rb
+++ b/templates/capybara_silence_puma.rb
@@ -1,0 +1,1 @@
+Capybara.server = :puma, { Silent: true }


### PR DESCRIPTION
When Capybara starts the first JavaScript spec of a run, it starts Puma
and prints out the Puma startup messages:

    Capybara starting Puma...
    * Version 3.12.1 , codename: Llamas in Pajamas
    * Min threads: 0, max threads: 4
    * Listening on tcp://127.0.0.1:62516

By setting `Silent: true`, we can prevent those messages from being printed.

A bit of background: https://github.com/rspec/rspec-rails/issues/1897

Proof that Capybara uses Puma as its default server: https://github.com/teamcapybara/capybara/blob/3.24.0/lib/capybara.rb#L247-L249
