### PR TITLE
Identify ourselves to git when changing HOME

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm: 2.6.5
 cache: bundler
 before_install:
+  - nvm install 8.16.0
   - git config --global user.name 'Travis CI'
   - git config --global user.email 'travis-ci@example.com'
   - gem update --system

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 rvm: 2.6.5
 cache: bundler
-sudo: false
 before_install:
   - git config --global user.name 'Travis CI'
   - git config --global user.email 'travis-ci@example.com'

--- a/spec/support/suspenders.rb
+++ b/spec/support/suspenders.rb
@@ -19,10 +19,7 @@ module SuspendersTestHelpers
       end
 
       Dir.chdir(APP_NAME) do
-        with_env("HOME", tmp_path) do
-          debug `git add .`
-          debug `git commit -m 'Initial commit'`
-        end
+        commit_all
       end
     end
   end
@@ -49,10 +46,7 @@ module SuspendersTestHelpers
           file.puts %{gem "suspenders", path: #{root_path.inspect}}
         end
 
-        with_env("HOME", tmp_path) do
-          debug `git add .`
-          debug `git commit -m 'Initial commit'`
-        end
+        commit_all
       end
     end
   end
@@ -133,6 +127,15 @@ module SuspendersTestHelpers
 
   def root_path
     File.expand_path('../../../', __FILE__)
+  end
+
+  def commit_all
+    with_env("HOME", tmp_path) do
+      debug `git config user.email suspenders@example.com`
+      debug `git config user.name "Suspenders Boy"`
+      debug `git add .`
+      debug `git commit -m 'Initial commit'`
+    end
   end
 
   def with_env(name, new_value)


### PR DESCRIPTION
If we change the value of `$HOME`, that means git(1) might not know who
we are. That can lead to warnings like this (taken from CI):

```
*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'travis@travis-job-da8e5dbd-8be0-4778-931d-583b72258a58.(none)')
```

Let's set our name and email whenever we run commands under a different
home directory, just to be tidy.