### PR TITLE
Move heredoc into templates

### DIFF
--- a/lib/suspenders/generators/base.rb
+++ b/lib/suspenders/generators/base.rb
@@ -24,6 +24,21 @@ module Suspenders
       def keep_file(destination)
         create_file(File.join(destination, ".keep"))
       end
+
+      def append_template_to_file(destination, source, *args)
+        partial = File.expand_path(find_in_source_paths(source))
+        append_to_file(destination, File.read(partial, *args))
+      end
+
+      def prepend_template_to_file(destination, source, *args)
+        partial = File.expand_path(find_in_source_paths(source))
+        prepend_to_file(destination, File.read(partial, *args))
+      end
+
+      def inject_template_into_file(destination, source, *args)
+        partial = File.expand_path(find_in_source_paths(source))
+        inject_into_file(destination, File.read(partial), *args)
+      end
     end
   end
 end

--- a/lib/suspenders/generators/ci_generator.rb
+++ b/lib/suspenders/generators/ci_generator.rb
@@ -2,21 +2,31 @@ require_relative "base"
 
 module Suspenders
   class CiGenerator < Generators::Base
+    def simplecov_gem
+      gem "simplecov", require: false, group: [:test]
+      Bundler.with_clean_env { run "bundle install" }
+    end
+
     def simplecov_test_integration
-      inject_into_file "spec/spec_helper.rb", before: 'SimpleCov.start "rails"' do
-        <<-RUBY
-
-  if ENV["CIRCLE_ARTIFACTS"]
-    dir = File.join(ENV["CIRCLE_ARTIFACTS"], "coverage")
-    SimpleCov.coverage_dir(dir)
-  end
-
-        RUBY
-      end
+      prepend_template_to_file(test_helper_file, "partials/ci_simplecov.rb")
     end
 
     def configure_ci
       template "circle.yml.erb", "circle.yml"
+    end
+
+    private
+
+    def test_helper_file
+      if using_rspec?
+        "spec/spec_helper.rb"
+      else
+        "test/test_helper.rb"
+      end
+    end
+
+    def using_rspec?
+      File.exist?("spec/spec_helper.rb")
     end
   end
 end

--- a/lib/suspenders/generators/db_optimizations_generator.rb
+++ b/lib/suspenders/generators/db_optimizations_generator.rb
@@ -8,23 +8,11 @@ module Suspenders
     end
 
     def configure_bullet
