### PR TITLE
Enforce bundler >= 2.1.0

### DIFF
--- a/suspenders.gemspec
+++ b/suspenders.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "bitters", ">= 2.0.4"
   s.add_dependency "parser", ">= 3.0"
+  s.add_dependency "bundler", ">= 2.1"
   s.add_dependency "rails", Suspenders::RAILS_VERSION
 
   s.add_development_dependency "pry"


### PR DESCRIPTION
Closes https://github.com/thoughtbot/suspenders/issues/1081

References:

- https://github.com/thoughtbot/suspenders/issues/1081
- https://github.com/thoughtbot/suspenders/issues/1047

Suspenders relies on the `Bundler.with_unbundled_env` method, which is only available on Bundler >= 2.1.0

When Suspenders was tied to Ruby 2.6.6 (when https://github.com/thoughtbot/suspenders/issues/1047 was reported), which had Bundler 1.7.2 as a default gem, it could happen that Rails would pick up Bundler 1.7.2 and Suspenders would thus fail when generating a new application.

Now Suspenders uses Ruby 2.7.4, which has Bundler 2.1.4 as a default gem - so even if we manually install Bundler 1.7.2, Rails won't pick that version up in `Gemfile.lock`, so we probably don't risk running into the Bundler problem again.

However, since we depend on Bundler >= 2.1.0, we'd better explicitly encode that dependency, as I'm not sure what the other edge cases (if any) are.