### PR TITLE
Use spring-watcher-listen gem

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -25,9 +25,8 @@ gem "tzinfo-data", platforms: [:mingw, :x64_mingw, :mswin, :jruby]
 gem "webpacker"
 
 group :development do
-  gem "listen"
   gem "rack-mini-profiler", require: false
-  gem "spring"
+  gem "spring-watcher-listen"
   gem "web-console"
 end
 


### PR DESCRIPTION
Closes #950

Back in 2014 the [spring listen watcher was extracted into a gem][b614].
Since that time, the listen gem has been in our Gemfile not doing
anything. Both spring and listen are dependencies of
spring-watcher-listen, so we can replace them both.

[b614]: https://github.com/rails/spring/commit/b614d94e83d863ffcb3eec06c6b2bb9250d5b5a5