### PR TITLE
Remove unnecessary dev dependency

### DIFF
--- a/lib/suspenders/generators/production/timeout_generator.rb
+++ b/lib/suspenders/generators/production/timeout_generator.rb
@@ -5,6 +5,7 @@ module Suspenders
     class TimeoutGenerator < Generators::Base
       def add_gem
         gem "rack-timeout", group: :production
+        Bundler.with_clean_env { run "bundle install" }
       end
 
       def configure_rack_timeout

--- a/suspenders.gemspec
+++ b/suspenders.gemspec
@@ -32,5 +32,4 @@ rush to build something amazing; don't use it if you like missing deadlines.
   s.add_dependency 'rails', Suspenders::RAILS_VERSION
 
   s.add_development_dependency 'rspec', '~> 3.2'
-  s.add_development_dependency 'rack-timeout'
 end


### PR DESCRIPTION
Travis was complaining about missing `rack-timeout` gem because, even if
we defined the `rack-timeout` as a `production` only gem, when we run
`bundle install` we install all of the gems, regardless of the
environment.

I added the `bundle install` command in the timeout generator, so this
should remove the need of a dev dependency on `rack-timeout`