### PR TITLE
Address deprecated method name

### DIFF
--- a/lib/suspenders/generators/base.rb
+++ b/lib/suspenders/generators/base.rb
@@ -13,7 +13,7 @@ module Suspenders
       private
 
       def app_name
-        Rails.app_class.parent_name.demodulize.underscore.dasherize
+        Rails.app_class.module_parent_name.demodulize.underscore.dasherize
       end
     end
   end


### PR DESCRIPTION
```
DEPRECATION WARNING: `Module#parent_name` has been renamed to
`module_parent_name`. `parent_name` is deprecated and will be removed in
Rails 6.1.
```