### PR TITLE
Fixes typo in example group type

### DIFF
--- a/spec/features/staging/pull_requests_spec.rb
+++ b/spec/features/staging/pull_requests_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.describe "suspenders:staging:pull_requests", type: :generators do
+RSpec.describe "suspenders:staging:pull_requests", type: :generator do
   it "generates the configuration for Heroku pipeline review apps" do
     with_app { generate("suspenders:staging:pull_requests") }
 


### PR DESCRIPTION
https://github.com/thoughtbot/suspenders/pull/956 introduced the `:generator` type.

This fixes a typo in the type name.