### PR TITLE
Add standard for linting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,9 @@
-require 'bundler/setup'
-require 'bundler/gem_tasks'
-require 'rspec/core/rake_task'
-require 'standard/rake'
+require "bundler/setup"
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+require "standard/rake"
 
 RSpec::Core::RakeTask.new(:rspec)
 
-desc 'Run the test suite'
-task :default => [:rspec, :standard]
+desc "Run the test suite"
+task default: [:rspec, :standard]

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,9 @@
 require 'bundler/setup'
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
+require 'standard/rake'
 
 RSpec::Core::RakeTask.new(:rspec)
 
 desc 'Run the test suite'
-task :default => :rspec
+task :default => [:rspec, :standard]

--- a/lib/suspenders/adapters/heroku.rb
+++ b/lib/suspenders/adapters/heroku.rb
@@ -7,8 +7,8 @@ module Suspenders
 
       def set_heroku_remotes
         remotes = <<~SHELL
-          #{command_to_join_heroku_app('staging')}
-          #{command_to_join_heroku_app('production')}
+          #{command_to_join_heroku_app("staging")}
+          #{command_to_join_heroku_app("production")}
 
           git config heroku.remote staging
         SHELL
@@ -29,28 +29,28 @@ module Suspenders
       end
 
       def set_heroku_rails_secrets
-        %w(staging production).each do |environment|
+        %w[staging production].each do |environment|
           run_toolbelt_command(
             "config:add SECRET_KEY_BASE=#{generate_secret}",
-            environment,
+            environment
           )
         end
       end
 
       def set_heroku_honeybadger_env
-        %w(staging production).each do |environment|
+        %w[staging production].each do |environment|
           run_toolbelt_command(
             "config:add HONEYBADGER_ENV=#{environment}",
-            environment,
+            environment
           )
         end
       end
 
       def set_heroku_backup_schedule
-        %w(staging production).each do |environment|
+        %w[staging production].each do |environment|
           run_toolbelt_command(
             "pg:backups:schedule DATABASE_URL --at '10:00 UTC'",
-            environment,
+            environment
           )
         end
       end
@@ -65,34 +65,34 @@ module Suspenders
         run_toolbelt_command(
           "pipelines:create #{heroku_app_name} \
             -a #{heroku_app_name}-staging --stage staging",
-          "staging",
+          "staging"
         )
 
         run_toolbelt_command(
           "pipelines:add #{heroku_app_name} \
             -a #{heroku_app_name}-production --stage production",
-          "production",
+          "production"
         )
       end
 
       def set_heroku_application_host
-        %w(staging production).each do |environment|
+        %w[staging production].each do |environment|
           run_toolbelt_command(
             "config:add APPLICATION_HOST=#{heroku_app_name}-#{environment}.herokuapp.com",
-            environment,
+            environment
           )
         end
       end
 
       def set_heroku_buildpacks
-        %w(staging production).each do |environment|
+        %w[staging production].each do |environment|
           run_toolbelt_command(
             "buildpacks:add --index 1 heroku/nodejs",
-            environment,
+            environment
           )
           run_toolbelt_command(
             "buildpacks:add --index 2 heroku/ruby",
-            environment,
+            environment
           )
         end
       end
@@ -128,7 +128,7 @@ module Suspenders
 
       def run_toolbelt_command(command, environment)
         app_builder.run(
-          "heroku #{command} --remote #{environment}",
+          "heroku #{command} --remote #{environment}"
         )
       end
     end

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -15,11 +15,11 @@ module Suspenders
       :set_heroku_honeybadger_env,
       :set_heroku_rails_secrets,
       :set_heroku_remotes,
-      :set_heroku_buildpacks,
+      :set_heroku_buildpacks
     )
 
     def readme
-      template 'README.md.erb', 'README.md'
+      template "README.md.erb", "README.md"
     end
 
     def gitignore
@@ -33,7 +33,7 @@ module Suspenders
     def setup_rack_mini_profiler
       copy_file(
         "rack_mini_profiler.rb",
-        "config/initializers/rack_mini_profiler.rb",
+        "config/initializers/rack_mini_profiler.rb"
       )
     end
 
@@ -42,15 +42,15 @@ module Suspenders
     end
 
     def raise_on_delivery_errors
-      replace_in_file 'config/environments/development.rb',
-        'raise_delivery_errors = false', 'raise_delivery_errors = true'
+      replace_in_file "config/environments/development.rb",
+        "raise_delivery_errors = false", "raise_delivery_errors = true"
     end
 
     def set_test_delivery_method
       inject_into_file(
         "config/environments/development.rb",
         "\n  config.action_mailer.delivery_method = :file",
-        after: "config.action_mailer.raise_delivery_errors = true",
+        after: "config.action_mailer.raise_delivery_errors = true"
       )
     end
 
@@ -90,7 +90,7 @@ module Suspenders
 
       RUBY
 
-      inject_into_class 'config/application.rb', 'Application', config
+      inject_into_class "config/application.rb", "Application", config
     end
 
     def configure_local_mail
@@ -98,27 +98,27 @@ module Suspenders
     end
 
     def setup_asset_host
-      replace_in_file 'config/environments/production.rb',
+      replace_in_file "config/environments/production.rb",
         "# config.action_controller.asset_host = 'http://assets.example.com'",
         'config.action_controller.asset_host = ENV.fetch("ASSET_HOST", ENV.fetch("APPLICATION_HOST"))'
 
       if File.exist?("config/initializers/assets.rb")
-        replace_in_file 'config/initializers/assets.rb',
+        replace_in_file "config/initializers/assets.rb",
           "config.assets.version = '1.0'",
           'config.assets.version = (ENV["ASSETS_VERSION"] || "1.0")'
       end
 
-      config = <<-EOD
-config.public_file_server.headers = {
-    "Cache-Control" => "public, max-age=31557600",
-  }
+      config = <<~EOD
+        config.public_file_server.headers = {
+            "Cache-Control" => "public, max-age=31557600",
+          }
       EOD
 
       configure_environment("production", config)
     end
 
     def setup_secret_token
-      template 'secrets.yml', 'config/secrets.yml', force: true
+      template "secrets.yml", "config/secrets.yml", force: true
     end
 
     def disallow_wrapping_parameters
