### PR TITLE
Updates default configuration to use requests specs

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -81,7 +81,8 @@ module Suspenders
     config.generators do |generate|
       generate.helper false
       generate.javascripts false
-      generate.request_specs false
+      generate.controller_specs false
+      generate.request_specs true
       generate.routing_specs false
       generate.stylesheets false
       generate.test_framework :rspec
@@ -223,7 +224,7 @@ module Suspenders
         <<~EOS
           task(:default).clear
           task default: [:spec]
-          
+
           if defined? RSpec
             task(:spec).clear
             RSpec::Core::RakeTask.new(:spec) do |t|

--- a/lib/suspenders/generators/testing_generator.rb
+++ b/lib/suspenders/generators/testing_generator.rb
@@ -3,7 +3,7 @@ require_relative "base"
 module Suspenders
   class TestingGenerator < Generators::Base
     def add_testing_gems
-      gem "rspec-rails", "~> 3.6", group: %i[development test]
+      gem "rspec-rails", "~> 5.1", group: %i[development test]
       gem "shoulda-matchers", group: :test
 
       Bundler.with_unbundled_env { run "bundle install" }

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -173,6 +173,14 @@ RSpec.describe "Suspend a new project with default configuration", type: :featur
     expect(layout_file).to match(/<html lang="en">/)
   end
 
+  it "configures requests specs" do
+    application_config = IO.read("#{project_path}/config/application.rb")
+
+    expect(application_config).to match(
+      /^ +generate.request_specs true$/
+    )
+  end
+
   it "configs active job queue adapter" do
     application_config = IO.read("#{project_path}/config/application.rb")
 


### PR DESCRIPTION
Request specs render views and thus can trigger more
code than controller specs

Also controller specs are failing because of rspec-rails
trying to render empty views and an incompatibility being
present

Co-Authored-By: Dorian Marié <dorian@dorianmarie.fr>