### PR TITLE
Add documentation for Deploying to Heroku to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ Suspenders also comes with:
 
 ## Heroku
 
+Read the documentation on [deploying to Heroku](heroku deploy)
+
 You can optionally create Heroku staging and production apps:
 
     suspenders app --heroku true
@@ -131,6 +133,7 @@ This:
 * Schedules automated backups for 10AM UTC for both `staging` and `production`
 
 [Heroku Pipeline]: https://devcenter.heroku.com/articles/pipelines
+[heroku deploy]: https://github.com/thoughtbot/suspenders/docs/heroku_deploy.md
 
 You can optionally specify alternate Heroku flags:
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Suspenders also comes with:
 
 ## Heroku
 
-Read the documentation on [deploying to Heroku](heroku deploy)
+Read the documentation on [deploying to Heroku][heroku deploy]
 
 You can optionally create Heroku staging and production apps:
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ This:
 * Schedules automated backups for 10AM UTC for both `staging` and `production`
 
 [Heroku Pipeline]: https://devcenter.heroku.com/articles/pipelines
-[heroku deploy]: https://github.com/thoughtbot/suspenders/docs/heroku_deploy.md
+[heroku deploy]: https://github.com/thoughtbot/suspenders/blob/master/docs/heroku_deploy.md
 
 You can optionally specify alternate Heroku flags:
 

--- a/docs/heroku_deploy.md
+++ b/docs/heroku_deploy.md
@@ -1,0 +1,22 @@
+# Deploying to Heroku
+
+## Setup
+
+Deploying to Heroku requires two additional steps:
+
+1. Manually add buildpacks `node.js` and `ruby` (in that order) to your Heroku
+   app. This is necessary because build order is important and Heroku's
+   auto-detection will add them in the wrong order.
+
+2. Set the following environment variables:
+
+- `ASSET_HOST`: `siteURL.herokuapp.com`
+- `APPLICATION_HOST`: `siteURL.herokuapp.com`
+- `SMTP_ADDRESS`: `smtp.example.com`
+- `SMTP_DOMAIN`: `example.com`
+- `SMTP_USERNAME`: `username`
+- `SMTP_PASSWORD`: `password`
+
+## Execution
+
+- Use the `./bin/deploy` convention for deploying to Heroku


### PR DESCRIPTION
I think that the process of deploying to Heroku has created enough [confusion](https://github.com/thoughtbot/suspenders/issues/935) and [frustration](https://github.com/thoughtbot/suspenders/issues/919#issuecomment-421632156) that it's time to add a simple summary of the setup required to the documentation about it. This should be updated and expanded or contracted when new issues arise or are resolved.