### PR TITLE
Set a bigger window for `save_and_open_screenshot`

### DIFF
--- a/templates/chromedriver.rb
+++ b/templates/chromedriver.rb
@@ -7,6 +7,7 @@ end
 Capybara.register_driver :headless_chrome do |app|
   options = ::Selenium::WebDriver::Chrome::Options.new
   options.headless!
+  options.add_argument "--window-size=1680,1050"
 
   Capybara::Selenium::Driver.new app,
     browser: :chrome,


### PR DESCRIPTION
1680x1050 is the size of a 15" retina Macbook Pro.

Without this setting, `save_and_open_screenshot` captures perhaps 75% of the screen, which makes it much less useful for debugging.

I'm sure some people have bigger screens, and could use an even larger window size, but this feels like a good default.