### PR TITLE
Finish .sample.env migration

### DIFF
--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -139,6 +139,7 @@ module Suspenders
 
     def generate_default
       run("spring stop")
+      generate("suspenders:runner")
       generate("suspenders:profiler")
       generate("suspenders:json")
       generate("suspenders:static")
@@ -156,7 +157,6 @@ module Suspenders
       generate("suspenders:analytics")
       generate("suspenders:inline_svg")
       generate("suspenders:advisories")
-      generate("suspenders:runner")
       generate("suspenders:preloader")
     end
 

--- a/lib/suspenders/generators/production/timeout_generator.rb
+++ b/lib/suspenders/generators/production/timeout_generator.rb
@@ -9,7 +9,7 @@ module Suspenders
       end
 
       def configure_rack_timeout
-        append_file ".env", rack_timeout_config
+        append_file ".sample.env", rack_timeout_config
       end
 
       private

--- a/lib/suspenders/generators/profiler_generator.rb
+++ b/lib/suspenders/generators/profiler_generator.rb
@@ -3,12 +3,12 @@ require_relative "base"
 module Suspenders
   class ProfilerGenerator < Generators::Base
     def augment_default_env
-      append_to_file ".env", "RACK_MINI_PROFILER=0\n"
+      append_to_file ".sample.env", "RACK_MINI_PROFILER=0\n"
     rescue Errno::ENOENT
-      create_file ".env", "RACK_MINI_PROFILER=0\n"
+      create_file ".sample.env", "RACK_MINI_PROFILER=0\n"
     rescue Thor::Error => e
       if e.message.match?(/does not appear to exist/)
-        create_file ".env", "RACK_MINI_PROFILER=0\n"
+        create_file ".sample.env", "RACK_MINI_PROFILER=0\n"
       else
         raise
       end

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Suspend a new project with default configuration" do
   end
 
   it "copies dotfiles" do
-    expect(File).to exist("#{project_path}/.env")
+    expect(File).to exist("#{project_path}/.sample.env")
   end
 
   it "doesn't generate test directory" do

--- a/spec/features/profiler_spec.rb
+++ b/spec/features/profiler_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "suspenders:profiler", type: :generator do
     expect("config/initializers/rack_mini_profiler.rb").to \
       match_contents(/Rack::MiniProfilerRails.initialize/)
     expect("Gemfile").to match_contents(/rack-mini-profiler/)
-    expect(".env").to match_contents(/RACK_MINI_PROFILER=0/)
+    expect(".sample.env").to match_contents(/RACK_MINI_PROFILER=0/)
   end
 
   it "removes rack-min-profiler" do
@@ -15,6 +15,6 @@ RSpec.describe "suspenders:profiler", type: :generator do
 
     expect("config/initializers/rack_mini_profiler.rb").not_to exist_as_a_file
     expect("Gemfile").not_to match_contents(/rack-mini-profiler/)
-    expect(".env").not_to exist_as_a_file
+    expect(".sample.env").not_to exist_as_a_file
   end
 end


### PR DESCRIPTION
In a056e1a85398e7140ce60b7c14721f9149cfa2b6 we migrated from `.env` to
`.sample.env`. Some stray `.env` files were left behind; fix those.