### PR TITLE
Add suspenders to rails app earlier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm: 2.6.5
 cache: bundler
 before_install:
-  - nvm install 8.16.0
+  - nvm install 13.12.0
   - git config --global user.name 'Travis CI'
   - git config --global user.email 'travis-ci@example.com'
   - gem update --system

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -1,0 +1,1 @@
+gem "suspenders", path: File.expand_path("../..", __dir__)

--- a/spec/support/suspenders.rb
+++ b/spec/support/suspenders.rb
@@ -38,14 +38,10 @@ module SuspendersTestHelpers
       add_fakes_to_path
 
       with_revision_for_honeybadger do
-        debug `#{system_rails_bin} new #{APP_NAME}`
+        debug `#{system_rails_bin} new #{APP_NAME} -m #{rails_template_path}`
       end
 
       Dir.chdir(APP_NAME) do
-        File.open("Gemfile", "a") do |file|
-          file.puts %{gem "suspenders", path: #{root_path.inspect}}
-        end
-
         commit_all
       end
     end
@@ -127,6 +123,10 @@ module SuspendersTestHelpers
 
   def root_path
     File.expand_path('../../../', __FILE__)
+  end
+
+  def rails_template_path
+    File.join(root_path, "spec", "support", "rails_template.rb")
   end
 
   def commit_all


### PR DESCRIPTION
We are seeing failures on CI for `Bundler could not find compatible
versions for gem "thor"`.

When our tests run `rails new`, that bundle installs inside the new
Rails application with thor constrained to ">= 0.20.3", "<2.0".
This started resolving to thor 1.0.0 when that version came out last
December (which is when our test suite started failing).
2019.

After running rails new, we add suspenders to the Gemfile of the new
rails application. suspenders depends on bitters, which depends on thor
"~> 0.19". This is incompatible with thor 1.0.0, which by this point is
already in the Gemfile.lock

This commit gets around the problem by adding suspenders to the Gemfile
via a template so it is there before the `bundle install`