### PR TITLE
Switch from chromedriver-helpers to webdrivers.

### DIFF
--- a/lib/suspenders/generators/js_driver_generator.rb
+++ b/lib/suspenders/generators/js_driver_generator.rb
@@ -3,8 +3,7 @@ require_relative "base"
 module Suspenders
   class JsDriverGenerator < Generators::Base
     def add_gems
-      gem "capybara-selenium", group: :test
-      gem "chromedriver-helper", group: :test
+      gem "webdrivers", group: :test
       Bundler.with_clean_env { run "bundle install" }
     end
 

--- a/templates/spec_helper.rb
+++ b/templates/spec_helper.rb
@@ -16,7 +16,10 @@ RSpec.configure do |config|
   config.order = :random
 end
 
-WebMock.disable_net_connect!(allow_localhost: true)
+WebMock.disable_net_connect!(
+  allow_localhost: true,
+  allow: "chromedriver.storage.googleapis.com",
+)
 
 # Only allow Timecop with block syntax
 Timecop.safe_mode = true


### PR DESCRIPTION
This commit replaces the deprecated chromedriver-helpers gem with the still supported webdrivers gem.

It's a backport of a change made to a suspenders-generated project, which has been happily running with this configuration for about a month now.

Fixes #1030