### PR TITLE
Describe generators

### DIFF
--- a/lib/suspenders/generators/base.rb
+++ b/lib/suspenders/generators/base.rb
@@ -10,6 +10,21 @@ module Suspenders
         File.expand_path(File.join("..", "..", "..", "templates"), __dir__)
       end
 
+      def self.inherited(subclass)
+        super
+
+        description_file = File.expand_path(
+          File.join(
+            default_source_root,
+            "descriptions",
+            "#{subclass.generator_name}.md",
+          ),
+        )
+
+        subclass.desc File.read(description_file)
+      rescue Errno::ENOENT
+      end
+
       private
 
       def app_name

--- a/lib/suspenders/generators/stylesheet_base_generator.rb
+++ b/lib/suspenders/generators/stylesheet_base_generator.rb
@@ -7,16 +7,16 @@ module Suspenders
       Bundler.with_clean_env { run "bundle install" }
     end
 
+    def remove_prior_config
+      remove_file "app/assets/stylesheets/application.css"
+    end
+
     def add_css_config
       copy_file(
         "application.scss",
         "app/assets/stylesheets/application.scss",
         force: true,
       )
-    end
-
-    def remove_prior_config
-      remove_file "app/assets/stylesheets/application.css"
     end
 
     def install_bitters

--- a/templates/descriptions/advisories.md
+++ b/templates/descriptions/advisories.md
@@ -1,0 +1,5 @@
+Show security advisories during development.
+
+Uses the `bundler-audit` gem and rake task to update the local security
+database and show any relevant issues with the app's dependencies. This happens
+on every test run and interaction with `bin/rake` and `bin/rails`.

--- a/templates/descriptions/analytics.md
+++ b/templates/descriptions/analytics.md
@@ -1,0 +1,4 @@
+Work with a user analytics service.
+
+Add the JavaScript for connecting to Segment to a partial and, if possible,
+include that partial on every page.

--- a/templates/descriptions/ci.md
+++ b/templates/descriptions/ci.md
@@ -1,0 +1,4 @@
+Prepare the app for running tests on a continuous integration service.
+
+Sets up a CircleCI configuration using `bin/setup` to initialize the app and
+`rake` to run the tests. Use SimpleCov for code coverage metrics on CI.

--- a/templates/descriptions/compression.md
+++ b/templates/descriptions/compression.md
@@ -1,0 +1,4 @@
+Compress HTTP requests at the Rails layer.
+
+This uses `Rack::Deflater`, and is done at the app layer instead of at the Web
+server layer.

--- a/templates/descriptions/db_optimizations.md
+++ b/templates/descriptions/db_optimizations.md
@@ -1,0 +1,2 @@
+Get database performance insights as you develop. This installs and configures
+Bullet.

--- a/templates/descriptions/deployment.md
+++ b/templates/descriptions/deployment.md
@@ -1,0 +1,5 @@
+Script and document the deployment.
+
+This adds a `bin/deploy` script, to be called like `deploy staging` or
+`deploy production`, along with updates to the README.md describing how to use
+it.

--- a/templates/descriptions/email.md
+++ b/templates/descriptions/email.md
@@ -1,0 +1,9 @@
+Configure the app for email.
+
+Set the app up with SMTP in production. This expects the following environment
+variables to be set:
+
+- `SMTP_ADDRESS`
+- `SMTP_DOMAIN`
+- `SMTP_PASSWORD`
+- `SMTP_USERNAME`

--- a/templates/descriptions/factories.md
+++ b/templates/descriptions/factories.md
@@ -1,0 +1,12 @@
+Build test data with clarity and ease.
+
+This uses FactoryBot to help you define dummy and test data for your test
+suite. The `create`, `build`, and `build_stubbed` class methods are directly
+available to all tests.
+
+We recommend putting FactoryBot definitions in one `spec/factories.rb` file, at
+least until it grows unwieldy. This helps reduce confusion around circular
+dependencies and makes it easy to jump between definitions.
+
+Outside of the tests, the `dev:prime` rake task can be used to insert initial
+development data into the database. You can use FactoryBot here, too.

--- a/templates/descriptions/force_tls.md
+++ b/templates/descriptions/force_tls.md
@@ -1,0 +1,1 @@
+Redirect users to the HTTPS URL on the production Web site.

--- a/templates/descriptions/forms.md
+++ b/templates/descriptions/forms.md
@@ -1,0 +1,1 @@
+Make forms easier to make with form helpers. This mostly involves SimpleForm.

--- a/templates/descriptions/inline_svg.md
+++ b/templates/descriptions/inline_svg.md
@@ -1,0 +1,2 @@
+Render SVG images inline, as a potential performance improvement for the
+viewer.

--- a/templates/descriptions/jobs.md
+++ b/templates/descriptions/jobs.md
@@ -1,0 +1,3 @@
+Set up our favorite job runner.
+
+Currently we like DelayedJob. Run all tests inline by default.

--- a/templates/descriptions/js_driver.md
+++ b/templates/descriptions/js_driver.md
@@ -1,0 +1,4 @@
+Set up the test suite for running JavaScript tests.
+
+This uses the latest and greatest JavaScript test runner -- currently,
+chromedriver. It comes with a headless mode and a headful/debugging mode.

