### PR TITLE
Automate generator lookup in the development environment

### DIFF
--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -139,10 +139,10 @@ module Suspenders
       bundle_command "exec rails db:migrate"
     end
 
-    def replace_gemfile(path)
+    def replace_gemfile
       template "Gemfile.erb", "Gemfile", force: true do |content|
-        if path
-          content.gsub(%r{gem .suspenders.}) { |s| %(#{s}, path: "#{path}") }
+        if development_env?
+          content.gsub(%r{gem .suspenders.}) { |s| %(#{s}, path: "#{root_path}") }
         else
           content
         end
@@ -240,6 +240,14 @@ module Suspenders
     end
 
     private
+
+    def root_path
+      @root_path ||= Pathname(__dir__).join("..", "..").expand_path
+    end
+
+    def development_env?
+      root_path.join("suspenders.gemspec").exist?
+    end
 
     def raise_on_missing_translations_in(environment)
       config = "config.action_view.raise_on_missing_translations = true"

--- a/lib/suspenders/generators/app_generator.rb
+++ b/lib/suspenders/generators/app_generator.rb
@@ -25,9 +25,6 @@ module Suspenders
     class_option :help, type: :boolean, aliases: "-h", group: :suspenders,
       desc: "Show this help message and quit"
 
-    class_option :path, type: :string, default: nil,
-      desc: "Path to the gem"
-
     class_option :skip_test, type: :boolean, default: true,
       desc: "Skip Test Unit"
 
@@ -64,7 +61,7 @@ module Suspenders
     end
 
     def customize_gemfile
-      build :replace_gemfile, options[:path]
+      build :replace_gemfile
       bundle_command "install"
     end
 

--- a/spec/support/feature_test_helpers.rb
+++ b/spec/support/feature_test_helpers.rb
@@ -12,10 +12,9 @@ module FeatureTestHelpers
   end
 
   def run_suspenders(arguments = nil)
-    arguments = "--path=#{root_path} #{arguments}"
     run_in_tmp do
       EnvPath.prepend_env_path!(fake_bin_path)
-      command = "#{suspenders_bin} _#{rails_version}_ #{APP_NAME} #{arguments}"
+      command = "#{suspenders_bin} #{APP_NAME} #{arguments}"
 
       with_revision_for_honeybadger do
         result = `#{command}`
@@ -58,7 +57,7 @@ module FeatureTestHelpers
       EnvPath.prepend_env_path!(fake_bin_path)
 
       with_revision_for_honeybadger do
-        debug `#{system_rails_bin} _#{rails_version}_ new #{APP_NAME} --skip-spring -d postgresql -m #{rails_template_path}`
+        debug `#{system_rails_bin} new #{APP_NAME} --skip-spring -d postgresql -m #{rails_template_path}`
       end
 
       Dir.chdir(APP_NAME) do
@@ -125,10 +124,6 @@ module FeatureTestHelpers
 
   def rails_template_path
     root_path.join("spec", "support", "rails_template.rb")
-  end
-
-  def rails_version
-    Rails::VERSION::STRING
   end
 
   def commit_all


### PR DESCRIPTION
Problem
-------

Some facts

- Suspenders includes itself in the generated application's `Gemfile`

- Suspenders generators run in the context of the generated
applications

- Generated applications include Suspenders as a development dependency

Given the last item, if we're running Suspenders in development, we'd
end up with two copies of it: the development copy and a gem copy. The
problem is that:

- The development copy will start up Suspenders

- Generators, since they run in the context of an application, will be
picked up from the gem

Therefore, running `bin/suspenders` in development may put us in a
situation where the development copy has changes that the gem copy
does not, which means our code changes would not fully apply.

To prevent such a mismatch, the existing solution is to run Suspenders
with `--path`, which inserts a `path` option in the Gemfile:

```ruby
gem "suspenders", path: "..."
```

To activate this behavior, running `bin/suspenders` with a `--path`
option is necessary:

```sh
bin/suspenders myapp --path=$HOME/suspenders
```

That is not an intuitive solution and may trip up developers working
on Suspenders, which won't always remember to use `--path`. What if we
could infer when to use a `path` option in the Gemfile by detecting if
we're running in development? We can certainly do that.

`bin/suspenders` should just work regardless of the environment, and
we shouldn't remember to pass any extra options for it to work.

Solution
--------

- Delete the `--path` option, including tests

- Infer the current environment by checking if the
`suspenders.gemspec` file exists. If so, it certainly means we're in
the development environment.
