### PR TITLE
Fix failing tests

### DIFF
--- a/spec/features/heroku_spec.rb
+++ b/spec/features/heroku_spec.rb
@@ -36,17 +36,6 @@ RSpec.describe "Heroku" do
 
       expect(readme).to include("./bin/deploy staging")
       expect(readme).to include("./bin/deploy production")
-
-      circle_yml_path = "#{project_path}/circle.yml"
-      circle_yml = IO.read(circle_yml_path)
-
-      expect(circle_yml).to include <<-YML.strip_heredoc
-      deployment:
-        staging:
-          branch: master
-          commands:
-            - bin/deploy staging
-      YML
     end
   end
 

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -256,8 +256,6 @@ RSpec.describe "Suspend a new project with default configuration" do
 
     expect(bin_setup).to include("PARENT_APP_NAME=#{app_name.dasherize}-staging")
     expect(bin_setup).to include("APP_NAME=#{app_name.dasherize}-staging-pr-$1")
-    expect(bin_setup).
-      to include("heroku run rails db:migrate --exit-code --app $APP_NAME")
     expect(bin_setup).to include("heroku ps:scale worker=1 --app $APP_NAME")
     expect(bin_setup).to include("heroku restart --app $APP_NAME")
 
@@ -268,7 +266,7 @@ RSpec.describe "Suspend a new project with default configuration" do
     bin_deploy_path = "#{project_path}/bin/deploy"
     bin_deploy = IO.read(bin_deploy_path)
 
-    expect(bin_deploy).to include("heroku run rails db:migrate --exit-code")
+    expect(bin_deploy).to include("git push")
     expect("bin/deploy").to be_executable
   end
 

--- a/spec/features/production/manifest_spec.rb
+++ b/spec/features/production/manifest_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "suspenders:production:manifest", type: :generator do
       name: SuspendersTestHelpers::APP_NAME.dasherize,
       env: {
         APPLICATION_HOST: { required: true },
+        AUTO_MIGRATE_DB: { value: "true" },
         EMAIL_RECIPIENTS: { required: true },
         HEROKU_APP_NAME: { required: true },
         HEROKU_PARENT_APP_NAME: { required: true },
@@ -24,6 +25,7 @@ RSpec.describe "suspenders:production:manifest", type: :generator do
       name: SuspendersTestHelpers::APP_NAME.dasherize,
       env: {
         APPLICATION_HOST: { required: true },
+        AUTO_MIGRATE_DB: { value: "true" },
         EMAIL_RECIPIENTS: { required: true },
         HEROKU_APP_NAME: { required: true },
         HEROKU_PARENT_APP_NAME: { required: true },

--- a/spec/support/contain_json_matcher.rb
+++ b/spec/support/contain_json_matcher.rb
@@ -4,21 +4,27 @@ require "json"
 
 RSpec::Matchers.define :contain_json do
   match do
-    sub_json = expected
-    filename = actual
+    @sub_json = expected
+    @filename = actual
 
-    filepath = File.join(project_path, filename)
-    json = JSON.parse(IO.read(filepath), symbolize_names: true)
-    sub_json <= json
+    @filepath = File.join(project_path, @filename)
+    @json = JSON.parse(IO.read(@filepath), symbolize_names: true)
+
+    subhash?(@sub_json, @json)
   end
 
   failure_message do
-    sub_json = expected
-    filename = actual
+    "in #{@filename}, expected to find\n#{@sub_json.inspect}\n" \
+      "in\n#{@json.inspect}"
+  end
 
-    filepath = File.join(project_path, filename)
-    json = JSON.parse(IO.read(filepath), symbolize_names: true)
+  private
 
-    "in #{filename}, expected to find\n#{sub_json.inspect}\nin\n#{json.inspect}"
+  def subhash?(inner, outer)
+    if inner.is_a?(Hash) && outer.is_a?(Hash)
+      inner.all? { |key, value| subhash?(value, outer[key]) }
+    else
+      inner == outer
+    end
   end
 end


### PR DESCRIPTION
We have two variety of fixes here: Heroku migration, and JSON subset
matcher.

The Heroku migration improvements from 5b68a176cbd40456e80ea9b91a98597cd91b4d8d
modified the `circle.yml` and `bin/deploy` files, but three tests had
not caught up.The `circle.yml` checks can be removed; that's no longer
done. Any reference to `heroku run rails db:migrate` can be removed;
that's handled for us automatically.

The `contain_json` matcher used `Hash#<=` to find the sub-hash; however,
this does not recur. Instead we can write our own recursive `subhash?`
helper method.