@@ -126,7 +126,7 @@ config.public_file_server.headers = {
     end
 
     def use_postgres_config_template
-      template 'postgresql_database.yml.erb', 'config/database.yml',
+      template "postgresql_database.yml.erb", "config/database.yml",
         force: true
     end
 
@@ -135,9 +135,9 @@ config.public_file_server.headers = {
     end
 
     def replace_gemfile(path)
-      template 'Gemfile.erb', 'Gemfile', force: true do |content|
+      template "Gemfile.erb", "Gemfile", force: true do |content|
         if path
-          content.gsub(%r{gem .suspenders.}) { |s| %{#{s}, path: "#{path}"} }
+          content.gsub(%r{gem .suspenders.}) { |s| %(#{s}, path: "#{path}") }
         else
           content
         end
@@ -145,7 +145,7 @@ config.public_file_server.headers = {
     end
 
     def ruby_version
-      create_file '.ruby-version', "#{Suspenders::RUBY_VERSION}\n"
+      create_file ".ruby-version", "#{Suspenders::RUBY_VERSION}\n"
     end
 
     def configure_i18n_for_missing_translations
@@ -154,7 +154,7 @@ config.public_file_server.headers = {
     end
 
     def configure_action_mailer_in_specs
-      copy_file 'action_mailer.rb', 'spec/support/action_mailer.rb'
+      copy_file "action_mailer.rb", "spec/support/action_mailer.rb"
     end
 
     def configure_time_formats
@@ -163,14 +163,14 @@ config.public_file_server.headers = {
     end
 
     def configure_action_mailer
-      action_mailer_host "development", %{"localhost:3000"}
-      action_mailer_asset_host "development", %{"http://localhost:3000"}
-      action_mailer_host "test", %{"www.example.com"}
-      action_mailer_asset_host "test", %{"http://www.example.com"}
+      action_mailer_host "development", %("localhost:3000")
+      action_mailer_asset_host "development", %("http://localhost:3000")
+      action_mailer_host "test", %("www.example.com")
+      action_mailer_asset_host "test", %("http://www.example.com")
       action_mailer_host "production", %{ENV.fetch("APPLICATION_HOST")}
       action_mailer_asset_host(
         "production",
-        %{ENV.fetch("ASSET_HOST", ENV.fetch("APPLICATION_HOST"))},
+        %{ENV.fetch("ASSET_HOST", ENV.fetch("APPLICATION_HOST"))}
       )
     end
 
@@ -199,15 +199,15 @@ config.public_file_server.headers = {
         "environment.rb",
         "environments/development.rb",
         "environments/production.rb",
-        "environments/test.rb",
+        "environments/test.rb"
       ]
 
       config_files.each do |config_file|
         path = File.join(destination_root, "config/#{config_file}")
 
-        accepted_content = File.readlines(path).reject do |line|
+        accepted_content = File.readlines(path).reject { |line|
           line =~ /^.*#.*$/ || line =~ /^$\n/
-        end
+        }
 
         File.open(path, "w") do |file|
           accepted_content.each { |line| file.puts line }
@@ -216,23 +216,23 @@ config.public_file_server.headers = {
     end
 
     def remove_routes_comment_lines
-      replace_in_file 'config/routes.rb',
+      replace_in_file "config/routes.rb",
         /Rails\.application\.routes\.draw do.*end/m,
         "Rails.application.routes.draw do\nend"
     end
 
     def setup_default_rake_task
-      append_file 'Rakefile' do
-        <<-EOS
-task(:default).clear
-task default: [:spec]
-
-if defined? RSpec
-  task(:spec).clear
-  RSpec::Core::RakeTask.new(:spec) do |t|
-    t.verbose = false
-  end
-end
+      append_file "Rakefile" do
+        <<~EOS
+          task(:default).clear
+          task default: [:spec]
+          
+          if defined? RSpec
+            task(:spec).clear
+            RSpec::Core::RakeTask.new(:spec) do |t|
+              t.verbose = false
+            end
+          end
         EOS
       end
     end
@@ -240,7 +240,7 @@ end
     private
 
     def raise_on_missing_translations_in(environment)
-      config = 'config.action_view.raise_on_missing_translations = true'
+      config = "config.action_view.raise_on_missing_translations = true"
 
       uncomment_lines("config/environments/#{environment}.rb", config)
     end

--- a/lib/suspenders/generators/advisories_generator.rb
+++ b/lib/suspenders/generators/advisories_generator.rb
@@ -9,7 +9,7 @@ module Suspenders
 
     def rake_task
       copy_file "bundler_audit.rake", "lib/tasks/bundler_audit.rake"
-      append_file "Rakefile", %{\ntask default: "bundle:audit"\n}
+      append_file "Rakefile", %(\ntask default: "bundle:audit"\n)
     end
   end
 end

--- a/lib/suspenders/generators/analytics_generator.rb
+++ b/lib/suspenders/generators/analytics_generator.rb
@@ -10,7 +10,7 @@ module Suspenders
     def render_partial
       if File.exist?(js_partial)
         inject_into_file js_partial,
-          %{\n\n<%= render "analytics" %>},
+          %(\n\n<%= render "analytics" %>),
           after: "<%= yield :javascript %>"
       end
     end

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -1,39 +1,39 @@
-require 'rails/generators'
-require 'rails/generators/rails/app/app_generator'
+require "rails/generators"
+require "rails/generators/rails/app/app_generator"
 
 module Suspenders
   class AppGenerator < Rails::Generators::AppGenerator
     hide!
 
     class_option :database, type: :string, aliases: "-d", default: "postgresql",
-      desc: "Configure for selected database (options: #{DATABASES.join("/")})"
+                            desc: "Configure for selected database (options: #{DATABASES.join("/")})"
 
     class_option :heroku, type: :boolean, aliases: "-H", default: false,
-      desc: "Create staging and production Heroku apps"
+                          desc: "Create staging and production Heroku apps"
 
     class_option :heroku_flags, type: :string, default: "",
-      desc: "Set extra Heroku flags"
+                                desc: "Set extra Heroku flags"
 
     class_option :github, type: :string, default: nil,
-      desc: "Create Github repository and add remote origin pointed to repo"
+                          desc: "Create Github repository and add remote origin pointed to repo"
 
     class_option :version, type: :boolean, aliases: "-v", group: :suspenders,
-      desc: "Show Suspenders version number and quit"
+                           desc: "Show Suspenders version number and quit"
 
-    class_option :help, type: :boolean, aliases: '-h', group: :suspenders,
-      desc: "Show this help message and quit"
+    class_option :help, type: :boolean, aliases: "-h", group: :suspenders,
+                        desc: "Show this help message and quit"
 
     class_option :path, type: :string, default: nil,
-      desc: "Path to the gem"
+                        desc: "Path to the gem"
 
     class_option :skip_test, type: :boolean, default: true,
-      desc: "Skip Test Unit"
+                             desc: "Skip Test Unit"
 
     class_option :skip_system_test,
-                 type: :boolean, default: true, desc: "Skip system test files"
+      type: :boolean, default: true, desc: "Skip system test files"
 
     class_option :skip_turbolinks,
-                 type: :boolean, default: true, desc: "Skip turbolinks gem"
+      type: :boolean, default: true, desc: "Skip turbolinks gem"
 
     def finish_template
       invoke :suspenders_customization
@@ -59,13 +59,13 @@ module Suspenders
 
     def customize_gemfile
       build :replace_gemfile, options[:path]
-      bundle_command 'install'
+      bundle_command "install"
     end
 
     def setup_database
-      say 'Setting up database'
+      say "Setting up database"
 
-      if 'postgresql' == options[:database]
+      if options[:database] == "postgresql"
         build :use_postgres_config_template
       end
 
@@ -73,7 +73,7 @@ module Suspenders
     end
 
     def setup_development_environment
-      say 'Setting up the development environment'
+      say "Setting up the development environment"
       build :configure_local_mail
       build :raise_on_missing_assets_in_test
       build :raise_on_delivery_errors
@@ -86,17 +86,17 @@ module Suspenders
     end
 
     def setup_production_environment
-      say 'Setting up the production environment'
+      say "Setting up the production environment"
       build :setup_asset_host
     end
 
     def setup_secret_token
-      say 'Moving secret token out of version control'
+      say "Moving secret token out of version control"
       build :setup_secret_token
     end
 
     def configure_app
-      say 'Configuring app'
+      say "Configuring app"
       build :configure_action_mailer
       build :configure_time_formats
       build :setup_default_rake_task
@@ -119,13 +119,13 @@ module Suspenders
 
     def create_github_repo
       if !options[:skip_git] && options[:github]
-        say 'Creating Github repo'
+        say "Creating Github repo"
         build :create_github_repo, options[:github]
       end
     end
 
     def copy_miscellaneous_files
-      say 'Copying miscellaneous support files'
+      say "Copying miscellaneous support files"
       build :copy_miscellaneous_files
     end
 
@@ -176,12 +176,12 @@ module Suspenders
     end
 
     def outro
-      say 'Congratulations! You just pulled our suspenders.'
+      say "Congratulations! You just pulled our suspenders."
       say honeybadger_outro
     end
 
     def self.banner
-      "suspenders #{arguments.map(&:usage).join(' ')} [options]"
+      "suspenders #{arguments.map(&:usage).join(" ")} [options]"
     end
 
     protected

--- a/lib/suspenders/generators/base.rb
+++ b/lib/suspenders/generators/base.rb
@@ -17,8 +17,8 @@ module Suspenders
           File.join(
             default_source_root,
             "descriptions",
-            "#{subclass.generator_name}.md",
-          ),
+            "#{subclass.generator_name}.md"
+          )
         )
 
         subclass.desc File.read(description_file)

--- a/lib/suspenders/generators/db_optimizations_generator.rb
+++ b/lib/suspenders/generators/db_optimizations_generator.rb
@@ -3,7 +3,7 @@ require_relative "base"
 module Suspenders
   class DbOptimizationsGenerator < Generators::Base
     def add_bullet
-      gem "bullet", group: %i(development test)
+      gem "bullet", group: %i[development test]
       Bundler.with_unbundled_env { run "bundle install" }
     end
 
@@ -11,7 +11,7 @@ module Suspenders
       inject_template_into_file(
         "config/environments/development.rb",
         "partials/db_optimizations_configuration.rb",
-        after: /config.action_mailer.raise_delivery_errors = .*/,
+        after: /config.action_mailer.raise_delivery_errors = .*/
       )
     end
   end

--- a/lib/suspenders/generators/factories_generator.rb
+++ b/lib/suspenders/generators/factories_generator.rb
@@ -3,7 +3,7 @@ require_relative "base"
 module Suspenders
   class FactoriesGenerator < Generators::Base
     def add_factory_bot
-      gem "factory_bot_rails", group: %i(development test)
+      gem "factory_bot_rails", group: %i[development test]
       Bundler.with_unbundled_env { run "bundle install" }
     end
 

--- a/lib/suspenders/generators/jobs_generator.rb
+++ b/lib/suspenders/generators/jobs_generator.rb
@@ -14,13 +14,13 @@ module Suspenders
     def initialize_active_job
       copy_file(
         "active_job.rb",
-        "config/initializers/active_job.rb",
+        "config/initializers/active_job.rb"
       )
     end
 
     def configure_active_job
       configure_application_file(
-        "config.active_job.queue_adapter = :delayed_job",
+        "config.active_job.queue_adapter = :delayed_job"
       )
       configure_environment "test", "config.active_job.queue_adapter = :inline"
     end
@@ -31,7 +31,7 @@ module Suspenders
       inject_into_file(
         "config/application.rb",
         "\n    #{config}",
-        before: "\n  end",
+        before: "\n  end"
       )
     end
   end

--- a/lib/suspenders/generators/js_driver_generator.rb
+++ b/lib/suspenders/generators/js_driver_generator.rb
@@ -11,7 +11,7 @@ module Suspenders
       copy_file "chromedriver.rb", "spec/support/chromedriver.rb"
       copy_file(
         "capybara_silence_puma.rb",
-        "spec/support/capybara_silence_puma.rb",
+        "spec/support/capybara_silence_puma.rb"
       )
     end
   end

--- a/lib/suspenders/generators/preloader_generator.rb
+++ b/lib/suspenders/generators/preloader_generator.rb
@@ -54,7 +54,7 @@ module Suspenders
           :always_gsub_file,
           @config_file,
           "config.cache_classes = true",
-          "config.cache_classes = false",
+          "config.cache_classes = false"
         )
       end
 
@@ -63,7 +63,7 @@ module Suspenders
           :always_gsub_file,
           @config_file,
           "config.cache_classes = false",
-          "config.cache_classes = true",
+          "config.cache_classes = true"
         )
       end
     end
@@ -71,10 +71,10 @@ module Suspenders
     protected
 
     def always_run(command, with: nil, verbose: true, env: nil, capture: nil,
-                   abort_on_failure: nil)
+      abort_on_failure: nil)
       destination = relative_to_original_destination_root(
         destination_root,
-        false,
+        false
       )
       desc = "#{command} from #{destination.inspect}"
 

--- a/lib/suspenders/generators/production/compression_generator.rb
+++ b/lib/suspenders/generators/production/compression_generator.rb
@@ -6,7 +6,7 @@ module Suspenders
       def add_rack_deflater
         configure_environment(
           :production,
-          %{config.middleware.use Rack::Deflater},
+          %(config.middleware.use Rack::Deflater)
         )
       end
     end

--- a/lib/suspenders/generators/production/email_generator.rb
+++ b/lib/suspenders/generators/production/email_generator.rb
@@ -14,7 +14,7 @@ module Suspenders
         inject_template_into_file(
           "config/environments/production.rb",
           "partials/email_smtp.rb",
-          after: "config.action_mailer.perform_caching = false",
+          after: "config.action_mailer.perform_caching = false"
         )
       end
 
@@ -22,11 +22,11 @@ module Suspenders
         expand_json(
           "app.json",
           env: {
-            SMTP_ADDRESS: { required: true },
-            SMTP_DOMAIN: { required: true },
-            SMTP_PASSWORD: { required: true },
-            SMTP_USERNAME: { required: true },
-          },
+            SMTP_ADDRESS: {required: true},
+            SMTP_DOMAIN: {required: true},
+            SMTP_PASSWORD: {required: true},
+            SMTP_USERNAME: {required: true}
+          }
         )
       end
     end

--- a/lib/suspenders/generators/production/manifest_generator.rb
+++ b/lib/suspenders/generators/production/manifest_generator.rb
@@ -9,15 +9,15 @@ module Suspenders
           name: app_name.dasherize,
           scripts: {},
           env: {
-            APPLICATION_HOST: { required: true },
-            AUTO_MIGRATE_DB: { value: true },
-            EMAIL_RECIPIENTS: { required: true },
-            HEROKU_APP_NAME: { required: true },
-            HEROKU_PARENT_APP_NAME: { required: true },
-            RACK_ENV: { required: true },
-            SECRET_KEY_BASE: { generator: "secret" },
+            APPLICATION_HOST: {required: true},
+            AUTO_MIGRATE_DB: {value: true},
+            EMAIL_RECIPIENTS: {required: true},
+            HEROKU_APP_NAME: {required: true},
+            HEROKU_PARENT_APP_NAME: {required: true},
+            RACK_ENV: {required: true},
+            SECRET_KEY_BASE: {generator: "secret"}
           },
-          addons: ["heroku-postgresql"],
+          addons: ["heroku-postgresql"]
         )
       end
     end

--- a/lib/suspenders/generators/production/single_redirect.rb
+++ b/lib/suspenders/generators/production/single_redirect.rb
@@ -7,7 +7,7 @@ module Suspenders
         inject_into_file(
           "config/environments/production.rb",
           %{\n  config.middleware.use Rack::CanonicalHost, ENV.fetch("APPLICATION_HOST")},
-          before: "\nend",
+          before: "\nend"
         )
       end
     end

--- a/lib/suspenders/generators/production/timeout_generator.rb
+++ b/lib/suspenders/generators/production/timeout_generator.rb
@@ -15,7 +15,7 @@ module Suspenders
       private
 
       def rack_timeout_config
-        %{RACK_TIMEOUT_SERVICE_TIMEOUT=10}
+        %(RACK_TIMEOUT_SERVICE_TIMEOUT=10)
       end
     end
   end

--- a/lib/suspenders/generators/profiler_generator.rb
+++ b/lib/suspenders/generators/profiler_generator.rb
@@ -24,7 +24,7 @@ module Suspenders
         "rack_mini_profiler.rb",
         "config/initializers/rack_mini_profiler.rb",
         force: false,
-        skip: true,
+        skip: true
       )
     end
 

--- a/lib/suspenders/generators/runner_generator.rb
+++ b/lib/suspenders/generators/runner_generator.rb
@@ -15,18 +15,18 @@ module Suspenders
         inject_template_into_file(
           "bin/setup",
           "partials/runner_setup.rb",
-          before: %{  puts "\\n== Preparing database =="},
+          before: %(  puts "\\n== Preparing database ==")
         )
       elsif bin_setup_mentions_ci?
         inject_into_file(
           "bin/setup",
-          %{  cp -i .sample.env .env\n},
-          after: %{if [ -z "$CI" ]; then\n},
+          %(  cp -i .sample.env .env\n),
+          after: %(if [ -z "$CI" ]; then\n)
         )
       else
         append_to_file(
           "bin/setup",
-          %{\nif [ -z "$CI" ]; then\n  cp -i .sample.env .env\nfi},
+          %(\nif [ -z "$CI" ]; then\n  cp -i .sample.env .env\nfi)
         )
       end
     end

--- a/lib/suspenders/generators/staging/pull_requests_generator.rb
+++ b/lib/suspenders/generators/staging/pull_requests_generator.rb
@@ -7,7 +7,7 @@ module Suspenders
         inject_template_into_file(
           "config/environments/production.rb",
           "partials/pull_requests_config.rb",
-          after: "Rails.application.configure do\n",
+          after: "Rails.application.configure do\n"
         )
       end
 
@@ -15,7 +15,7 @@ module Suspenders
         template(
           "bin_setup_review_app.erb",
           "bin/setup_review_app",
-          force: true,
+          force: true
         )
 
         run "chmod a+x bin/setup_review_app"

--- a/lib/suspenders/generators/stylelint_generator.rb
+++ b/lib/suspenders/generators/stylelint_generator.rb
@@ -26,7 +26,8 @@ module Suspenders
         @base.invoke @generator
       end
 
-      def revoke!; end
+      def revoke!
+      end
     end
 
     class ToggleComments

--- a/lib/suspenders/generators/stylesheet_base_generator.rb
+++ b/lib/suspenders/generators/stylesheet_base_generator.rb
@@ -15,7 +15,7 @@ module Suspenders
       copy_file(
         "application.scss",
         "app/assets/stylesheets/application.scss",
-        force: true,
+        force: true
       )
     end
 

--- a/lib/suspenders/generators/testing_generator.rb
+++ b/lib/suspenders/generators/testing_generator.rb
@@ -4,7 +4,7 @@ module Suspenders
   class TestingGenerator < Generators::Base
     def add_testing_gems
       gem "spring-commands-rspec", group: :development
-      gem "rspec-rails", "~> 3.6", group: %i(development test)
+      gem "rspec-rails", "~> 3.6", group: %i[development test]
       gem "shoulda-matchers", group: :test
 
       Bundler.with_unbundled_env { run "bundle install" }
@@ -24,7 +24,7 @@ module Suspenders
     def provide_shoulda_matchers_config
       copy_file(
         "shoulda_matchers_config_rspec.rb",
-        "spec/support/shoulda_matchers.rb",
+        "spec/support/shoulda_matchers.rb"
       )
     end
 

--- a/lib/suspenders/version.rb
+++ b/lib/suspenders/version.rb
@@ -1,8 +1,8 @@
 module Suspenders
   RAILS_VERSION = "~> 6.0.0".freeze
-  RUBY_VERSION = IO.
-    read("#{File.dirname(__FILE__)}/../../.ruby-version").
-    strip.
-    freeze
+  RUBY_VERSION = IO
+    .read("#{File.dirname(__FILE__)}/../../.ruby-version")
+    .strip
+    .freeze
   VERSION = "1.54.1".freeze
 end

--- a/spec/adapters/heroku_spec.rb
+++ b/spec/adapters/heroku_spec.rb
@@ -10,10 +10,10 @@ module Suspenders
 
         Heroku.new(app_builder).set_heroku_remotes
 
-        expect(app_builder).to have_received(:append_file).
-          with(setup_file, /heroku apps:info --app #{app_name.dasherize}-production/)
-        expect(app_builder).to have_received(:append_file).
-          with(setup_file, /heroku apps:info --app #{app_name.dasherize}-staging/)
+        expect(app_builder).to have_received(:append_file)
+          .with(setup_file, /heroku apps:info --app #{app_name.dasherize}-production/)
+        expect(app_builder).to have_received(:append_file)
+          .with(setup_file, /heroku apps:info --app #{app_name.dasherize}-staging/)
       end
 
       it "sets the heroku rails secrets" do
@@ -23,10 +23,10 @@ module Suspenders
         Heroku.new(app_builder).set_heroku_rails_secrets
 
         expect(app_builder).to(
-          have_configured_var("staging", "SECRET_KEY_BASE"),
+          have_configured_var("staging", "SECRET_KEY_BASE")
         )
         expect(app_builder).to(
-          have_configured_var("production", "SECRET_KEY_BASE"),
+          have_configured_var("production", "SECRET_KEY_BASE")
         )
       end
 
@@ -47,11 +47,11 @@ module Suspenders
         Heroku.new(app_builder).set_heroku_application_host
 
         expect(app_builder).to(
-          have_configured_var("staging", "APPLICATION_HOST"),
+          have_configured_var("staging", "APPLICATION_HOST")
         )
 
         expect(app_builder).to(
-          have_configured_var("production", "APPLICATION_HOST"),
+          have_configured_var("production", "APPLICATION_HOST")
         )
       end
 
@@ -61,16 +61,16 @@ module Suspenders
 
         Heroku.new(app_builder).set_heroku_buildpacks
 
-        %w(staging production).each do |remote|
+        %w[staging production].each do |remote|
           expect(app_builder).to(
             have_configured_buildpack(
-              remote_name: remote, index: 1, packname: "heroku/nodejs",
-            ),
+              remote_name: remote, index: 1, packname: "heroku/nodejs"
+            )
           )
           expect(app_builder).to(
             have_configured_buildpack(
-              remote_name: remote, index: 2, packname: "heroku/ruby",
-            ),
+              remote_name: remote, index: 2, packname: "heroku/ruby"
+            )
           )
         end
       end
@@ -80,8 +80,8 @@ module Suspenders
       end
 
       def have_backup_schedule(remote_name)
-        have_received(:run).
-          with(/pg:backups:schedule DATABASE_URL --at '10:00 UTC' --remote #{remote_name}/)
+        have_received(:run)
+          .with(/pg:backups:schedule DATABASE_URL --at '10:00 UTC' --remote #{remote_name}/)
       end
 
       def have_configured_var(remote_name, var)
@@ -90,7 +90,7 @@ module Suspenders
 
       def have_configured_buildpack(remote_name:, index:, packname:)
         have_received(:run).with(
-          /buildpacks:add --index #{index} #{packname} --remote #{remote_name}/,
+          /buildpacks:add --index #{index} #{packname} --remote #{remote_name}/
         )
       end
     end

--- a/spec/expand_json_spec.rb
+++ b/spec/expand_json_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe Suspenders::Actions::ExpandJson do
           destination_root,
           destination_file_name,
           env: {
-            SMTP_ADDRESS: { required: true },
-          },
+            SMTP_ADDRESS: {required: true}
+          }
         ).invoke!
       end
 
@@ -26,8 +26,8 @@ RSpec.describe Suspenders::Actions::ExpandJson do
           destination_root,
           destination_file_name,
           env: {
-            HEROKU_APP_NAME: { required: true },
-          },
+            HEROKU_APP_NAME: {required: true}
+          }
         ).invoke!
 
         expected = <<~JSON
@@ -53,9 +53,9 @@ RSpec.describe Suspenders::Actions::ExpandJson do
         destination_root,
         destination_file_name,
         env: {
-          foo: { required: true },
-          bar: { required: true },
-        },
+          foo: {required: true},
+          bar: {required: true}
+        }
       ).invoke!
     end
 
