### PR TITLE
Introduce a clear failure message for the match_contents RSpec matcher

### DIFF
--- a/spec/support/match_contents_matcher.rb
+++ b/spec/support/match_contents_matcher.rb
@@ -1,17 +1,18 @@
 RSpec::Matchers.define :match_contents do |regexp|
-  match do |filename|
-    @filename = filename
-    @contents = TestPaths.app_path.join(filename).read
-
-    @contents =~ regexp
+  def file_contents(filename)
+    TestPaths.app_path.join(filename).read
   end
 
-  failure_message do
-    <<~MESSAGE
-      #{@filename} does not match the regex #{regexp}.
-      Contents for #{@filename} are:
+  match do |filename|
+    file_contents(filename) =~ regexp
+  end
 
-      #{@contents}
+  failure_message do |filename|
+    <<~MESSAGE
+      #{filename} does not match the regex #{regexp}.
+      The contents for #{filename} are:
+
+      #{file_contents(filename)}
     MESSAGE
   end
 end

--- a/spec/support/match_contents_matcher.rb
+++ b/spec/support/match_contents_matcher.rb
@@ -1,7 +1,18 @@
 RSpec::Matchers.define :match_contents do |regexp|
   match do |filename|
-    contents = TestPaths.app_path.join(filename).read
-    contents =~ regexp
+    @filename = filename
+    @contents = TestPaths.app_path.join(filename).read
+
+    @contents =~ regexp
+  end
+
+  failure_message do
+    <<~MESSAGE
+      #{@filename} does not match the regex #{regexp}.
+      Contents for #{@filename} are:
+
+      #{@contents}
+    MESSAGE
   end
 end
 


### PR DESCRIPTION
The `match_contents` RSpec matcher is used to match on the contents of files manipulated by a generator.  When a failure happens, however, the reason why it happens is often not clear.

This PR improves the error message and includes the contents of the target file in it to allow for better debugging.