### PR TITLE
Keep using sprockets v3

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -19,7 +19,7 @@ gem "rails", "<%= Suspenders::RAILS_VERSION %>"
 gem "recipient_interceptor"
 gem "sassc-rails"
 gem "skylight"
-gem "sprockets", ">= 3.0.0"
+gem "sprockets", "< 4"
 gem "title"
 gem "tzinfo-data", platforms: [:mingw, :x64_mingw, :mswin, :jruby]
 gem "webpacker"


### PR DESCRIPTION
This commit should fix the CI on master.

I don't know if in thoughtbot you already use sprockets v4. We do not, so we fixed the version of sprockets to v3. Even Rails 6 does not support sprockets v4 right now 🤔 

From a plain new `rails new blog` application with rails 6

```
    sass-rails (5.1.0)
      railties (>= 5.2.0)
      sass (~> 3.1)
      sprockets (>= 2.8, < 4.0)
      sprockets-rails (>= 2.0, < 4.0)
      tilt (>= 1.1, < 3)
```