### PR TITLE
Remove .ctags configuration

### DIFF
--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -44,9 +44,7 @@ RSpec.describe "Suspend a new project with default configuration" do
   end
 
   it "copies dotfiles" do
-    %w[.ctags .env].each do |dotfile|
-      expect(File).to exist("#{project_path}/#{dotfile}")
-    end
+    expect(File).to exist("#{project_path}/.env")
   end
 
   it "doesn't generate test directory" do

--- a/templates/dotfiles/.ctags
+++ b/templates/dotfiles/.ctags
@@ -1,2 +1,0 @@
---recurse=yes
---exclude=vendor


### PR DESCRIPTION
Not all of us are blessed with ctags-compatible editors these days, but
that's not the main thing.

Those of us who are using an editor built for programming are [running
ctags automatically], and therefore the configuration in `.ctags` is not
useful.

[running ctags automatically]: https://github.com/ludovicchabant/vim-gutentags/

Of the projects I found on my laptop, none have modified `.ctags` beyond
this default.

This file made more sense [when it was added], but now it's a relic of a
different era.

[when it was added]: https://github.com/thoughtbot/suspenders/pull/595