### PR TITLE
Updates default configuration to use requests specs

### DIFF
--- a/lib/suspenders/generators/testing_generator.rb
+++ b/lib/suspenders/generators/testing_generator.rb
@@ -3,7 +3,7 @@ require_relative "base"
 module Suspenders
   class TestingGenerator < Generators::Base
     def add_testing_gems
-      gem "rspec-rails", "~> 3.6", group: %i[development test]
+      gem "rspec-rails", "~> 5.1", group: %i[development test]
       gem "shoulda-matchers", group: :test
 
       Bundler.with_unbundled_env { run "bundle install" }

--- a/lib/suspenders/version.rb
+++ b/lib/suspenders/version.rb
@@ -4,5 +4,5 @@ module Suspenders
     .read("#{File.dirname(__FILE__)}/../../.ruby-version")
     .strip
     .freeze
-  VERSION = "1.55.1".freeze
+  VERSION = "1.55.2".freeze
 end

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -173,6 +173,14 @@ RSpec.describe "Suspend a new project with default configuration", type: :featur
     expect(layout_file).to match(/<html lang="en">/)
   end
 
+  it "configures requests specs" do
+    application_config = IO.read("#{project_path}/config/application.rb")
+
+    expect(application_config).to match(
+      /^ +generate.request_specs true$/
+    )
+  end
+
   it "configs active job queue adapter" do
     application_config = IO.read("#{project_path}/config/application.rb")
 


### PR DESCRIPTION
We were trying out suspenders, e.g. `suspenders projectname`

Then did a scaffold `rails g scaffold Book title`

Then when running the specs (`rspec`) we got an error related to the views not rendering.

A good fix is to use requests specs instead of controller specs, they render the views so they test more code

Fixes #1090
 
Co-Authored-By: Dorian Marié <dorian@dorianmarie.fr>