### PR TITLE
Configure System Test drivers with `driven_by`

### DIFF
--- a/templates/chromedriver.rb
+++ b/templates/chromedriver.rb
@@ -15,3 +15,13 @@ Capybara.register_driver :headless_chrome do |app|
 end
 
 Capybara.javascript_driver = :headless_chrome
+
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    driven_by :rack_test
+  end
+
+  config.before(:each, type: :system, js: true) do
+    driven_by Capybara.javascript_driver
+  end
+end


### PR DESCRIPTION
According to the documentation from [`rspec-rails`][rspec-rails]:

> RSpec **does not** use your `ApplicationSystemTestCase` helper.
> Instead it uses the default `driven_by(:selenium)` from Rails. If you
> want to override this behaviour you can call `driven_by` manually in a
> test.

This commit introduces an [`RSpec.configure`][configure] block which
sets the default driver for `type: :system` tests by invoking
[`driven_by`][driven_by] with [`:rack_test`][rack_test].

To opt into JavaScript-enabled tests, set the `js: true` (or `:js`)
metadata on a `describe`, `context`, or `it` block.

[driven_by]: https://api.rubyonrails.org/v6.0/classes/ActionDispatch/SystemTestCase.html#method-c-driven_by
[rspec-rails]: https://relishapp.com/rspec/rspec-rails/v/3-9/docs/system-specs/system-spec
[configure]: https://relishapp.com/rspec/rspec-core/docs/configuration/custom-settings#simple-setting-(with-defaults)
[rack_test]: https://github.com/rack-test/rack-test