@@ -64,8 +64,8 @@ RSpec.describe Suspenders::Actions::ExpandJson do
         destination_root,
         destination_file_name,
         env: {
-          foo: { required: true },
-        },
+          foo: {required: true}
+        }
       ).revoke!
 
       expected = <<~JSON

--- a/spec/fakes/bin/heroku
+++ b/spec/fakes/bin/heroku
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
 
-require File.expand_path(File.join('..', '..', 'support', 'fake_heroku'), File.dirname(__FILE__))
+require File.expand_path(File.join("..", "..", "support", "fake_heroku"), File.dirname(__FILE__))
 
 FakeHeroku.new(ARGV).run!

--- a/spec/fakes/bin/hub
+++ b/spec/fakes/bin/hub
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
 
-require File.expand_path(File.join('..', '..', 'support', 'fake_github'), File.dirname(__FILE__))
+require File.expand_path(File.join("..", "..", "support", "fake_github"), File.dirname(__FILE__))
 
 FakeGithub.new(ARGV).run!

--- a/spec/features/cli_help_spec.rb
+++ b/spec/features/cli_help_spec.rb
@@ -20,10 +20,10 @@ RSpec.describe "Command line help output" do
 
   it "provides help and version usage within the suspenders group" do
     expect(help_text).to include <<~EOH
