### PR TITLE
Automatically configure buildpacks on heroku

### DIFF
--- a/docs/heroku_deploy.md
+++ b/docs/heroku_deploy.md
@@ -4,11 +4,7 @@
 
 Deploying to Heroku requires two additional steps:
 
-1. Manually add buildpacks `node.js` and `ruby` (in that order) to your Heroku
-   app. This is necessary because build order is important and Heroku's
-   auto-detection will add them in the wrong order.
-
-2. Set the following environment variables:
+1. Set the following environment variables:
 
 - `ASSET_HOST`: `siteURL.herokuapp.com`
 - `APPLICATION_HOST`: `siteURL.herokuapp.com`

--- a/lib/suspenders/adapters/heroku.rb
+++ b/lib/suspenders/adapters/heroku.rb
@@ -84,6 +84,19 @@ module Suspenders
         end
       end
 
+      def set_heroku_buildpacks
+        %w(staging production).each do |environment|
+          run_toolbelt_command(
+            "buildpacks:add --index 1 heroku/nodejs",
+            environment,
+          )
+          run_toolbelt_command(
+            "buildpacks:add --index 2 heroku/ruby",
+            environment,
+          )
+        end
+      end
+
       private
 
       attr_reader :app_builder

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -15,6 +15,7 @@ module Suspenders
       :set_heroku_honeybadger_env,
       :set_heroku_rails_secrets,
       :set_heroku_remotes,
+      :set_heroku_buildpacks,
     )
 
     def readme

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -119,6 +119,7 @@ module Suspenders
         build :set_heroku_application_host
         build :set_heroku_honeybadger_env
         build :set_heroku_backup_schedule
+        build :set_heroku_buildpacks
         build :create_heroku_pipeline
         build :configure_automatic_deployment
       end

--- a/spec/adapters/heroku_spec.rb
+++ b/spec/adapters/heroku_spec.rb
@@ -55,6 +55,26 @@ module Suspenders
         )
       end
 
+      it "configures nodejs and ruby packs" do
+        app_builder = double(app_name: app_name)
+        allow(app_builder).to receive(:run)
+
+        Heroku.new(app_builder).set_heroku_buildpacks
+
+        %w(staging production).each do |remote|
+          expect(app_builder).to(
+            have_configured_buildpack(
+              remote_name: remote, index: 1, packname: "heroku/nodejs",
+            ),
+          )
+          expect(app_builder).to(
+            have_configured_buildpack(
+              remote_name: remote, index: 2, packname: "heroku/ruby",
+            ),
+          )
+        end
+      end
+
       def app_name
         SuspendersTestHelpers::APP_NAME
       end
@@ -66,6 +86,12 @@ module Suspenders
 
       def have_configured_var(remote_name, var)
         have_received(:run).with(/config:add #{var}=.+ --remote #{remote_name}/)
+      end
+
+      def have_configured_buildpack(remote_name:, index:, packname:)
+        have_received(:run).with(
+          /buildpacks:add --index #{index} #{packname} --remote #{remote_name}/,
+        )
       end
     end
   end


### PR DESCRIPTION
We can automatically add buildpacks to heroku! :)

```
Buildpack added. Next release on provaprova-staging will use heroku/nodejs.
Run git push staging master to create a new release using this buildpack.
         run  heroku buildpacks:add --index 2 heroku/ruby --remote staging from "."
Buildpack added. Next release on provaprova-staging will use:
  1. heroku/nodejs
  2. heroku/ruby
Run git push staging master to create a new release using these buildpacks.
         run  heroku buildpacks:add --index 1 heroku/nodejs --remote production from "."
Buildpack added. Next release on provaprova-production will use heroku/nodejs.
Run git push production master to create a new release using this buildpack.
         run  heroku buildpacks:add --index 2 heroku/ruby --remote production from "."
Buildpack added. Next release on provaprova-production will use:
  1. heroku/nodejs
  2. heroku/ruby
```