### PR TITLE
Rails 6.1.1

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -99,8 +99,8 @@ module Suspenders
 
     def setup_asset_host
       replace_in_file "config/environments/production.rb",
-        "# config.action_controller.asset_host = 'http://assets.example.com'",
-        'config.action_controller.asset_host = ENV.fetch("ASSET_HOST", ENV.fetch("APPLICATION_HOST"))'
+        "# config.asset_host = 'http://assets.example.com'",
+        'config.asset_host = ENV.fetch("ASSET_HOST", ENV.fetch("APPLICATION_HOST"))'
 
       if File.exist?("config/initializers/assets.rb")
         replace_in_file "config/initializers/assets.rb",
@@ -240,7 +240,7 @@ module Suspenders
     private
 
     def raise_on_missing_translations_in(environment)
-      config = "config.action_view.raise_on_missing_translations = true"
+      config = "config.i18n.raise_on_missing_translations = true"
 
       uncomment_lines("config/environments/#{environment}.rb", config)
     end

--- a/lib/suspenders/version.rb
+++ b/lib/suspenders/version.rb
@@ -1,5 +1,5 @@
 module Suspenders
-  RAILS_VERSION = "~> 6.0.0".freeze
+  RAILS_VERSION = "~> 6.1.1".freeze
   RUBY_VERSION = IO
     .read("#{File.dirname(__FILE__)}/../../.ruby-version")
     .strip

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe "Suspend a new project with default configuration", type: :featur
   it "raises on missing translations in development and test" do
     [development_config, test_config].each do |environment_file|
       expect(environment_file).to match(
-        /^ +config.action_view.raise_on_missing_translations = true$/
+        /^ +config.i18n.raise_on_missing_translations = true$/
       )
     end
   end

--- a/templates/active_job.rb
+++ b/templates/active_job.rb
@@ -1,4 +1,5 @@
 require "active_job/logging"
+require "active_job/log_subscriber"
 
 ActiveSupport::Notifications.unsubscribe("enqueue.active_job")
 


### PR DESCRIPTION
Along the way some tiny changes were made:

- Use [`config.i18n.raise_on_missing_translations`] instead of the
deprecated setting.
- Unify asset host config under `config.asset_host`.
- Better print-debugging in the test suite for the `destroy` task.

[`config.i18n.raise_on_missing_translations`]: https://github.com/rails/rails/pull/31571

Closes #1060 .