### PR TITLE
Shuffle custom placeholder directories

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -182,20 +182,6 @@ config.public_file_server.headers = {
       copy_file "Procfile", "Procfile"
     end
 
-    def setup_default_directories
-      [
-        'app/views/pages',
-        'spec/lib',
-        'spec/controllers',
-        'spec/helpers',
-        'spec/support/matchers',
-        'spec/support/mixins',
-        'spec/support/shared_examples'
-      ].each do |dir|
-        empty_directory_with_keep_file dir
-      end
-    end
-
     def copy_dotfiles
       directory("dotfiles", ".")
     end

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -52,7 +52,6 @@ module Suspenders
       invoke :setup_database
       invoke :create_github_repo
       invoke :generate_default
-      invoke :setup_default_directories
       invoke :create_heroku_apps
       invoke :generate_deployment_default
       invoke :remove_config_comment_lines
@@ -132,10 +131,6 @@ module Suspenders
 
     def setup_dotfiles
       build :copy_dotfiles
-    end
-
-    def setup_default_directories
-      build :setup_default_directories
     end
 
     def copy_miscellaneous_files

--- a/lib/suspenders/generators/base.rb
+++ b/lib/suspenders/generators/base.rb
@@ -15,6 +15,15 @@ module Suspenders
       def app_name
         Rails.app_class.module_parent_name.demodulize.underscore.dasherize
       end
+
+      def empty_directory_with_keep_file(destination)
+        empty_directory(destination, {})
+        keep_file(destination)
+      end
+
+      def keep_file(destination)
+        create_file(File.join(destination, ".keep"))
+      end
     end
   end
 end

--- a/lib/suspenders/generators/static_generator.rb
+++ b/lib/suspenders/generators/static_generator.rb
@@ -6,5 +6,9 @@ module Suspenders
       gem "high_voltage"
       Bundler.with_clean_env { run "bundle install" }
     end
+
+    def make_placeholder_directory
+      empty_directory_with_keep_file "app/views/pages"
+    end
   end
 end

--- a/lib/suspenders/generators/testing_generator.rb
+++ b/lib/suspenders/generators/testing_generator.rb
@@ -40,16 +40,5 @@ module Suspenders
     def configure_action_mailer_in_specs
       copy_file "action_mailer.rb", "spec/support/action_mailer.rb"
     end
-
-    private
-
-    def empty_directory_with_keep_file(destination)
-      empty_directory(destination, {})
-      keep_file(destination)
-    end
-
-    def keep_file(destination)
-      create_file(File.join(destination, ".keep"))
-    end
   end
 end

--- a/spec/features/static_spec.rb
+++ b/spec/features/static_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+RSpec.describe "suspenders:static", type: :generator do
+  it "adds the gem and pages directory" do
+    with_app { generate("suspenders:static") }
+
+    expect("Gemfile").to match_contents(/high_voltage/)
+    expect("app/views/pages/.keep").to exist_as_a_file
+  end
+
+  it "removes the gem and pages directory" do
+    with_app { destroy("suspenders:static") }
+
+    expect("app/views/pages/.keep").not_to exist_as_a_file
+    expect("Gemfile").not_to match_contents(/high_voltage/)
+  end
+end


### PR DESCRIPTION
We had a part of the code that made placeholder directories. Let's
remove most of them and move the rest around.

The `app/views/pages` directory is used for static pages as used by
`high_voltage`. Move that into the `StaticGenerator`.

The `spec/support` directory is used for all tests, and implied by
creating subdirectories. The `TestingGenerator` does this for us.

This removes `spec/lib`, `spec/controllers`, `spec/helpers`,
`spec/support/matchers`, `spec/support/mixins`, and
`spec/support/shared_examples`.

The `spec/lib` and `spec/helpers` directories are for tests under `lib`
and `app/helpers`, respectively. These directories are rarely used these
days, so let's not make these directories by default.

The `spec/controllers` directory is for controller unit tests. These
have mostly been replaced by `spec/features`, `spec/requests`, and
`spec/system`. Let's hold off on this directory for now.

The subdirectories under `spec/support` -- `matchers`, `mixins`, and
`shared_examples` -- are far too often overlooked, and instead
everything is dropped directly under `spec/support`. And in practice,
90% of the time, this is fine. People just don't extract a ton of stuff
into `spec/support`. If a project does, they can find a way to
re-organize things as appropriate.

---

During the creation of this diff, a `suspenders:placeholders` generator
was extracted. Eventually it only created `app/services` and
`spec/services`, which lead to a discussion about whether we want to
encourage such behavior. The decision was made not to make those
directories in here (since we hadn't been doing that already) and
instead to move [the discussion](https://github.com/thoughtbot/guides/pull/578) to our guides.

---

Historically:

~~This adds the `suspenders:placeholders` generator, which makes empty
directories for all the usual (but missing) suspects. It adds an empty
`.keep` file to each so that they will be added to the git repository so
everyone can enjoy them.~~

~~- `app/views/pages` - static pages as used by `high_voltage`.~~
~~- `spec/lib` - tests for files in `lib/`.~~
~~- `spec/controllers` - unit tests for controllers.~~
~~- `spec/helpers` - tests for Rails view helpers.~~
~~- `spec/support/matchers` - RSpec matcher definitions.~~
~~- `spec/support/mixins` - Unclear.~~
~~- `spec/support/shared_examples` - RSpec shared example group definitions.~~

~~Updated:~~

~~- Move `app/views/pages` into the StaticGenerator.~~
~~- The `spec/support` directory itself is implied by the TestingGenerator.~~
~~- `spec/lib` is very seldom used; we mostly put that kind of stuff in `app/services`.~~
~~- `spec/controllers` and `spec/helpers` are basically unused these days, with preference given to `spec/features` or `spec/system`.~~
~~- `spec/support/matchers` and `spec/support/shared_examples` are often mistakenly unused, with people dumping matchers and shared example groups in `spec/support`. Instead of fighting this, embrace it.~~
~~- I have no idea what `spec/support/mixins` was for.~~