-Suspenders options:
-  -h, [--help], [--no-help]        # Show this help message and quit
-  -v, [--version], [--no-version]  # Show Suspenders version number and quit
-EOH
+      Suspenders options:
+        -h, [--help], [--no-help]        # Show this help message and quit
+        -v, [--version], [--no-version]  # Show Suspenders version number and quit
+    EOH
   end
 
   it "does not show the default extended rails help section" do

--- a/spec/features/heroku_spec.rb
+++ b/spec/features/heroku_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe "Heroku" do
       expect(FakeHeroku).to have_configured_vars("staging", "SECRET_KEY_BASE")
       expect(FakeHeroku).to have_configured_vars(
         "production",
-        "SECRET_KEY_BASE",
+        "SECRET_KEY_BASE"
       )
-      %w(staging production).each do |env|
+      %w[staging production].each do |env|
         expect(FakeHeroku).to have_configured_vars(env, "APPLICATION_HOST")
         expect(FakeHeroku).to have_configured_vars(env, "HONEYBADGER_ENV")
       end
@@ -42,7 +42,7 @@ RSpec.describe "Heroku" do
   context "--heroku with region flag" do
     before(:all) do
       clean_up
-      run_suspenders(%{--heroku=true --heroku-flags="--region eu"})
+      run_suspenders(%(--heroku=true --heroku-flags="--region eu"))
       setup_app_dependencies
     end
 

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -11,20 +11,20 @@ RSpec.describe "Suspend a new project with default configuration" do
   it "uses custom Gemfile" do
     gemfile_file = IO.read("#{project_path}/Gemfile")
     expect(gemfile_file).to match(
-      /^ruby "#{Suspenders::RUBY_VERSION}"$/,
+      /^ruby "#{Suspenders::RUBY_VERSION}"$/
     )
     expect(gemfile_file).to match(
-      /^gem "autoprefixer-rails"$/,
+      /^gem "autoprefixer-rails"$/
     )
     expect(gemfile_file).to match(
-      /^gem "rails", "#{Suspenders::RAILS_VERSION}"$/,
+      /^gem "rails", "#{Suspenders::RAILS_VERSION}"$/
     )
   end
 
   it "ensures project specs pass" do
     Dir.chdir(project_path) do
       Bundler.with_unbundled_env do
