### PR TITLE
Pull in the DATABASE_URL explicitly

### DIFF
--- a/templates/postgresql_database.yml.erb
+++ b/templates/postgresql_database.yml.erb
@@ -6,6 +6,7 @@ development: &default
   pool: <%%= Integer(ENV.fetch("DB_POOL", 5)) %>
   reaping_frequency: <%%= Integer(ENV.fetch("DB_REAPING_FREQUENCY", 10)) %>
   timeout: 5000
+  url:  <%%= ENV["DATABASE_URL"] %>
 
 test:
   <<: *default


### PR DESCRIPTION
As part of building the Suspenders app, we run `bin/rails db:create`.
This runs under `RAILS_ENV=development` but [creates both the development
and test databases][].

[creates both the development and test databases]: https://github.com/rails/rails/blob/de630cdac82a67edd342a9693d96bcda91a54c08/activerecord/lib/active_record/tasks/database_tasks.rb#L549

There was recent work to [combine the `DATABASE_URL` environment variable
with the existing `config/database.yml`] in ActiveRecord, with the YAML
providing the base and the env var overriding and filling in missing
pieces. This allows us to set the `DATABASE_URL` for CI and have the
tests pick it up.

[combine the `DATABASE_URL` environment variable with the existing `config/database.yml`]: https://github.com/rails/rails/blob/de630cdac82a67edd342a9693d96bcda91a54c08/activerecord/lib/active_record/database_configurations.rb#L180

However, [this merging _only_ works for the current `RAILS_ENV`]. This
means that any of our tests that runs the `suspenders` command line will
output this error:

[this merging _only_ works for the current `RAILS_ENV`]: https://github.com/rails/rails/pull/36770

```
could not connect to server: No such file or directory
	Is the server running locally and accepting
	connections on Unix domain socket "/var/run/postgresql/.s.PGSQL.5432"?
Couldn't create 'dummy_app_test' database. Please check your configuration.
rails aborted!
ActiveRecord::NoDatabaseError: could not connect to server: No such file or directory
	Is the server running locally and accepting
	connections on Unix domain socket "/var/run/postgresql/.s.PGSQL.5432"?
bin/rails:4:in `<main>'

Caused by:
PG::ConnectionBad: could not connect to server: No such file or directory
	Is the server running locally and accepting
	connections on Unix domain socket "/var/run/postgresql/.s.PGSQL.5432"?
bin/rails:4:in `<main>'
Tasks: TOP => db:create
```

(It seems this error does not cause the test to fail, perhaps because we
never check `$?.success?` for our backticks.)

However, [if ActiveRecord finds a `:url` key in the database YAML, it
will slurp that in]. We can use that to read the `DATABASE_URL` from the
environment.

[if ActiveRecord finds a `:url` key in the database YAML, it will slurp that in]: https://github.com/rails/rails/blob/de630cdac82a67edd342a9693d96bcda91a54c08/activerecord/lib/active_record/database_configurations.rb#L238

This should also help developers who have odd DB setups and need a
`DATABASE_URL` set.
