### PR TITLE
Remove remaining spring references

### DIFF
--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -138,7 +138,6 @@ module Suspenders
     end
 
     def generate_default
-      run("spring stop")
       generate("suspenders:runner")
       generate("suspenders:profiler")
       generate("suspenders:json")


### PR DESCRIPTION
In this PR, we are removing the `spring stop` command from `AppGenerator`.

I thought it would be useful to run `spring stop` for individual generators, but within the context where `spring stop` is being removed we generate a full application with the `suspenders` command, so there's no risk of spring running or interfering with anything.