-        expect(`rake`).to include('0 failures')
+        expect(`rake`).to include("0 failures")
       end
     end
   end
@@ -54,8 +54,8 @@ RSpec.describe "Suspend a new project with default configuration" do
   it "loads secret_key_base from env" do
     secrets_file = IO.read("#{project_path}/config/secrets.yml")
 
-    expect(secrets_file).
-      to match(/secret_key_base: <%= ENV\["SECRET_KEY_BASE"\] %>/)
+    expect(secrets_file)
+      .to match(/secret_key_base: <%= ENV\["SECRET_KEY_BASE"\] %>/)
   end
 
   it "adds bin/setup file" do
@@ -85,15 +85,15 @@ RSpec.describe "Suspend a new project with default configuration" do
   end
 
   it "initializes ActiveJob to avoid memory bloat" do
-    expect(File).
-      to exist("#{project_path}/config/initializers/active_job.rb")
+    expect(File)
+      .to exist("#{project_path}/config/initializers/active_job.rb")
   end
 
   it "records pageviews through Segment if ENV variable set" do
-    expect(analytics_partial).
-      to include(%{<% if ENV["SEGMENT_KEY"] %>})
-    expect(analytics_partial).
-      to include(%{analytics.load("<%= ENV["SEGMENT_KEY"] %>");})
+    expect(analytics_partial)
+      .to include(%(<% if ENV["SEGMENT_KEY"] %>))
+    expect(analytics_partial)
+      .to include(%{analytics.load("<%= ENV["SEGMENT_KEY"] %>");})
   end
 
   it "raises on unpermitted parameters in all environments" do
