### PR TITLE
Fix ActionMailer asset host in production.

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -170,7 +170,7 @@ module Suspenders
       action_mailer_host "production", %{ENV.fetch("APPLICATION_HOST")}
       action_mailer_asset_host(
         "production",
-        %{ENV.fetch("ASSET_HOST", ENV.fetch("APPLICATION_HOST"))}
+        %q{"https://#{ENV.fetch("ASSET_HOST", ENV.fetch("APPLICATION_HOST"))}"}
       )
     end
 

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -206,7 +206,7 @@ module Suspenders
         path = File.join(destination_root, "config/#{config_file}")
 
         accepted_content = File.readlines(path).reject { |line|
-          line =~ /^.*#.*$/ || line =~ /^$\n/
+          line =~ /^\s*#.*$/ || line =~ /^$\n/
         }
 
         File.open(path, "w") do |file|

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -168,10 +168,12 @@ module Suspenders
       action_mailer_host "test", %("www.example.com")
       action_mailer_asset_host "test", %("http://www.example.com")
       action_mailer_host "production", %{ENV.fetch("APPLICATION_HOST")}
+      # rubocop:disable Lint/InterpolationCheck
       action_mailer_asset_host(
         "production",
         %q{"https://#{ENV.fetch("ASSET_HOST", ENV.fetch("APPLICATION_HOST"))}"}
       )
+      # rubocop:enable Lint/InterpolationCheck
     end
 
     def create_heroku_apps(flags)

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe "Suspend a new project with default configuration", type: :featur
   it "sets action mailer default host and asset host" do
     config_key = "config.action_mailer.asset_host"
     config_value =
-      %q{ENV\.fetch\("ASSET_HOST", ENV\.fetch\("APPLICATION_HOST"\)\)}
+      %q{"https://#{ENV\.fetch\("ASSET_HOST", ENV\.fetch\("APPLICATION_HOST"\)\)}}
     expect(production_config).to match(/#{config_key} = #{config_value}/)
   end
 

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -214,7 +214,7 @@ RSpec.describe "Suspend a new project with default configuration", type: :featur
     ]
 
     config_files.each do |file|
-      expect(file).not_to match(%r{.*#.*})
+      expect(file).not_to match(/^\s*#.*$/)
       expect(file).not_to eq(file.strip)
       expect(file).not_to match(%r{^$\n\n})
     end

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -147,8 +147,10 @@ RSpec.describe "Suspend a new project with default configuration", type: :featur
 
   it "sets action mailer default host and asset host" do
     config_key = "config.action_mailer.asset_host"
+    # rubocop:disable Lint/InterpolationCheck
     config_value =
       %q{"https://#{ENV\.fetch\("ASSET_HOST", ENV\.fetch\("APPLICATION_HOST"\)\)}}
+    # rubocop:enable Lint/InterpolationCheck
     expect(production_config).to match(/#{config_key} = #{config_value}/)
   end
 


### PR DESCRIPTION
This change was [originally made in a suspenders-based app to fix a problem
we were having with images not rendering in emails][1]. This commit replicates
the fix up-stream for future suspenders users.

The change fixes image URLs in emails by adding a protocol to the
ActionMailer asset_host setting.

While the setting is called "host", based on the examples in the Rails
documentation, it could be more accurately described as a "URL-prefix" --
all of the examples include a protocol as well as a host.

Prior to this change, image URLs were generated in emails from production
environments with a protocol-relative URL (e.g. //example.com/image.png),
and were not rendering correctly in the various mail clients we tested.

[1]: https://github.com/thoughtbot/albaik-web/pull/609