### PR TITLE
Fix bundler error on bin/suspenders script

### DIFF
--- a/bin/suspenders
+++ b/bin/suspenders
@@ -23,13 +23,9 @@ if str = ARGV.first
       abort "Suspenders error: Unable to find Rails version #{rails_version}"
     end
   else
-    require "bundler"
+    require "suspenders/version"
 
-    spec = Bundler.definition.specs.find { |s| s.name == "rails" }
-
-    if spec.nil?
-      abort "Suspenders error: Unable to find Rails in Bundle"
-    end
+    spec = Gem::Specification.find_by_name("rails", Suspenders::RAILS_VERSION)
 
     activate_rails_version.call(spec.version.to_s)
   end


### PR DESCRIPTION
Sometimes `bin/suspenders` would pick up the maximum installed Rails
version but Suspenders would freeze the Rails version to
`Suspenders::RAILS_VERSION` on the generated application -- and
therefore `bin/suspenders` would fail with a confusing error.

A fix for that was attempted in this commit:
https://github.com/thoughtbot/suspenders/commit/f3ce221d553e611d1c8e32a22cafd9fa214999f8

However, that fix tried to use Bundler, which is only available in the
context of an application that has a Gemfile. It was only tested on
the local development environment, which runs within a Bundler
context. We'll do what we can to not repeat that error in the future.

The correct fix should find a compatible Rails gem using rubygem's
API (and not Bundler) and then activate it so that `bin/suspenders` can
run. A compatible Rails version (currently `'~> 6.0.0'`) will always be
available because Rails is a dependency of the Suspenders gem, so we
don't need to throw an error if the version can't be found.