@@ -112,13 +112,13 @@ RSpec.describe "Suspend a new project with default configuration" do
 
   it "configures public_file_server.headers in production" do
     expect(production_config).to match(
-      /^ +config.public_file_server.headers = {\n +"Cache-Control" => "public,/,
+      /^ +config.public_file_server.headers = {\n +"Cache-Control" => "public,/
     )
   end
 
   it "configures production environment to enforce SSL" do
     expect(production_config).to match(
-      /^ +config.force_ssl = true/,
+      /^ +config.force_ssl = true/
     )
   end
 
@@ -141,8 +141,8 @@ RSpec.describe "Suspend a new project with default configuration" do
   end
 
   it "configs :test email delivery method for development" do
-    expect(development_config).
-      to match(/^ +config.action_mailer.delivery_method = :file$/)
+    expect(development_config)
+      .to match(/^ +config.action_mailer.delivery_method = :file$/)
   end
 
   it "sets action mailer default host and asset host" do
@@ -161,8 +161,8 @@ RSpec.describe "Suspend a new project with default configuration" do
     email_file = File.join(project_path, "config", "initializers", "email.rb")
     email_config = IO.read(email_file)
 
-    expect(email_config).
-      to include(%{RecipientInterceptor.new(ENV["EMAIL_RECIPIENTS"])})
+    expect(email_config)
+      .to include(%{RecipientInterceptor.new(ENV["EMAIL_RECIPIENTS"])})
   end
 
   it "configures language in html element" do
@@ -186,26 +186,26 @@ RSpec.describe "Suspend a new project with default configuration" do
     delayed_job = IO.read("#{project_path}/bin/delayed_job")
 
     expect(delayed_job).to match(
-      /^require 'delayed\/command'$/,
+      /^require 'delayed\/command'$/
     )
   end
 
   it "configs bullet gem in development" do
-    expect(development_config).to match /^ +Bullet.enable = true$/
-    expect(development_config).to match /^ +Bullet.bullet_logger = true$/
-    expect(development_config).to match /^ +Bullet.rails_logger = true$/
+    expect(development_config).to match(/^ +Bullet.enable = true$/)
+    expect(development_config).to match(/^ +Bullet.bullet_logger = true$/)
+    expect(development_config).to match(/^ +Bullet.rails_logger = true$/)
   end
 
   it "configs missing assets to raise in test" do
     expect(test_config).to match(
-      /^ +config.assets.raise_runtime_errors = true$/,
+      /^ +config.assets.raise_runtime_errors = true$/
     )
   end
 
   it "adds spring to binstubs" do
     expect(File).to exist("#{project_path}/bin/spring")
 
-    bin_stubs = %w(rake rails rspec)
+    bin_stubs = %w[rake rails rspec]
     bin_stubs.each do |bin_stub|
       expect(IO.read("#{project_path}/bin/#{bin_stub}")).to match(/spring/)
     end
@@ -217,7 +217,7 @@ RSpec.describe "Suspend a new project with default configuration" do
       IO.read("#{project_path}/config/environment.rb"),
       development_config,
       test_config,
-      production_config,
+      production_config
     ]
 
     config_files.each do |file|
@@ -279,34 +279,34 @@ RSpec.describe "Suspend a new project with default configuration" do
   end
 
   it "configures bourbon, and bitters" do
-    app_css = read_project_file(%w(app assets stylesheets application.scss))
+    app_css = read_project_file(%w[app assets stylesheets application.scss])
     expect(app_css).to match(
-      /normalize\.css\/normalize.*bourbon.*base/m,
+      /normalize\.css\/normalize.*bourbon.*base/m
     )
   end
 
   it "doesn't use turbolinks" do
-    app_js = read_project_file(%w(app javascript packs application.js))
+    app_js = read_project_file(%w[app javascript packs application.js])
     expect(app_js).not_to match(/turbolinks/)
   end
 
   it "configures Timecop safe mode" do
-    spec_helper = read_project_file(%w(spec spec_helper.rb))
+    spec_helper = read_project_file(%w[spec spec_helper.rb])
     expect(spec_helper).to match(/Timecop.safe_mode = true/)
   end
 
   def development_config
     @_development_config ||=
-      read_project_file %w(config environments development.rb)
+      read_project_file %w[config environments development.rb]
   end
 
   def test_config
-    @_test_config ||= read_project_file %w(config environments test.rb)
+    @_test_config ||= read_project_file %w[config environments test.rb]
   end
 
   def production_config
     @_production_config ||=
-      read_project_file %w(config environments production.rb)
+      read_project_file %w[config environments production.rb]
   end
 
   def analytics_partial

--- a/spec/features/production/compression_spec.rb
+++ b/spec/features/production/compression_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "suspenders:production:compression", type: :generator do
       with_app { generate("suspenders:production:compression") }
 
       expect("config/environments/production.rb").to match_contents(
-        %r{config.middleware.use Rack::Deflater},
+        %r{config.middleware.use Rack::Deflater}
       )
     end
   end
@@ -16,7 +16,7 @@ RSpec.describe "suspenders:production:compression", type: :generator do
       with_app { destroy("suspenders:production:compression") }
 
       expect("config/environments/production.rb").not_to match_contents(
-        %r{Rack::Deflater},
+        %r{Rack::Deflater}
       )
     end
   end

--- a/spec/features/production/email_spec.rb
+++ b/spec/features/production/email_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe "suspenders:production:email", type: :generator do
 
     expect("app.json").to contain_json(
       env: {
-        SMTP_ADDRESS: { required: true },
-        SMTP_DOMAIN: { required: true },
-        SMTP_PASSWORD: { required: true },
-        SMTP_USERNAME: { required: true },
-      },
+        SMTP_ADDRESS: {required: true},
+        SMTP_DOMAIN: {required: true},
+        SMTP_PASSWORD: {required: true},
+        SMTP_USERNAME: {required: true}
+      }
     )
   end
 
@@ -37,11 +37,11 @@ RSpec.describe "suspenders:production:email", type: :generator do
 
     expect("app.json").not_to contain_json(
       env: {
-        SMTP_ADDRESS: { required: true },
-        SMTP_DOMAIN: { required: true },
-        SMTP_PASSWORD: { required: true },
-        SMTP_USERNAME: { required: true },
-      },
+        SMTP_ADDRESS: {required: true},
+        SMTP_DOMAIN: {required: true},
+        SMTP_PASSWORD: {required: true},
+        SMTP_USERNAME: {required: true}
+      }
     )
   end
 end

--- a/spec/features/production/manifest_spec.rb
+++ b/spec/features/production/manifest_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe "suspenders:production:manifest", type: :generator do
     expect("app.json").to contain_json(
       name: SuspendersTestHelpers::APP_NAME.dasherize,
       env: {
-        APPLICATION_HOST: { required: true },
-        AUTO_MIGRATE_DB: { value: true },
-        EMAIL_RECIPIENTS: { required: true },
-        HEROKU_APP_NAME: { required: true },
-        HEROKU_PARENT_APP_NAME: { required: true },
-        RACK_ENV: { required: true },
-        SECRET_KEY_BASE: { generator: "secret" },
-      },
+        APPLICATION_HOST: {required: true},
+        AUTO_MIGRATE_DB: {value: true},
+        EMAIL_RECIPIENTS: {required: true},
+        HEROKU_APP_NAME: {required: true},
+        HEROKU_PARENT_APP_NAME: {required: true},
+        RACK_ENV: {required: true},
+        SECRET_KEY_BASE: {generator: "secret"}
+      }
     )
   end
 
