### PR TITLE
Upgrade to Bitters 2.0.4

### DIFF
--- a/lib/suspenders/generators/advisories_generator.rb
+++ b/lib/suspenders/generators/advisories_generator.rb
@@ -3,7 +3,11 @@ require_relative "base"
 module Suspenders
   class AdvisoriesGenerator < Generators::Base
     def bundler_audit_gem
-      gem "bundler-audit", require: false, group: %i[development test]
+      gem "bundler-audit",
+          require: false,
+          group: %i[development test],
+          git: "https://github.com/rubysec/bundler-audit.git",
+          branch: "0.7.0"
       Bundler.with_clean_env { run "bundle install" }
     end
 

--- a/suspenders.gemspec
+++ b/suspenders.gemspec
@@ -28,7 +28,7 @@ rush to build something amazing; don't use it if you like missing deadlines.
   s.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.version = Suspenders::VERSION
 
-  s.add_dependency 'bitters', '~> 2.0'
+  s.add_dependency 'bitters', '>= 2.0.4'
   s.add_dependency 'rails', Suspenders::RAILS_VERSION
 
   s.add_development_dependency 'rspec', '~> 3.2'


### PR DESCRIPTION
The most important part of this Bitters release is the updated
dependency on Thor. We were seeing issues like:

```
Bundler could not find compatible versions for gem "thor":
  In snapshot (Gemfile.lock):
    thor (= 1.0.1)

  In Gemfile:
    suspenders was resolved to 1.53.0, which depends on
      bitters (~> 2.0) was resolved to 2.0.3, which depends on
        thor (~> 0.19)

    rails (~> 6.0.2, >= 6.0.2.1) was resolved to 6.0.2.1, which depends on
      railties (= 6.0.2.1) was resolved to 6.0.2.1, which depends on
        thor (>= 0.20.3, < 2.0)
```

Updating Bitters will fix that.