### PR TITLE
Fix broken tests after the new heroku deploy flow change

### DIFF
--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -256,8 +256,6 @@ RSpec.describe "Suspend a new project with default configuration" do
 
     expect(bin_setup).to include("PARENT_APP_NAME=#{app_name.dasherize}-staging")
     expect(bin_setup).to include("APP_NAME=#{app_name.dasherize}-staging-pr-$1")
-    expect(bin_setup).
-      to include("heroku run rails db:migrate --exit-code --app $APP_NAME")
     expect(bin_setup).to include("heroku ps:scale worker=1 --app $APP_NAME")
     expect(bin_setup).to include("heroku restart --app $APP_NAME")
 
@@ -268,7 +266,7 @@ RSpec.describe "Suspend a new project with default configuration" do
     bin_deploy_path = "#{project_path}/bin/deploy"
     bin_deploy = IO.read(bin_deploy_path)
 
-    expect(bin_deploy).to include("heroku run rails db:migrate --exit-code")
+    expect(bin_deploy).to include('git push "$target" "$branch:master"')
     expect("bin/deploy").to be_executable
   end
 

--- a/spec/features/production/manifest_spec.rb
+++ b/spec/features/production/manifest_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "suspenders:production:manifest", type: :generator do
       name: SuspendersTestHelpers::APP_NAME.dasherize,
       env: {
         APPLICATION_HOST: { required: true },
+        AUTO_MIGRATE_DB: { value: "true" },
         EMAIL_RECIPIENTS: { required: true },
         HEROKU_APP_NAME: { required: true },
         HEROKU_PARENT_APP_NAME: { required: true },
@@ -24,6 +25,7 @@ RSpec.describe "suspenders:production:manifest", type: :generator do
       name: SuspendersTestHelpers::APP_NAME.dasherize,
       env: {
         APPLICATION_HOST: { required: true },
+        AUTO_MIGRATE_DB: { value: "true" },
         EMAIL_RECIPIENTS: { required: true },
         HEROKU_APP_NAME: { required: true },
         HEROKU_PARENT_APP_NAME: { required: true },


### PR DESCRIPTION
`rake db:migrate` has been removed from the heroku deploy flow. This
commits fixes tests :)