@@ -24,14 +24,14 @@ RSpec.describe "suspenders:production:manifest", type: :generator do
     expect("app.json").not_to contain_json(
       name: SuspendersTestHelpers::APP_NAME.dasherize,
       env: {
-        APPLICATION_HOST: { required: true },
-        AUTO_MIGRATE_DB: { value: true },
-        EMAIL_RECIPIENTS: { required: true },
-        HEROKU_APP_NAME: { required: true },
-        HEROKU_PARENT_APP_NAME: { required: true },
-        RACK_ENV: { required: true },
-        SECRET_KEY_BASE: { generator: "secret" },
-      },
+        APPLICATION_HOST: {required: true},
+        AUTO_MIGRATE_DB: {value: true},
+        EMAIL_RECIPIENTS: {required: true},
+        HEROKU_APP_NAME: {required: true},
+        HEROKU_PARENT_APP_NAME: {required: true},
+        RACK_ENV: {required: true},
+        SECRET_KEY_BASE: {generator: "secret"}
+      }
     )
   end
 end

--- a/spec/features/production/single_redirect_spec.rb
+++ b/spec/features/production/single_redirect_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "suspenders:production:single_redirect", type: :generator do
       middleware_canonical_host = %r{config.middleware.use Rack::CanonicalHost, ENV.fetch\("APPLICATION_HOST"\)}
 
       expect("config/environments/production.rb").to match_contents(
-        middleware_canonical_host,
+        middleware_canonical_host
       )
     end
   end
@@ -18,7 +18,7 @@ RSpec.describe "suspenders:production:single_redirect", type: :generator do
       middleware_canonical_host = %r{config.middleware.use Rack::CanonicalHost, ENV.fetch\("APPLICATION_HOST"\)}
 
       expect("config/environments/production.rb").not_to match_contents(
-        middleware_canonical_host,
+        middleware_canonical_host
       )
     end
   end

--- a/spec/features/stylelint_spec.rb
+++ b/spec/features/stylelint_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe "suspenders:stylelint", type: :generator do
     it "creates .stylelintrc.json" do
       with_app { generate("suspenders:stylelint") }
 
-      expect(".stylelintrc.json").
-        to match_contents(%r{"extends": "@thoughtbot/stylelint-config"})
+      expect(".stylelintrc.json")
+        .to match_contents(%r{"extends": "@thoughtbot/stylelint-config"})
     end
 
     it "adds stylelint and @thoughtbot/stylelint-config to the package.json" do
@@ -21,7 +21,7 @@ RSpec.describe "suspenders:stylelint", type: :generator do
       with_app { generate("suspenders:stylelint") }
 
       expect(".hound.yml").to(
-        match_contents(/^  config_file: \.stylelintrc\.json/),
+        match_contents(/^  config_file: \.stylelintrc\.json/)
       )
     end
   end
@@ -43,8 +43,8 @@ RSpec.describe "suspenders:stylelint", type: :generator do
       end
 
       expect("package.json").not_to match_contents(/stylelint/)
-      expect("package.json").
-        not_to match_contents(%r{@thoughtbot/stylelint-config})
+      expect("package.json")
+        .not_to match_contents(%r{@thoughtbot/stylelint-config})
     end
 
     it "comments in the hound config_file option" do
@@ -53,8 +53,8 @@ RSpec.describe "suspenders:stylelint", type: :generator do
         destroy("suspenders:stylelint")
       end
 
