### PR TITLE
Fix missing whitespace

### DIFF
--- a/templates/partials/db_optimizations_configuration.rb
+++ b/templates/partials/db_optimizations_configuration.rb
@@ -1,3 +1,5 @@
+
+
 config.after_initialize do
   Bullet.enable = true
   Bullet.bullet_logger = true

--- a/templates/partials/db_optimizations_configuration.rb
+++ b/templates/partials/db_optimizations_configuration.rb
@@ -1,7 +1,7 @@
 
 
-config.after_initialize do
-  Bullet.enable = true
-  Bullet.bullet_logger = true
-  Bullet.rails_logger = true
-end
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.bullet_logger = true
+    Bullet.rails_logger = true
+  end

--- a/templates/partials/email_smtp.rb
+++ b/templates/partials/email_smtp.rb
@@ -1,3 +1,3 @@
 
-config.action_mailer.delivery_method = :smtp
-config.action_mailer.smtp_settings = SMTP_SETTINGS
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = SMTP_SETTINGS


### PR DESCRIPTION
Prior to this PR, using the `DbOptimizationsGenerator` would result in an invalid `config/environments/development.rb` containing the following code:

```ruby
  # Don't care if the mailer can't send.
  config.action_mailer.raise_delivery_errors = falseconfig.after_initialize do
  Bullet.enable = true
  Bullet.bullet_logger = true
  Bullet.rails_logger = true
end
```

Commit b15c906 moved the injected code to a template, and we apparently lost some necessary whitespace in the process.

While we're here, this PR also adds some additional indentation to some of the injected partials so that the generated files look a bit nicer.