--- a/templates/descriptions/json.md
+++ b/templates/descriptions/json.md
@@ -1,0 +1,1 @@
+Use the fastest JSON parser available.

--- a/templates/descriptions/lint.md
+++ b/templates/descriptions/lint.md
@@ -1,0 +1,3 @@
+Prepare the app for style linting.
+
+This sets up your app to use Hound with a default Hound configuration.

--- a/templates/descriptions/manifest.md
+++ b/templates/descriptions/manifest.md
@@ -1,0 +1,2 @@
+Write the AppManifest (`app.json`) document with all the environment variables
+we require.

--- a/templates/descriptions/preloader.md
+++ b/templates/descriptions/preloader.md
@@ -1,0 +1,3 @@
+Speed up your Rails development flow with a preloader.
+
+This installs Spring, including the Spring binstubs.

--- a/templates/descriptions/profiler.md
+++ b/templates/descriptions/profiler.md
@@ -1,0 +1,7 @@
+Show runtime profiling for your Rails app as you develop it.
+
+This uses the `rack-mini-profiler` gem to show a speed badge on every page.
+This is controlled by the `RACK_MINI_PROFILER` environment variable which
+defaults to `0` in the `.sample.env`. Set it to `1` to enable profiling.
+
+Updates your README.md to explain this environment variable.

--- a/templates/descriptions/pull_requests.md
+++ b/templates/descriptions/pull_requests.md
@@ -1,0 +1,4 @@
+Create a staging environment for each pull request.
+
+This glues Heroku review apps to GitHub pull requests, populating the database
+from the generic staging environment on a low-scale review app.

--- a/templates/descriptions/runner.md
+++ b/templates/descriptions/runner.md
@@ -1,0 +1,10 @@
+Set up the app to run locally with ease.
+
+Use Puma and the Rails jobs runner to run the app. This can be done via either
+`heroku local` or any Foreman-compatible project runner (e.g. `foreman start`).
+
+Configure your app using `.env`. Installs a basic `.sample.env` that is meant
+to be checked into git and used as a template for your `.env`. The `bin/setup`
+script is modified to safely copy `.sample.env` to `.env` for you.
+
+Document all of this in the README.

--- a/templates/descriptions/single_redirect.md
+++ b/templates/descriptions/single_redirect.md
@@ -1,0 +1,1 @@
+Canonicalize the URL by configuring the `Rack::CanonicalHost` middleware.

--- a/templates/descriptions/static.md
+++ b/templates/descriptions/static.md
@@ -1,0 +1,5 @@
+Easily add static pages to your dynamic Rails app.
+
+Files placed in the `app/views/pages` directory are rendered using the standard
+Rails view renderer and accessible at `/pages/:view_name`, via the
+`high_voltage` gem.

--- a/templates/descriptions/stylelint.md
+++ b/templates/descriptions/stylelint.md
@@ -1,0 +1,3 @@
+Enable stylesheet linting.
+
+This configures the stylelint tool to work locally and integrated with Hound.

--- a/templates/descriptions/stylesheet_base.md
+++ b/templates/descriptions/stylesheet_base.md
@@ -1,0 +1,4 @@
+Set up the basic tools needed for the thoughtbot design system.
+
+This integrates the Bourbon library of Scss mixins with Normalize.css as a
+reset, then re-styles it by bringing Bitters into your project.

--- a/templates/descriptions/testing.md
+++ b/templates/descriptions/testing.md
@@ -1,0 +1,9 @@
+Set up the project for an in-depth test-driven development workflow.
+
+- Maintain the test DB schema.
+- Clear mail deliveries between tests.
+- Import i18n helpers for use in tests.
+- Prepare for system tests in `spec/system`.
+- Integrate Formulaic for easier form testing.
+- RSpec infers the file type based on the directory name.
+- Install and configure RSpec and shoulda-matchers, with Spring integration.

--- a/templates/descriptions/timeout.md
+++ b/templates/descriptions/timeout.md
@@ -1,0 +1,4 @@
+Kill Rack requests that last too long.
+
+This adds the `rack-timeout` gem and configures it to kill the connection after
+10 seconds.

--- a/templates/descriptions/views.md
+++ b/templates/descriptions/views.md
@@ -1,0 +1,8 @@
+View templates for flash, JavaScript, and CSS.
+
+- Disable CSS animations in tests.
+- Run JavaScript when the page has loaded.
+- Use the `title` gem for controlling the page title via i18n.
+- Insert one-off JavaScript into a `:javascript` content block.
+- Creates the directory for storing generic, application-level partials.
+- Render user-facing partials (alert, error, notice, success) on all pages.


### PR DESCRIPTION
This adds a description to all of our generators, except for the main
one. The main one will continue to use the `USAGE` file.

The descriptions are stored in a Markdown file under
`templates/descriptions`, named after the generator. For example,
`Suspenders::ViewsGenerator` is described by
`templates/descriptions/views.md`.

A little metaprogramming is used in the parent class to make this
seamless for the generators.

---

While here, fix a few generators:

- ~~`.env` is now `.sample.env`.~~ #1036 
- Move the `remove_prior_config` method up, so we don't remove the
config that we just added.