### PR TITLE
Make Suspenders abort when something goes wrong

### DIFF
--- a/lib/suspenders.rb
+++ b/lib/suspenders.rb
@@ -1,4 +1,5 @@
 require "suspenders/version"
+require "suspenders/exit_on_failure"
 require "suspenders/generators/advisories_generator"
 require "suspenders/generators/app_generator"
 require "suspenders/generators/static_generator"

--- a/lib/suspenders/exit_on_failure.rb
+++ b/lib/suspenders/exit_on_failure.rb
@@ -1,0 +1,19 @@
+require "active_support/concern"
+require "English"
+
+module Suspenders
+  module ExitOnFailure
+    extend ActiveSupport::Concern
+
+    def bundle_command(*)
+      super
+      exit(false) if $CHILD_STATUS.exitstatus.nonzero?
+    end
+
+    module ClassMethods
+      def exit_on_failure?
+        true
+      end
+    end
+  end
+end

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -3,6 +3,8 @@ require "rails/generators/rails/app/app_generator"
 
 module Suspenders
   class AppGenerator < Rails::Generators::AppGenerator
+    include ExitOnFailure
+
     hide!
 
     class_option :database, type: :string, aliases: "-d", default: "postgresql",
@@ -34,6 +36,9 @@ module Suspenders
 
     class_option :skip_turbolinks,
       type: :boolean, default: true, desc: "Skip turbolinks gem"
+
+    class_option :skip_spring, type: :boolean, default: true,
+      desc: class_options[:skip_spring].description
 
     def finish_template
       invoke :suspenders_customization
@@ -138,18 +143,16 @@ module Suspenders
     end
 
     def generate_default
-      run("spring stop > /dev/null 2>&1")
+      run("spring stop > /dev/null 2>&1 || true")
       generate("suspenders:runner")
       generate("suspenders:profiler")
       generate("suspenders:json")
       generate("suspenders:static")
-      generate("suspenders:stylesheet_base")
+      generate("suspenders:stylesheet_base") unless options[:api]
       generate("suspenders:testing")
       generate("suspenders:ci")
       generate("suspenders:js_driver")
-      unless options[:api]
-        generate("suspenders:forms")
-      end
+      generate("suspenders:forms") unless options[:api]
       generate("suspenders:db_optimizations")
       generate("suspenders:factories")
       generate("suspenders:lint")

--- a/lib/suspenders/generators/base.rb
+++ b/lib/suspenders/generators/base.rb
@@ -5,6 +5,7 @@ module Suspenders
   module Generators
     class Base < Rails::Generators::Base
       include Suspenders::Actions
+      include ExitOnFailure
 
       def self.default_source_root
         File.expand_path(File.join("..", "..", "..", "templates"), __dir__)

--- a/spec/features/api_spec.rb
+++ b/spec/features/api_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Suspend a new project with --api flag", type: :feature do
   end
 
   it "ensures project specs pass" do
-    run_suspenders("--api")
+    run_suspenders!("--api")
 
     Dir.chdir(project_path) do
       Bundler.with_unbundled_env do

--- a/spec/suspenders/app_generator_spec.rb
+++ b/spec/suspenders/app_generator_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+RSpec.describe Suspenders::AppGenerator do
+  it "includes ExitOnFailure" do
+    expect(described_class.ancestors).to include(Suspenders::ExitOnFailure)
+  end
+
+  it "skips spring by default" do
+    expect(described_class.class_options[:skip_spring]&.default).to be true
+  end
+end

--- a/spec/suspenders/exit_on_failure_spec.rb
+++ b/spec/suspenders/exit_on_failure_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+
+RSpec.describe Suspenders::ExitOnFailure do
+  def make_generator_class(&block)
+    Class.new Rails::Generators::AppBase do
+      include Suspenders::ExitOnFailure
+
+      class_eval(&block)
+    end
+  end
+
+  def generator_exit_status(generator_class)
+    pid = fork do
+      OutputStub.silence { generator_class.start }
+    end
+
+    Process.wait(pid)
+
+    $CHILD_STATUS.exitstatus.zero? ? :exit_success : :exit_failure
+  end
+
+  it "exits with failure status on generator error" do
+    generator_class = make_generator_class do
+      def generator_task
+        copy_file "non_existing_file", "non_existing_destination"
+      end
+    end
+
+    expect(generator_exit_status(generator_class)).to be :exit_failure
+  end
+
+  it "exits with failure status on bundle command error" do
+    generator_class = make_generator_class do
+      def generator_task
+        bundle_command "non_existing_bundle_command 2> /dev/null"
+      end
+    end
+
+    expect(generator_exit_status(generator_class)).to be :exit_failure
+  end
+end

--- a/spec/suspenders/generators/base_spec.rb
+++ b/spec/suspenders/generators/base_spec.rb
@@ -1,0 +1,7 @@
+require "spec_helper"
+
+RSpec.describe Suspenders::Generators::Base do
+  it "includes ExitOnFailure" do
+    expect(described_class.ancestors).to include(Suspenders::ExitOnFailure)
+  end
+end


### PR DESCRIPTION
Closes [#1080](https://github.com/thoughtbot/suspenders/issues/1080)

This task is part of our "Rescue" board: https://github.com/thoughtbot/suspenders/projects/1

## What changed?

`bin/suspenders` is now halting on error. Not halting on error was a huge source of confusion for Suspenders users. Some examples of issues we are resolving here:

- If using the wrong Ruby version, Suspenders will fail loudly. Currently, Suspenders is limited to a single Ruby version (we'll make the Ruby version flexible in another PR.) Example:

```
      create  storage/.keep
      create  tmp/storage
      create  tmp/storage/.keep
      remove  config/initializers/cors.rb
      remove  config/initializers/new_framework_defaults_6_1.rb
       force  Gemfile
         run  bundle install
Your Ruby version is 2.7.5, but your Gemfile specified 2.7.4
```

No more output. The user will instantly know something is wrong and will attempt to fix the error.

- If Postgres is not running, Suspenders will fail when trying to create the database
- If a generator fails because of some unmet requirement, Suspenders will halt as well (recall that every individual generator runs within a subprocess.)

## Changelog

- Override thor's `exit_on_failure?` to `true` on `AppGenerator`. `AppGenerator` is the class that extends `Rails::Generators::AppGenerator` and runs our own version of `rails new` through `bin/suspenders`.
- Override thor's `exit_on_failure?` to `true` on `Suspenders::Generators::Base` (the base class of our individual generators.)
- Make `Rails::Generators::AppGenerator#bundle_command` fail on error. Unfortunately, it is not hooked up to thor's default error handling mechanism, so it won't leverage Thor's `exit_on_failure` setting.
- Override the default value of `skip_spring` to `true`. Rails will still try to generate spring binstubs when finishing up the application, which would make `bin/suspenders` fail given our newly introduced `exit_on_failure` setting.
- Avoid the `spring stop` command from halting `bin/suspenders` when `spring` is not installed or when it calls a binstub that can't find the real `spring`.
- Add unit tests for the new settings. `exit_on_failure` is a `:nodoc:` in Thor, and it's unfortunate they don't provide an official setting for that. If it ever breaks, we'll need to know.
- Don't run the stylesheets generator when `--api` is set. That avoids the stylesheet generator (and thus `bin/suspenders`) from failing with our new settings.
- Rename `DEBUG` => `SHOW_DEBUG` because `DEBUG` is already taken by Ruby and prints out too many symbols.