### PR TITLE
Remove browserslist

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -242,7 +242,6 @@ config.public_file_server.headers = {
     end
 
     def copy_miscellaneous_files
-      copy_file "browserslist", "browserslist"
       copy_file "errors.rb", "config/initializers/errors.rb"
       copy_file "json_encoding.rb", "config/initializers/json_encoding.rb"
     end

--- a/templates/browserslist
+++ b/templates/browserslist
@@ -1,3 +1,0 @@
-Last 2 versions
-Explorer >= 11
-Android >= 4.4


### PR DESCRIPTION
Fixes #993

Webpacker already generates `.browserslistrc`, which is not compatible
with `browserslist`. I decided to go with the default options provided
by the [webpacker `.browserslistrc`][browserslistrc], rather than trying
to override it with our own, to minimize maintenance in suspenders as
more browsers become unused.

[browserslistrc]: https://github.com/rails/webpacker/blob/master/lib/install/config/.browserslistrc