### PR TITLE
Bump Rails version to 6.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,5 @@ before_install:
 install: bundle install
 notifications:
   email: false
+services:
+  - postgresql

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -185,7 +185,6 @@ module Suspenders
       generate("suspenders:lint")
       generate("suspenders:jobs")
       generate("suspenders:analytics")
-      generate("suspenders:views")
     end
 
     def generate_deployment_default
@@ -195,6 +194,10 @@ module Suspenders
       generate("suspenders:production:timeout")
       generate("suspenders:production:deployment")
       generate("suspenders:production:manifest")
+    end
+
+    def generate_views
+      generate("suspenders:views")
     end
 
     def outro

--- a/lib/suspenders/version.rb
+++ b/lib/suspenders/version.rb
@@ -1,5 +1,5 @@
 module Suspenders
-  RAILS_VERSION = "~> 5.2.3".freeze
+  RAILS_VERSION = "~> 6.0.0".freeze
   RUBY_VERSION = IO.
     read("#{File.dirname(__FILE__)}/../../.ruby-version").
     strip.

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -308,7 +308,7 @@ RSpec.describe "Suspend a new project with default configuration" do
   end
 
   it "doesn't use turbolinks" do
-    app_js = read_project_file(%w(app assets javascripts application.js))
+    app_js = read_project_file(%w(app javascript packs application.js))
     expect(app_js).not_to match(/turbolinks/)
   end
 

--- a/suspenders.gemspec
+++ b/suspenders.gemspec
@@ -32,4 +32,5 @@ rush to build something amazing; don't use it if you like missing deadlines.
   s.add_dependency 'rails', Suspenders::RAILS_VERSION
 
   s.add_development_dependency 'rspec', '~> 3.2'
+  s.add_development_dependency 'rack-timeout'
 end

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -21,11 +21,8 @@ gem "skylight"
 gem "sprockets", ">= 3.0.0"
 gem "title"
 gem "tzinfo-data", platforms: [:mingw, :x64_mingw, :mswin, :jruby]
-gem "uglifier"
 gem "bootsnap", require: false
-<% if options[:webpack] %>
 gem "webpacker"
-<% end %>
 
 group :development do
   gem "listen"

--- a/templates/_javascript.html.erb
+++ b/templates/_javascript.html.erb
@@ -1,3 +1,3 @@
-<%= javascript_include_tag :application %>
+<%= javascript_pack_tag :application %>
 
 <%= yield :javascript %>

--- a/templates/dotfiles/.env
+++ b/templates/dotfiles/.env
@@ -5,7 +5,6 @@ PORT=3000
 RACK_ENV=development
 RACK_MINI_PROFILER=0
 SECRET_KEY_BASE=development_secret
-EXECJS_RUNTIME=Node
 SMTP_ADDRESS=smtp.example.com
 SMTP_DOMAIN=example.com
 SMTP_PASSWORD=password


### PR DESCRIPTION
In addition to bumping the Rails version, this commit makes a couple JS
changes to support Rails using webpacker by default.

The remaining changes were to get CI to pass:

- Explicitly adding the travis postgresql service might not have solved
the test failures I was having, but it did make some warnings go away.
- I don't fully understand why we need to add rack_timeout as a
development dependency and not any of the other gems, but it made Travis
happy
- I also don't fully understand why I needed to move the
`suspenders:views` generator last. The tests passed locally without
that change, and I was able to generate a working application regardless
of the order. But on CI, the generators that ran just after
`suspenders:views` were failing with errors about `flashes_helper.rb`
not existing. There is something fishy going on there, and I spent a lot
of time debugging without success. I am suspicious of bootsnap and
zeitwerk, both of which appeared in the stack trace. Since the order of
this generator doesn't matter much, I would like to go forward with this
workaround. I may come back and debug more later to see if there is a
bug somewhere.