### PR TITLE
A `gem` action

### DIFF
--- a/lib/suspenders/actions.rb
+++ b/lib/suspenders/actions.rb
@@ -142,7 +142,7 @@ module Suspenders
       end
 
       def gem_group(gemfile)
-        groups_re = groups.map {|group| ":#{group}" }.join("[, ]+")
+        groups_re = groups.map { |group| ":#{group}" }.join("[, ]+")
         data = /^group[ (]+#{groups_re}[ )]+do.+?^end/mo.match(gemfile)
 
         if data
@@ -180,8 +180,8 @@ module Suspenders
       end
 
       def remove_gemline(old_content, indentation:, positioning:)
-        group_without_gem = old_content.byteslice(positioning[0], positioning[1]).
-          sub(/^#{" " * indentation}gem[ (]+['"]#{name}.*\n/, "")
+        group_without_gem = old_content.byteslice(positioning[0], positioning[1])
+          .sub(/^#{" " * indentation}gem[ (]+['"]#{name}.*\n/, "")
         new_content = old_content.byteslice(0, positioning[0]) +
           group_without_gem +
           old_content.byteslice((positioning[0] + positioning[1])..)
@@ -192,7 +192,7 @@ module Suspenders
 
       def subsequent_gemline(gemfile, indentation:, positioning:)
         scanner = StringScanner.new(
-          gemfile.byteslice(positioning[0], positioning[1]),
+          gemfile.byteslice(positioning[0], positioning[1])
         )
 
         while scanner.scan_until(/^#{" " * indentation}gem[ (]+['"]([^'"]+)/)
@@ -208,24 +208,24 @@ module Suspenders
         announce
         IO.write(
           gemfile_path,
-          new_content(old_content, position: position, indentation: indentation),
+          new_content(old_content, position: position, indentation: indentation)
         )
       end
 
       def new_content(old_content, position:, indentation:)
         ensure_newline((old_content.byteslice(0, position) || "")) +
-          (" " *indentation) +
+          (" " * indentation) +
           gemline +
           ensure_newline((old_content.byteslice(position..) || ""))
       end
 
       def final_line(gemfile, indentation:, positioning:)
         scanner = StringScanner.new(
-          gemfile.byteslice(positioning[0], positioning[1]),
+          gemfile.byteslice(positioning[0], positioning[1])
         )
         result = nil
 
-        while scanner.scan_until(/#{" " *indentation}gem[ (]+['"][^'"]+['"]/)
+        while scanner.scan_until(/#{" " * indentation}gem[ (]+['"][^'"]+['"]/)
           result = [scanner.pos, scanner.matched.bytes.size]
         end
 
@@ -239,15 +239,15 @@ module Suspenders
       def gemline
         parts = [name, version].compact.map { |part| part.inspect }
 
-        options&.each_pair do |k,v|
-          parts << %{#{k}: #{v.inspect}}
+        options&.each_pair do |k, v|
+          parts << %(#{k}: #{v.inspect})
         end
 
         "gem #{parts.compact.join(", ")}\n"
       end
 
       def announce
-        message = "#{name}"
+        message = name.to_s.dup
 
         if version
           message << " (#{version})"
@@ -259,7 +259,6 @@ module Suspenders
 
         Thor::Base.shell.new.say_status :gemfile, message
       end
-
     end
   end
 end

--- a/lib/suspenders/actions.rb
+++ b/lib/suspenders/actions.rb
@@ -237,10 +237,10 @@ module Suspenders
       end
 
       def gemline
-        parts = [%{"#{name}"}, version]
+        parts = [name, version].compact.map { |part| part.inspect }
 
         options&.each_pair do |k,v|
-          parts << %{#{k}: "#{v}"}
+          parts << %{#{k}: #{v.inspect}}
         end
 
         "gem #{parts.compact.join(", ")}\n"

--- a/lib/suspenders/actions.rb
+++ b/lib/suspenders/actions.rb
@@ -1,3 +1,5 @@
+require "strscan"
+
 module Suspenders
   module Actions
     def replace_in_file(relative_path, find, replace)
@@ -29,6 +31,10 @@ module Suspenders
 
     def expand_json(file, data)
       action ExpandJson.new(destination_root, file, data)
+    end
+
+    def gem(name, version = nil, **options)
+      action Gem.new(destination_root, name, version, **options)
     end
 
     class ExpandJson
@@ -80,6 +86,180 @@ module Suspenders
           end
         end
       end
+    end
+
+    class Gem
+      def initialize(destination_root, name, version, **options)
+        @destination_root = destination_root
+        @name = name
+        @version = version
+        @groups = Array(options.delete(:group))
+        @options = options
+      end
+
+      def invoke!
+        existing_gemfile = IO.read(gemfile_path)
+
+        if groups.present?
+          positioning = gem_group(existing_gemfile)
+
+          if positioning
+            insert_gemline(existing_gemfile, indentation: 2, positioning: positioning)
+          else
+            positioning = final_group(existing_gemfile)
+
+            if positioning
+              insert_gemline(existing_gemfile, indentation: 2, positioning: positioning)
+            else
+              insert_gemline(existing_gemfile, indentation: 2, positioning: [0, existing_gemfile.bytes.size])
+            end
+          end
+        else
+          insert_gemline(existing_gemfile, indentation: 0, positioning: [0, existing_gemfile.bytes.size])
+        end
+      end
+
+      def revoke!
+        existing_gemfile = IO.read(gemfile_path)
+
+        if groups.present?
+          positioning = gem_group(existing_gemfile)
+
+          if positioning
+            remove_gemline(existing_gemfile, indentation: 2, positioning: positioning)
+          end
+        else
+          remove_gemline(existing_gemfile, indentation: 0, positioning: [0, existing_gemfile.bytes.size])
+        end
+      end
+
+      private
+
+      attr_reader :destination_root, :name, :version, :groups, :options
+
+      def gemfile_path
+        File.join(destination_root, "Gemfile")
+      end
+
+      def gem_group(gemfile)
+        groups_re = groups.map {|group| ":#{group}" }.join("[, ]+")
+        data = /^group[ (]+#{groups_re}[ )]+do.+?^end/mo.match(gemfile)
+
+        if data
+          [data.begin(0), data[0].bytes.size]
+        end
+      end
+
+      def final_group(gemfile)
+        scanner = StringScanner.new(gemfile)
+        result = nil
+
+        while scanner.scan_until(/^group.+?do.+?^end+/m)
+          if scanner.matched?
+            result = [scanner.pos, scanner.matched.bytes.size]
+          end
+        end
+
+        result
+      end
+
+      def insert_gemline(gemfile, indentation:, positioning:)
+        position = subsequent_gemline(gemfile, indentation: indentation, positioning: positioning)
+
+        if position
+          insert_gemline_at(gemfile, positioning[0] + position, indentation: indentation)
+        else
+          final_positioning = final_line(gemfile, indentation: indentation, positioning: positioning)
+
+          if final_positioning
+            insert_gemline_at(gemfile, positioning[0] + final_positioning[1], indentation: indentation)
+          else
+            insert_gemline_at(gemfile, positioning[0] + positioning[1], indentation: indentation)
+          end
+        end
+      end
+
+      def remove_gemline(old_content, indentation:, positioning:)
+        group_without_gem = old_content.byteslice(positioning[0], positioning[1]).
+          sub(/^#{" " * indentation}gem[ (]+['"]#{name}.*\n/, "")
+        new_content = old_content.byteslice(0, positioning[0]) +
+          group_without_gem +
+          old_content.byteslice((positioning[0] + positioning[1])..)
+
+        announce
+        IO.write(gemfile_path, new_content)
+      end
+
+      def subsequent_gemline(gemfile, indentation:, positioning:)
+        scanner = StringScanner.new(
+          gemfile.byteslice(positioning[0], positioning[1]),
+        )
+
+        while scanner.scan_until(/^#{" " * indentation}gem[ (]+['"]([^'"]+)/)
+          if name < scanner.captures[0]
+            return scanner.pos - scanner.matched.bytes.size
+          end
+        end
+
+        nil
+      end
+
+      def insert_gemline_at(old_content, position, indentation:)
+        announce
+        IO.write(
+          gemfile_path,
+          new_content(old_content, position: position, indentation: indentation),
+        )
+      end
+
+      def new_content(old_content, position:, indentation:)
+        ensure_newline((old_content.byteslice(0, position) || "")) +
+          (" " *indentation) +
+          gemline +
+          ensure_newline((old_content.byteslice(position..) || ""))
+      end
+
+      def final_line(gemfile, indentation:, positioning:)
+        scanner = StringScanner.new(
+          gemfile.byteslice(positioning[0], positioning[1]),
+        )
+        result = nil
+
+        while scanner.scan_until(/#{" " *indentation}gem[ (]+['"][^'"]+['"]/)
+          result = [scanner.pos, scanner.matched.bytes.size]
+        end
+
+        result
+      end
+
+      def ensure_newline(str)
+        "#{str.chomp}\n"
+      end
+
+      def gemline
+        parts = [%{"#{name}"}, version]
+
+        options&.each_pair do |k,v|
+          parts << %{#{k}: "#{v}"}
+        end
+
+        "gem #{parts.compact.join(", ")}\n"
+      end
+
+      def announce
+        message = "#{name}"
+
+        if version
+          message << " (#{version})"
+        end
+
+        if options[:git]
+          message = options[:git]
+        end
+
+        Thor::Base.shell.new.say_status :gemfile, message
+      end
+
     end
   end
 end

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -143,11 +143,11 @@ module Suspenders
       generate("suspenders:profiler")
       generate("suspenders:json")
       generate("suspenders:static")
-      generate("suspenders:stylesheet_base")
       generate("suspenders:testing")
       generate("suspenders:ci")
       generate("suspenders:js_driver")
       unless options[:api]
+        generate("suspenders:stylesheet_base")
         generate("suspenders:forms")
       end
       generate("suspenders:db_optimizations")

--- a/spec/features/ci_spec.rb
+++ b/spec/features/ci_spec.rb
@@ -11,7 +11,10 @@ RSpec.describe "suspenders:ci", type: :generator do
   end
 
   it "removes Circle and SimpleCov" do
-    with_app { destroy("suspenders:ci") }
+    with_app do
+      generate("suspenders:ci")
+      destroy("suspenders:ci")
+    end
 
     expect("circle.yml").not_to exist_as_a_file
     expect("test/test_helper.rb").not_to match_contents(/SimpleCov/)

--- a/spec/features/static_spec.rb
+++ b/spec/features/static_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe "suspenders:static", type: :generator do
   end
 
   it "removes the gem and pages directory" do
-    with_app { destroy("suspenders:static") }
+    with_app do
+      generate("suspenders:static")
+      destroy("suspenders:static")
+    end
 
     expect("app/views/pages/.keep").not_to exist_as_a_file
     expect("Gemfile").not_to match_contents(/high_voltage/)


### PR DESCRIPTION
For too long we have [suffered] under the tyranny of Rails' mediocre `gem`
action! But Rails 6 took it a step too far: it [no longer] supports a
`destroy` generator.

[suffered]: https://github.com/thoughtbot/suspenders/issues/915
[no longer]:https://github.com/thoughtbot/suspenders/pull/1061#issuecomment-797764390

So it's high time we make our own. In the process, encode the rules we
like to see: keep gems alphabetical, and use the `group` block syntax
instead of the `:group` argument.

When inserting a gem, we have to consider two cases: do we have a group
specification? If we don't have a group name, insert it alphabetically
before the first non-indented `gem "..."` declaration. If we do have a
group name, find the block for that group and insert it alphabetically.
But there's also the chance thar we are the first to add this group, in
which case we should add the group with the `gem` line at the end.

When removing a group, we again consider the groups case. If there is no
group specification, remove the first matching non-indented `gem "..."`
declaration. If we have a group spec, find the group block in the
Gemfile and remove it. If there is no such group block, do nothing.

Closes #915.
