### PR TITLE
Run CI on pushes to main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,9 @@ name: CI
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
   pull_request:
     paths-ignore:
       - 'docs/**'


### PR DESCRIPTION
CI currently runs on manual work flow dispatches for the `main` branch.
This updates CI to run on pushes to the `main` branch.