### PR TITLE
Stop customizing error pages

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -205,21 +205,6 @@ config.public_file_server.headers = {
       copy_file "json_encoding.rb", "config/initializers/json_encoding.rb"
     end
 
-    def customize_error_pages
-      meta_tags =<<-EOS
-  <meta charset="utf-8" />
-  <meta name="viewport" content="initial-scale=1" />
-      EOS
-
-      %w(500 404 422).each do |page|
-        path = "public/#{page}.html"
-        if File.exist?(path)
-          inject_into_file path, meta_tags, after: "<head>\n"
-          replace_in_file path, /<!--.+-->\n/, ''
-        end
-      end
-    end
-
     def remove_config_comment_lines
       config_files = [
         "application.rb",

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -47,7 +47,6 @@ module Suspenders
       invoke :setup_secret_token
       invoke :configure_app
       invoke :copy_miscellaneous_files
-      invoke :customize_error_pages
       invoke :setup_dotfiles
       invoke :setup_database
       invoke :create_github_repo
@@ -136,11 +135,6 @@ module Suspenders
     def copy_miscellaneous_files
       say 'Copying miscellaneous support files'
       build :copy_miscellaneous_files
-    end
-
-    def customize_error_pages
-      say 'Customizing the 500/404/422 pages'
-      build :customize_error_pages
     end
 
     def remove_config_comment_lines


### PR DESCRIPTION
This did three things:

- Specify the charset in the HTML body.
- Specify the viewport.
- Remove comments.

The charset was removed from Rails in
https://github.com/rails/rails/commit/38f669766cb4d328e121afab020f4a52ca45421f .
It's not needed in the HTML if it's sent from the server. It's best to
send it from the server, in fact; otherwise the browser will parse the
first _n_ bytes of the file in a default charset, hit the charset meta
tag, then re-parse from the top under the new charset. We can remove
this meta tag now.

The viewport is in the default error page HTML as of
https://github.com/rails/rails/commit/7166507eae3d12c22e04a99ddd70972419643cd3 .

That leaves us with the comments. It'd be nice if they weren't there. I
don't know if that's worth a generator. The comment reads e.g.

```
 <!-- This file lives in public/404.html -->
```