### PR TITLE
Disable platform warnings in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_install:
   - git config --global user.email 'travis-ci@example.com'
   - gem update --system
   - gem install bundler
+  - bundler config --global disable_platform_warnings true
 install: bundle install
 notifications:
   email: false


### PR DESCRIPTION
The tzinfo-data gem is only used by MS Windows and JRuby. This causes
Bundler to print a warning on actual OSes used for development or for
hosting.

> The dependency tzinfo-data (>= 0) will be unused by any of the
> platforms Bundler is installing for. Bundler is installing for ruby
> but the dependency is only for x86-mingw32, x64-mingw32, x86-mswin32,
> java. To add those platforms to the bundle, run `bundle lock
> --add-platform x86-mingw32 x64-mingw32 x86-mswin32 java`.

Silence this warning in CI with the `disable_platform_warnings` Bundler
configuration, [documented] to

> Disable warnings during bundle install when a dependency is unused on
> the current platform.

[documented]: https://bundler.io/v1.17/bundle_config.html