### PR TITLE
Run database migrations as the last step of bin/suspenders 

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -135,6 +135,10 @@ module Suspenders
       bundle_command "exec rails db:create db:migrate"
     end
 
+    def run_database_migrations
+      bundle_command "exec rails db:migrate"
+    end
+
     def replace_gemfile(path)
       template "Gemfile.erb", "Gemfile", force: true do |content|
         if path

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -59,6 +59,7 @@ module Suspenders
       invoke :generate_deployment_default
       invoke :remove_config_comment_lines
       invoke :remove_routes_comment_lines
+      invoke :run_database_migrations
       invoke :outro
     end
 
@@ -140,6 +141,10 @@ module Suspenders
 
     def remove_routes_comment_lines
       build :remove_routes_comment_lines
+    end
+
+    def run_database_migrations
+      build :run_database_migrations
     end
 
     def generate_default


### PR DESCRIPTION
This commit ensures that `bundle exec rails db:migrate` is run before the app is generated. Prior to this commit, running `./bin/setup` in the app generated by suspenders would have resulted in a failure due to a pending migration.

Issues
------
Closes #1095

Co-authored-by: Thiago Silva <thiagoaraujos@gmail.com>