-      expect(".hound.yml").
-        to match_contents(/^  # config_file: \.stylelintrc\.json/)
+      expect(".hound.yml")
+        .to match_contents(/^  # config_file: \.stylelintrc\.json/)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,10 @@
-require 'bundler/setup'
+require "bundler/setup"
 
 Bundler.require(:default, :test)
 
-require (Pathname.new(__FILE__).dirname + '../lib/suspenders').expand_path
+require (Pathname.new(__FILE__).dirname + "../lib/suspenders").expand_path
 
-Dir['./spec/support/**/*.rb'].each { |file| require file }
+Dir["./spec/support/**/*.rb"].sort.each { |file| require file }
 
 RSpec.configure do |config|
   config.include SuspendersTestHelpers

--- a/spec/support/fake_github.rb
+++ b/spec/support/fake_github.rb
@@ -1,13 +1,13 @@
 class FakeGithub
-  RECORDER = File.expand_path(File.join('..', '..', 'tmp', 'hub_commands'), File.dirname(__FILE__))
+  RECORDER = File.expand_path(File.join("..", "..", "tmp", "hub_commands"), File.dirname(__FILE__))
 
   def initialize(args)
     @args = args
   end
 
   def run!
-    File.open(RECORDER, 'a') do |file|
-      file.write @args.join(' ')
+    File.open(RECORDER, "a") do |file|
+      file.write @args.join(" ")
     end
   end
 

--- a/spec/support/fake_heroku.rb
+++ b/spec/support/fake_heroku.rb
@@ -1,5 +1,5 @@
 class FakeHeroku
-  RECORDER = File.expand_path(File.join('..', '..', 'tmp', 'heroku_commands'), File.dirname(__FILE__))
+  RECORDER = File.expand_path(File.join("..", "..", "tmp", "heroku_commands"), File.dirname(__FILE__))
 
   def initialize(args)
     @args = args
@@ -9,8 +9,8 @@ class FakeHeroku
     if @args.first == "help"
       puts "pipelines      #  manage collections of apps in pipelines"
     end
-    File.open(RECORDER, 'a') do |file|
-      file.puts @args.join(' ')
+    File.open(RECORDER, "a") do |file|
+      file.puts @args.join(" ")
     end
   end
 
@@ -19,7 +19,7 @@ class FakeHeroku
   end
 
   def self.has_gem_included?(project_path, gem_name)
-    gemfile = File.open(File.join(project_path, 'Gemfile'), 'a')
+    gemfile = File.open(File.join(project_path, "Gemfile"), "a")
 
     File.foreach(gemfile).any? do |line|
       line.match(/#{Regexp.quote(gem_name)}/)
@@ -30,10 +30,10 @@ class FakeHeroku
     app_name = "#{SuspendersTestHelpers::APP_NAME.dasherize}-#{environment}"
 
     command = if flags
-                "create #{app_name} #{flags} --remote #{environment}\n"
-              else
-                "create #{app_name} --remote #{environment}\n"
-              end
+      "create #{app_name} #{flags} --remote #{environment}\n"
+    else
+      "create #{app_name} --remote #{environment}\n"
+    end
 
     File.foreach(RECORDER).any? { |line| line == command }
   end

--- a/spec/support/project_files.rb
+++ b/spec/support/project_files.rb
@@ -19,7 +19,7 @@ module ProjectFiles
 
     FileUtils.cp(
       File.join(root_path, "templates", from_in_templates),
-      destination,
+      destination
     )
   end
 end

--- a/spec/support/suspenders.rb
+++ b/spec/support/suspenders.rb
@@ -88,7 +88,7 @@ module SuspendersTestHelpers
   end
 
   def add_fakes_to_path
-    ENV["PATH"] = "#{support_bin}:#{ENV['PATH']}"
+    ENV["PATH"] = "#{support_bin}:#{ENV["PATH"]}"
   end
 
   def project_path
@@ -106,7 +106,7 @@ module SuspendersTestHelpers
   end
 
   def suspenders_bin
-    File.join(root_path, 'bin', 'suspenders')
+    File.join(root_path, "bin", "suspenders")
   end
 
   def system_rails_bin
@@ -122,7 +122,7 @@ module SuspendersTestHelpers
   end
 
   def root_path
-    File.expand_path('../../../', __FILE__)
+    File.expand_path("../../../", __FILE__)
   end
 
   def rails_template_path
@@ -144,7 +144,6 @@ module SuspendersTestHelpers
     ENV[name] = new_value.to_s
 
     yield
-
   ensure
     ENV.delete(name)
 

--- a/suspenders.gemspec
+++ b/suspenders.gemspec
@@ -32,4 +32,5 @@ rush to build something amazing; don't use it if you like missing deadlines.
   s.add_dependency 'rails', Suspenders::RAILS_VERSION
 
   s.add_development_dependency 'rspec', '~> 3.2'
+  s.add_development_dependency 'standard'
 end

--- a/suspenders.gemspec
+++ b/suspenders.gemspec
@@ -1,36 +1,35 @@
-# -*- encoding: utf-8 -*-
-$:.push File.expand_path('../lib', __FILE__)
-require 'suspenders/version'
-require 'date'
+$:.push File.expand_path("../lib", __FILE__)
+require "suspenders/version"
+require "date"
 
 Gem::Specification.new do |s|
   s.required_ruby_version = ">= #{Suspenders::RUBY_VERSION}"
   s.required_rubygems_version = ">= 2.7.4"
-  s.authors = ['thoughtbot']
-  s.date = Date.today.strftime('%Y-%m-%d')
+  s.authors = ["thoughtbot"]
+  s.date = Date.today.strftime("%Y-%m-%d")
 
-  s.description = <<-HERE
-Suspenders is a base Rails project that you can upgrade. It is used by
-thoughtbot to get a jump start on a working app. Use Suspenders if you're in a
-rush to build something amazing; don't use it if you like missing deadlines.
+  s.description = <<~HERE
+    Suspenders is a base Rails project that you can upgrade. It is used by
+    thoughtbot to get a jump start on a working app. Use Suspenders if you're in a
+    rush to build something amazing; don't use it if you like missing deadlines.
   HERE
 
-  s.email = 'support@thoughtbot.com'
-  s.executables = ['suspenders']
+  s.email = "support@thoughtbot.com"
+  s.executables = ["suspenders"]
   s.extra_rdoc_files = %w[README.md LICENSE]
   s.files = `git ls-files`.split("\n")
-  s.homepage = 'http://github.com/thoughtbot/suspenders'
-  s.license = 'MIT'
-  s.name = 'suspenders'
-  s.rdoc_options = ['--charset=UTF-8']
-  s.require_paths = ['lib']
+  s.homepage = "http://github.com/thoughtbot/suspenders"
+  s.license = "MIT"
+  s.name = "suspenders"
+  s.rdoc_options = ["--charset=UTF-8"]
+  s.require_paths = ["lib"]
   s.summary = "Generate a Rails app using thoughtbot's best practices."
   s.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.version = Suspenders::VERSION
 
-  s.add_dependency 'bitters', '>= 2.0.4'
-  s.add_dependency 'rails', Suspenders::RAILS_VERSION
+  s.add_dependency "bitters", ">= 2.0.4"
+  s.add_dependency "rails", Suspenders::RAILS_VERSION
 
-  s.add_development_dependency 'rspec', '~> 3.2'
-  s.add_development_dependency 'standard'
+  s.add_development_dependency "rspec", "~> 3.2"
+  s.add_development_dependency "standard"
 end

--- a/templates/capybara_silence_puma.rb
+++ b/templates/capybara_silence_puma.rb
@@ -1,1 +1,1 @@
-Capybara.server = :puma, { Silent: true }
+Capybara.server = :puma, {Silent: true}

--- a/templates/errors.rb
+++ b/templates/errors.rb
@@ -15,7 +15,7 @@ HTTP_ERRORS = [
   Net::HTTPBadResponse,
   Net::HTTPHeaderSyntaxError,
   Net::ProtocolError,
-  Timeout::Error,
+  Timeout::Error
 ]
 
 SMTP_SERVER_ERRORS = [
@@ -23,12 +23,12 @@ SMTP_SERVER_ERRORS = [
   Net::SMTPAuthenticationError,
   Net::SMTPServerBusy,
   Net::SMTPUnknownError,
-  Timeout::Error,
+  Timeout::Error
 ]
 
 SMTP_CLIENT_ERRORS = [
   Net::SMTPFatalError,
-  Net::SMTPSyntaxError,
+  Net::SMTPSyntaxError
 ]
 
 SMTP_ERRORS = SMTP_SERVER_ERRORS + SMTP_CLIENT_ERRORS

--- a/templates/partials/ci_simplecov.rb
+++ b/templates/partials/ci_simplecov.rb
@@ -6,11 +6,9 @@ if ENV.fetch("COVERAGE", false)
     SimpleCov.coverage_dir(dir)
   end
 
-
   SimpleCov.start "rails"
 
   if defined?(Spring) && ENV["DISABLE_SPRING"].to_i == 1
     Rails.application.eager_load!
   end
 end
-

--- a/templates/partials/db_optimizations_configuration.rb
+++ b/templates/partials/db_optimizations_configuration.rb
@@ -1,7 +1,5 @@
-
-
-  config.after_initialize do
-    Bullet.enable = true
-    Bullet.bullet_logger = true
-    Bullet.rails_logger = true
-  end
+config.after_initialize do
+  Bullet.enable = true
+  Bullet.bullet_logger = true
+  Bullet.rails_logger = true
+end

--- a/templates/partials/email_smtp.rb
+++ b/templates/partials/email_smtp.rb
@@ -1,3 +1,2 @@
-
-  config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = SMTP_SETTINGS
+config.action_mailer.delivery_method = :smtp
+config.action_mailer.smtp_settings = SMTP_SETTINGS

--- a/templates/partials/pull_requests_config.rb
+++ b/templates/partials/pull_requests_config.rb
@@ -2,4 +2,3 @@ if ENV.fetch("HEROKU_APP_NAME", "").include?("staging-pr-")
   ENV["APPLICATION_HOST"] = ENV["HEROKU_APP_NAME"] + ".herokuapp.com"
   ENV["ASSET_HOST"] = ENV["HEROKU_APP_NAME"] + ".herokuapp.com"
 end
-

--- a/templates/partials/runner_setup.rb
+++ b/templates/partials/runner_setup.rb
@@ -1,3 +1,2 @@
 puts "\n== Copying sample env =="
-system! 'cp -i .sample.env .env'
-
+system! "cp -i .sample.env .env"

--- a/templates/spec_helper.rb
+++ b/templates/spec_helper.rb
@@ -18,7 +18,7 @@ end
 
 WebMock.disable_net_connect!(
   allow_localhost: true,
-  allow: "chromedriver.storage.googleapis.com",
+  allow: "chromedriver.storage.googleapis.com"
 )
 
 # Only allow Timecop with block syntax

--- a/templates/spring.rb
+++ b/templates/spring.rb
@@ -2,5 +2,5 @@ Spring.watch(
   ".ruby-version",
   ".rbenv-vars",
   "tmp/restart.txt",
-  "tmp/caching-dev.txt",
+  "tmp/caching-dev.txt"
 )


### PR DESCRIPTION
Add standard for linting
===

https://github.com/testdouble/standard

thoughtbot is moving toward standard instead of Hound + Rubocop:
https://github.com/thoughtbot/guides/pull/606

This commit adds the standard gem and adds standard to the default rake
task

Apply standard fixes
===

This commit applies the changes after running `rake standard:fix`