### PR TITLE
Drop use of git in gemspec

### DIFF
--- a/suspenders.gemspec
+++ b/suspenders.gemspec
@@ -16,14 +16,13 @@ Gem::Specification.new do |s|
   s.email = "support@thoughtbot.com"
   s.executables = ["suspenders"]
   s.extra_rdoc_files = %w[README.md LICENSE]
-  s.files = `git ls-files`.split("\n")
+  s.files = Dir[".ruby-version", "bin/suspenders", "{docs,lib,templates}/**/*", "LICENSE", "*.md"]
   s.homepage = "http://github.com/thoughtbot/suspenders"
   s.license = "MIT"
   s.name = "suspenders"
   s.rdoc_options = ["--charset=UTF-8"]
   s.require_paths = ["lib"]
   s.summary = "Generate a Rails app using thoughtbot's best practices."
-  s.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.version = Suspenders::VERSION
 
   s.add_dependency "bitters", ">= 2.0.4"


### PR DESCRIPTION
Closes https://github.com/thoughtbot/suspenders/issues/1055

Changes `suspenders.gemspec` to not depend on git. Additionally, we can safely remove `s.test_files` since [its use is no longer recommended](https://github.com/rubygems/guides/issues/90) and was introduced in the Suspenders codebase many years ago.