### PR TITLE
Use the latest version of bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
   - git config --global user.name 'Travis CI'
   - git config --global user.email 'travis-ci@example.com'
   - gem update --system
-  - gem install bundler -v '< 2'
+  - gem install bundler
 install: bundle install
 notifications:
   email: false


### PR DESCRIPTION
a0b8511ed downgraded bundler because bundler-audit had a pessimistic
constraint on bundler. bundler-audit has since released a version that
works with bundler 2.