### PR TITLE
Remove Gemfile constraint on sprockets

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -19,7 +19,6 @@ gem "rails", "<%= Suspenders::RAILS_VERSION %>"
 gem "recipient_interceptor"
 gem "sassc-rails"
 gem "skylight"
-gem "sprockets", "< 4"
 gem "title"
 gem "tzinfo-data", platforms: [:mingw, :x64_mingw, :mswin, :jruby]
 gem "webpacker"


### PR DESCRIPTION
Closes #1009

We had locked the version of Sprockets to get around some test failures.
If those test failures are no longer around, we should not lock this
version.