-      inject_into_file(
+      inject_template_into_file(
         "config/environments/development.rb",
-        configuration,
-        after: "config.action_mailer.raise_delivery_errors = true\n",
+        "partials/db_optimizations_configuration.rb",
+        after: /config.action_mailer.raise_delivery_errors = .*/,
       )
-    end
-
-    private
-
-    def configuration
-      <<-RUBY
-  config.after_initialize do
-    Bullet.enable = true
-    Bullet.bullet_logger = true
-    Bullet.rails_logger = true
-  end
-      RUBY
     end
   end
 end

--- a/lib/suspenders/generators/production/deployment_generator.rb
+++ b/lib/suspenders/generators/production/deployment_generator.rb
@@ -9,18 +9,7 @@ module Suspenders
       end
 
       def inform_user
-        instructions = <<~MARKDOWN
-
-          ## Deploying
-
-          If you have previously run the `./bin/setup` script,
-          you can deploy to staging and production with:
-
-              % ./bin/deploy staging
-              % ./bin/deploy production
-        MARKDOWN
-
-        append_file "README.md", instructions
+        append_template_to_file "README.md", "partials/deployment_readme.md"
       end
     end
   end

--- a/lib/suspenders/generators/production/email_generator.rb
+++ b/lib/suspenders/generators/production/email_generator.rb
@@ -11,14 +11,11 @@ module Suspenders
       end
 
       def use_smtp
-        config = <<-RUBY
-
-  config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = SMTP_SETTINGS
-        RUBY
-
-        inject_into_file "config/environments/production.rb", config,
-          after: "config.action_mailer.perform_caching = false"
+        inject_template_into_file(
+          "config/environments/production.rb",
+          "partials/email_smtp.rb",
+          after: "config.action_mailer.perform_caching = false",
+        )
       end
 
       def env_vars

--- a/lib/suspenders/generators/profiler_generator.rb
+++ b/lib/suspenders/generators/profiler_generator.rb
@@ -29,17 +29,7 @@ module Suspenders
     end
 
     def update_readme
-      config = <<~CONFIG
-
-        ## Profiler
-
-        The [rack-mini-profiler] gem can be enabled by setting
-        `RACK_MINI_PROFILER=1` in the environment. This will display a speed
-        badge on every page.
-
-        [rack-mini-profiler]: https://github.com/MiniProfiler/rack-mini-profiler
-      CONFIG
-      append_to_file "README.md", config
+      append_template_to_file "README.md", "partials/profiler_readme.md"
     end
   end
 end

--- a/lib/suspenders/generators/runner_generator.rb
+++ b/lib/suspenders/generators/runner_generator.rb
@@ -12,19 +12,13 @@ module Suspenders
 
     def copy_sample_env
       if bin_setup_is_ruby?
-        copy_command = <<~RUBY
-          puts "\\n== Copying sample env =="
-          system! 'cp -i .sample.env .env'
-
-        RUBY
-
-        insert_into_file(
+        inject_template_into_file(
           "bin/setup",
-          copy_command,
+          "partials/runner_setup.rb",
           before: %{  puts "\\n== Preparing database =="},
         )
       elsif bin_setup_mentions_ci?
-        insert_into_file(
+        inject_into_file(
           "bin/setup",
           %{  cp -i .sample.env .env\n},
           after: %{if [ -z "$CI" ]; then\n},
@@ -38,41 +32,7 @@ module Suspenders
     end
 
     def update_readme
-      configure = <<~MARKDOWN
-
-        ## Configuration
-
-        Environment variables during local development are handled by the node-foreman
-        project runner. To provide environment variables, create a `.env` file at the
-        root of the project. In that file provide the environment variables listed in
-        `.sample.env`. The `bin/setup` script does this for you, but be careful about
-        overwriting your existing `.env` file.
-
-        `app.json` also contains a list of environment variables that are required for
-        the application. The `.sample.env` file provides either non-secret vars that
-        can be copied directly into your own `.env` file or instructions on where to
-        obtain secret values.
-
-        During development add any new environment variables needed by the application
-        to both `.sample.env` and `app.json`, providing either **public** default
-        values or brief instructions on where secret values may be found.
-
-        Do not commit the `.env` file to the git repo.
-
-        ## Running the Application
-
-        Use the `heroku local` runner to run the app locally as it would run on Heroku.
-        This uses the node-forman runner, which reads from the `Procfile` file.
-
-        ```sh
-        heroku local
-        ```
-
-        Once the server is started the application is reachable at
-        `http://localhost:3000`.
-      MARKDOWN
-
-      append_to_file "README.md", configure
+      append_template_to_file "README.md", "partials/runner_readme.md"
     end
 
     private

--- a/lib/suspenders/generators/staging/pull_requests_generator.rb
+++ b/lib/suspenders/generators/staging/pull_requests_generator.rb
@@ -4,17 +4,9 @@ module Suspenders
   module Staging
     class PullRequestsGenerator < Generators::Base
       def configure_heroku_staging_pr_pipeline_host
-        config = <<-RUBY
-
-  if ENV.fetch("HEROKU_APP_NAME", "").include?("staging-pr-")
-    ENV["APPLICATION_HOST"] = ENV["HEROKU_APP_NAME"] + ".herokuapp.com"
-    ENV["ASSET_HOST"] = ENV["HEROKU_APP_NAME"] + ".herokuapp.com"
-  end
-        RUBY
-
-        inject_into_file(
+        inject_template_into_file(
           "config/environments/production.rb",
-          config,
+          "partials/pull_requests_config.rb",
           after: "Rails.application.configure do\n",
         )
       end

--- a/spec/features/ci_spec.rb
+++ b/spec/features/ci_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+
+RSpec.describe "suspenders:ci", type: :generator do
+  it "configures Circle with SimpleCov" do
+    with_app { generate("suspenders:ci") }
+
+    expect("Gemfile").to match_contents(/simplecov/)
+    expect("test/test_helper.rb").to match_contents(/SimpleCov.coverage_dir/)
+    expect("test/test_helper.rb").to match_contents(/SimpleCov.start/)
+    expect("circle.yml").to exist_as_a_file
+  end
+
+  it "removes Circle and SimpleCov" do
+    with_app { destroy("suspenders:ci") }
+
+    expect("circle.yml").not_to exist_as_a_file
+    expect("test/test_helper.rb").not_to match_contents(/SimpleCov/)
+    expect("Gemfile").not_to match_contents(/simplecov/)
+  end
+
+  it "configures RSpec" do
+    with_app do
+      copy_file "spec_helper.rb", "spec/spec_helper.rb"
+
+      generate("suspenders:ci")
+    end
+
+    expect("spec/spec_helper.rb").to match_contents(/SimpleCov.coverage_dir/)
+    expect("spec/spec_helper.rb").to match_contents(/SimpleCov.start/)
+  end
+end

--- a/spec/features/db_optimizations_spec.rb
+++ b/spec/features/db_optimizations_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+RSpec.describe "suspenders:db_optimizations", type: :generator do
+  it "configures bullet" do
+    with_app { generate("suspenders:db_optimizations") }
+
+    expect("Gemfile").to match_contents(/bullet/)
+    expect("config/environments/development.rb").to \
+      match_contents(/Bullet.enable/)
+  end
+
+  it "removes bullet" do
+    with_app { destroy("suspenders:db_optimizations") }
+
+    expect("Gemfile").not_to match_contents(/bullet/)
+    expect("config/environments/development.rb").not_to \
+      match_contents(/Bullet.enable/)
+  end
+end

--- a/spec/features/runner_spec.rb
+++ b/spec/features/runner_spec.rb
@@ -27,13 +27,4 @@ RSpec.describe "suspenders:runner", type: :generator do
 
     expect("bin/setup").to match_contents(/\.sample\.env/)
   end
-
-  private
-
-  def copy_file(from_in_templates, to_in_project)
-    FileUtils.cp(
-      File.join(root_path, "templates", from_in_templates),
-      File.join(project_path, to_in_project),
-    )
-  end
 end

--- a/spec/support/project_files.rb
+++ b/spec/support/project_files.rb
@@ -10,4 +10,16 @@ module ProjectFiles
     path = File.join(project_path, filename)
     FileUtils.rm_rf(path)
   end
+
+  def copy_file(from_in_templates, to_in_project)
+    destination = File.join(project_path, to_in_project)
+    destination_dirname = File.dirname(destination)
+
+    FileUtils.mkdir_p(destination_dirname)
+
+    FileUtils.cp(
+      File.join(root_path, "templates", from_in_templates),
+      destination,
+    )
+  end
 end

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -38,7 +38,6 @@ end
 group :test do
   gem "formulaic"
   gem "launchy"
-  gem "simplecov", require: false
   gem "timecop"
   gem "webmock"
 end

--- a/templates/partials/ci_simplecov.rb
+++ b/templates/partials/ci_simplecov.rb
@@ -1,0 +1,16 @@
+if ENV.fetch("COVERAGE", false)
+  require "simplecov"
+
+  if ENV["CIRCLE_ARTIFACTS"]
+    dir = File.join(ENV["CIRCLE_ARTIFACTS"], "coverage")
+    SimpleCov.coverage_dir(dir)
+  end
+
+
+  SimpleCov.start "rails"
+
+  if defined?(Spring) && ENV["DISABLE_SPRING"].to_i == 1
+    Rails.application.eager_load!
+  end
+end
+

--- a/templates/partials/db_optimizations_configuration.rb
+++ b/templates/partials/db_optimizations_configuration.rb
@@ -1,0 +1,5 @@
+config.after_initialize do
+  Bullet.enable = true
+  Bullet.bullet_logger = true
+  Bullet.rails_logger = true
+end

--- a/templates/partials/deployment_readme.md
+++ b/templates/partials/deployment_readme.md
@@ -1,0 +1,8 @@
+
+## Deploying
+
+If you have previously run the `./bin/setup` script,
+you can deploy to staging and production with:
+
+    % ./bin/deploy staging
+    % ./bin/deploy production

--- a/templates/partials/email_smtp.rb
+++ b/templates/partials/email_smtp.rb
@@ -1,0 +1,3 @@
+
+config.action_mailer.delivery_method = :smtp
+config.action_mailer.smtp_settings = SMTP_SETTINGS

--- a/templates/partials/profiler_readme.md
+++ b/templates/partials/profiler_readme.md
@@ -1,0 +1,8 @@
+
+## Profiler
+
+The [rack-mini-profiler] gem can be enabled by setting
+`RACK_MINI_PROFILER=1` in the environment. This will display a speed
+badge on every page.
+
+[rack-mini-profiler]: https://github.com/MiniProfiler/rack-mini-profiler

--- a/templates/partials/pull_requests_config.rb
+++ b/templates/partials/pull_requests_config.rb
@@ -1,0 +1,5 @@
+if ENV.fetch("HEROKU_APP_NAME", "").include?("staging-pr-")
+  ENV["APPLICATION_HOST"] = ENV["HEROKU_APP_NAME"] + ".herokuapp.com"
+  ENV["ASSET_HOST"] = ENV["HEROKU_APP_NAME"] + ".herokuapp.com"
+end
+

--- a/templates/partials/runner_readme.md
+++ b/templates/partials/runner_readme.md
@@ -1,0 +1,31 @@
+## Configuration
+
+Environment variables during local development are handled by the node-foreman
+project runner. To provide environment variables, create a `.env` file at the
+root of the project. In that file provide the environment variables listed in
+`.sample.env`. The `bin/setup` script does this for you, but be careful about
+overwriting your existing `.env` file.
+
+`app.json` also contains a list of environment variables that are required for
+the application. The `.sample.env` file provides either non-secret vars that
+can be copied directly into your own `.env` file or instructions on where to
+obtain secret values.
+
+During development add any new environment variables needed by the application
+to both `.sample.env` and `app.json`, providing either **public** default
+values or brief instructions on where secret values may be found.
+
+Do not commit the `.env` file to the git repo.
+
+## Running the Application
+
+Use the `heroku local` runner to run the app locally as it would run on Heroku.
+This uses the node-forman runner, which reads from the `Procfile` file.
+
+```sh
+heroku local
+```
+
+Once the server is started the application is reachable at
+`http://localhost:3000`.
+

--- a/templates/partials/runner_setup.rb
+++ b/templates/partials/runner_setup.rb
@@ -1,0 +1,3 @@
+puts "\n== Copying sample env =="
+system! 'cp -i .sample.env .env'
+

--- a/templates/spec_helper.rb
+++ b/templates/spec_helper.rb
@@ -1,9 +1,3 @@
-if ENV.fetch("COVERAGE", false)
-  require "simplecov"
-
-  SimpleCov.start "rails"
-end
-
 require "webmock/rspec"
 require "timecop"
 


### PR DESCRIPTION
This adds a `templates/partials` directory, for storing incomplete
templates. They are named after their generator; for example, the
`runner` generator has templates `runner_readme.md` and
`runner_setup.rb`.

Extract all the heredoc into these templates. This gives us an easier
view into the content and more access to syntax highlighting in more
places (e.g. GitHub).

Along the way, backfill tests for generators without any: `ci` and
`db_optimizations. This exposed an issue with the `ci` generator: it did
not work with the default Rails `test/test_helper.rb`, and it mixed
SimpleCov in various places. So this is a substantial change to that
one generator.

---

[Idea](https://github.com/thoughtbot/suspenders/pull/1019#discussion_r354010635) by @jsilasbailey .