### PR TITLE
Copy auto migrate into project

### DIFF
--- a/docs/heroku_deploy.md
+++ b/docs/heroku_deploy.md
@@ -12,6 +12,7 @@ Deploying to Heroku requires two additional steps:
 - `SMTP_DOMAIN`: `example.com`
 - `SMTP_USERNAME`: `username`
 - `SMTP_PASSWORD`: `password`
+- `AUTO_MIGRATE_DB`: `true`
 
 ## Execution
 

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -206,7 +206,8 @@ config.public_file_server.headers = {
     end
 
     def configure_automatic_deployment
-      append_file "Procfile", "release: bin/auto_migrate"
+      append_file "Procfile", "release: bin/auto_migrate\n"
+      copy_file "bin_auto_migrate", "bin/auto_migrate"
     end
 
     def create_github_repo(repo_name)

--- a/lib/suspenders/generators/production/manifest_generator.rb
+++ b/lib/suspenders/generators/production/manifest_generator.rb
@@ -10,7 +10,7 @@ module Suspenders
           scripts: {},
           env: {
             APPLICATION_HOST: { required: true },
-            AUTO_MIGRATE_DB: { value: "true" },
+            AUTO_MIGRATE_DB: { value: true },
             EMAIL_RECIPIENTS: { required: true },
             HEROKU_APP_NAME: { required: true },
             HEROKU_PARENT_APP_NAME: { required: true },

--- a/spec/features/production/manifest_spec.rb
+++ b/spec/features/production/manifest_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "suspenders:production:manifest", type: :generator do
       name: SuspendersTestHelpers::APP_NAME.dasherize,
       env: {
         APPLICATION_HOST: { required: true },
-        AUTO_MIGRATE_DB: { value: "true" },
+        AUTO_MIGRATE_DB: { value: true },
         EMAIL_RECIPIENTS: { required: true },
         HEROKU_APP_NAME: { required: true },
         HEROKU_PARENT_APP_NAME: { required: true },
@@ -25,7 +25,7 @@ RSpec.describe "suspenders:production:manifest", type: :generator do
       name: SuspendersTestHelpers::APP_NAME.dasherize,
       env: {
         APPLICATION_HOST: { required: true },
-        AUTO_MIGRATE_DB: { value: "true" },
+        AUTO_MIGRATE_DB: { value: true },
         EMAIL_RECIPIENTS: { required: true },
         HEROKU_APP_NAME: { required: true },
         HEROKU_PARENT_APP_NAME: { required: true },


### PR DESCRIPTION
I noticed that `bin_auto_migrate` was not copied into project directory. I think it must be present so heroku will call it in its `release` script