### PR TITLE
Introduce suspenders:advisories generator

### DIFF
--- a/lib/suspenders.rb
+++ b/lib/suspenders.rb
@@ -1,4 +1,5 @@
 require "suspenders/version"
+require "suspenders/generators/advisories_generator"
 require "suspenders/generators/app_generator"
 require "suspenders/generators/static_generator"
 require "suspenders/generators/stylesheet_base_generator"

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -214,11 +214,6 @@ config.public_file_server.headers = {
       run "hub create #{repo_name}"
     end
 
-    def setup_bundler_audit
-      copy_file "bundler_audit.rake", "lib/tasks/bundler_audit.rake"
-      append_file "Rakefile", %{\ntask default: "bundle:audit"\n}
-    end
-
     def copy_miscellaneous_files
       copy_file "errors.rb", "config/initializers/errors.rb"
       copy_file "json_encoding.rb", "config/initializers/json_encoding.rb"

--- a/lib/suspenders/generators/advisories_generator.rb
+++ b/lib/suspenders/generators/advisories_generator.rb
@@ -4,9 +4,9 @@ module Suspenders
   class AdvisoriesGenerator < Generators::Base
     def bundler_audit_gem
       gem "bundler-audit",
-        ">= 0.5.0",
-        require: false,
-        group: [:development, :test]
+          ">= 0.5.0",
+          require: false,
+          group: [:development, :test]
     end
 
     def rake_task

--- a/lib/suspenders/generators/advisories_generator.rb
+++ b/lib/suspenders/generators/advisories_generator.rb
@@ -3,7 +3,9 @@ require_relative "base"
 module Suspenders
   class AdvisoriesGenerator < Generators::Base
     def bundler_audit_gem
-      gem "bundler-audit", ">= 0.5.0", require: false,
+      gem "bundler-audit",
+        ">= 0.5.0",
+        require: false,
         group: [:development, :test]
     end
 

--- a/lib/suspenders/generators/advisories_generator.rb
+++ b/lib/suspenders/generators/advisories_generator.rb
@@ -4,6 +4,7 @@ module Suspenders
   class AdvisoriesGenerator < Generators::Base
     def bundler_audit_gem
       gem "bundler-audit", require: false, group: %i[development test]
+      Bundler.with_clean_env { run "bundle install" }
     end
 
     def rake_task

--- a/lib/suspenders/generators/advisories_generator.rb
+++ b/lib/suspenders/generators/advisories_generator.rb
@@ -1,0 +1,15 @@
+require_relative "base"
+
+module Suspenders
+  class AdvisoriesGenerator < Generators::Base
+    def bundler_audit_gem
+      gem "bundler-audit", ">= 0.5.0", require: false,
+        group: [:development, :test]
+    end
+
+    def rake_task
+      copy_file "bundler_audit.rake", "lib/tasks/bundler_audit.rake"
+      append_file "Rakefile", %{\ntask default: "bundle:audit"\n}
+    end
+  end
+end

--- a/lib/suspenders/generators/advisories_generator.rb
+++ b/lib/suspenders/generators/advisories_generator.rb
@@ -3,10 +3,7 @@ require_relative "base"
 module Suspenders
   class AdvisoriesGenerator < Generators::Base
     def bundler_audit_gem
-      gem "bundler-audit",
-          ">= 0.5.0",
-          require: false,
-          group: %i[development test]
+      gem "bundler-audit", require: false, group: %i[development test]
     end
 
     def rake_task

--- a/lib/suspenders/generators/advisories_generator.rb
+++ b/lib/suspenders/generators/advisories_generator.rb
@@ -6,7 +6,7 @@ module Suspenders
       gem "bundler-audit",
           ">= 0.5.0",
           require: false,
-          group: [:development, :test]
+          group: %i[development test]
     end
 
     def rake_task

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -51,7 +51,6 @@ module Suspenders
       invoke :setup_dotfiles
       invoke :setup_database
       invoke :create_github_repo
-      invoke :setup_bundler_audit
       invoke :generate_default
       invoke :setup_default_directories
       invoke :create_heroku_apps
@@ -139,11 +138,6 @@ module Suspenders
       build :setup_default_directories
     end
 
-    def setup_bundler_audit
-      say "Setting up bundler-audit"
-      build :setup_bundler_audit
-    end
-
     def copy_miscellaneous_files
       say 'Copying miscellaneous support files'
       build :copy_miscellaneous_files
@@ -179,6 +173,7 @@ module Suspenders
       generate("suspenders:jobs")
       generate("suspenders:analytics")
       generate("suspenders:inline_svg")
+      generate("suspenders:advisories")
       generate("suspenders:preloader")
     end
 

--- a/spec/features/advisories_spec.rb
+++ b/spec/features/advisories_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "suspenders:advisories", type: :generator do
     with_app { generate("suspenders:advisories") }
 
     run_in_project do
-      expect(`rake -T`).to include('rake bundle:audit')
+      expect(`rake -T`).to include("rake bundle:audit")
     end
     expect("lib/tasks/bundler_audit.rake").to \
       match_contents(/Bundler::Audit::Task.new/)
@@ -18,7 +18,7 @@ RSpec.describe "suspenders:advisories", type: :generator do
     expect("Gemfile").not_to match_contents(/bundler-audit/)
     expect("lib/tasks/bundler_audit.rake").not_to exist_as_a_file
     run_in_project do
-      expect(`rake -T`).not_to include('rake bundle:audit')
+      expect(`rake -T`).not_to include("rake bundle:audit")
     end
   end
 end

--- a/spec/features/advisories_spec.rb
+++ b/spec/features/advisories_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+
+RSpec.describe "suspenders:advisories", type: :generator do
+  it "configures bundler-audit" do
+    with_app { generate("suspenders:advisories") }
+
+    run_in_project do
+      expect(`rake -T`).to include('rake bundle:audit')
+    end
+    expect("lib/tasks/bundler_audit.rake").to \
+      match_contents(/Bundler::Audit::Task.new/)
+    expect("Gemfile").to match_contents(/bundler-audit/)
+  end
+
+  it "removes bundler-audit" do
+    with_app { destroy("suspenders:advisories") }
+
+    expect("Gemfile").not_to match_contents(/bundler-audit/)
+    expect("lib/tasks/bundler_audit.rake").not_to exist_as_a_file
+    run_in_project do
+      expect(`rake -T`).not_to include('rake bundle:audit')
+    end
+  end
+end

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -32,7 +32,6 @@ end
 
 group :development, :test do
   gem "awesome_print"
-  gem "bundler-audit", ">= 0.5.0", require: false
   gem "dotenv-rails"
   gem "pry-byebug"
   gem "pry-rails"


### PR DESCRIPTION
This configures the project to announce security advisories during test
and development, specifically using the [bundler-audit] gem.

[bundler-audit]: https://github.com/rubysec/bundler-audit

A cool fact about life is that the bundler-audit gem is licensed under
the GNU GPL 3+ license. This means that if we were to distribute a Rails
app that uses it, the app itself would also need to be GNU GPL 3+ or
compatible.