### PR TITLE
Make Chromedriver truly headless

### DIFF
--- a/templates/chromedriver.rb
+++ b/templates/chromedriver.rb
@@ -8,14 +8,9 @@ Capybara.register_driver :headless_chrome do |app|
   options = ::Selenium::WebDriver::Chrome::Options.new
   options.headless!
 
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: %w(headless disable-gpu) },
-  )
-
   Capybara::Selenium::Driver.new app,
     browser: :chrome,
-    options: options,
-    desired_capabilities: capabilities
+    options: options
 end
 
 Capybara.javascript_driver = :headless_chrome

--- a/templates/chromedriver.rb
+++ b/templates/chromedriver.rb
@@ -5,12 +5,16 @@ Capybara.register_driver :chrome do |app|
 end
 
 Capybara.register_driver :headless_chrome do |app|
+  options = ::Selenium::WebDriver::Chrome::Options.new
+  options.headless!
+
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
     chromeOptions: { args: %w(headless disable-gpu) },
   )
 
   Capybara::Selenium::Driver.new app,
     browser: :chrome,
+    options: options,
     desired_capabilities: capabilities
 end
 


### PR DESCRIPTION
When I use Suspenders' configuration on a new project, JavaScript tests open up the Chrome app in a real window (i.e. not headless).

When using the configuration in this commit, Chrome quietly bounces once, in the taskbar (on macOS), and does not create a window.