### PR TITLE
Add standard to lint generator

### DIFF
--- a/lib/suspenders/generators/lint_generator.rb
+++ b/lib/suspenders/generators/lint_generator.rb
@@ -5,5 +5,10 @@ module Suspenders
     def set_up_hound
       copy_file "hound.yml", ".hound.yml"
     end
+
+    def set_up_standard
+      gem "standard", group: :development
+      prepend_to_file("Rakefile", 'require "standard/rake"')
+    end
   end
 end

--- a/spec/features/lint_spec.rb
+++ b/spec/features/lint_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+RSpec.describe "suspenders:lint", type: :generator do
+  it "sets up standard" do
+    with_app { generate("suspenders:lint") }
+
+    expect("Gemfile").to match_contents(/standard/)
+
+    run_in_project do
+      expect(`rake -T`).to include("rake standard")
+    end
+  end
+
+  it "removes standard" do
+    with_app do
+      generate("suspenders:lint")
+      destroy("suspenders:lint")
+    end
+
+    expect("Gemfile").not_to match_contents(/standard/)
+
+    run_in_project do
+      expect(`rake -T`).not_to include("rake standard")
+    end
+  end
+end

--- a/templates/hound.yml
+++ b/templates/hound.yml
@@ -7,8 +7,7 @@ javascript:
   enabled: true
   # ignore_file: .javascript_ignore
 ruby:
-  # config_file: .ruby-style.yml
-  enabled: true
+  enabled: false
 scss:
   enabled: false
 stylelint:


### PR DESCRIPTION
This commit adds the [standard] gem, and requires the standard rake task
in the Rakefile.

It also disables RuboCop on Hound, since standard is meant to replace
RuboCop.

[standard]: https://github.com/testdouble/standard

Co-authored-by: Daniel Colson <danieljamescolson@gmail.com>