### PR TITLE
Replace Delayed::Job with Sidekiq

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ It includes application gems like:
 * [Autoprefixer Rails](https://github.com/ai/autoprefixer-rails) for CSS vendor prefixes
 * [Bourbon](https://github.com/thoughtbot/bourbon) for Sass mixins
 * [Bitters](https://github.com/thoughtbot/bitters) for scaffold application styles
-* [Delayed Job](https://github.com/collectiveidea/delayed_job) for background
+* [Sidekiq](https://github.com/mperham/sidekiq) for background
   processing
 * [High Voltage](https://github.com/thoughtbot/high_voltage) for static pages
 * [Honeybadger](https://www.honeybadger.io/?affiliate=A43uwl) for exception notification
@@ -182,6 +182,8 @@ requires Google Chrome or Chromium.
 [Google Chromedriver]: https://sites.google.com/a/chromium.org/chromedriver/home
 
 PostgreSQL needs to be installed and running for the `db:create` rake task.
+
+Redis needs to be installed and running for Sidekiq
 
 ## Issues
 

--- a/lib/suspenders/generators/jobs_generator.rb
+++ b/lib/suspenders/generators/jobs_generator.rb
@@ -3,12 +3,8 @@ require_relative "base"
 module Suspenders
   class JobsGenerator < Generators::Base
     def add_jobs_gem
-      gem "delayed_job_active_record"
+      gem "sidekiq"
       Bundler.with_unbundled_env { run "bundle install" }
-    end
-
-    def configure_background_jobs_for_rspec
-      generate "delayed_job:active_record"
     end
 
     def initialize_active_job
@@ -19,9 +15,12 @@ module Suspenders
     end
 
     def configure_active_job
-      configure_application_file(
-        "config.active_job.queue_adapter = :delayed_job"
-      )
+      configure_application_file("config.active_job.queue_adapter = :sidekiq")
+      configure_application_file("config.action_mailer.deliver_later_queue_name = nil")
+      configure_application_file("config.action_mailbox.queues.routing = nil")
+      configure_application_file("config.active_storage.queues.analysis = nil")
+      configure_application_file("config.active_storage.queues.purge = nil")
+      configure_application_file("config.active_storage.queues.mirror = nil")
       configure_environment "test", "config.active_job.queue_adapter = :inline"
     end
 

--- a/lib/suspenders/generators/production/manifest_generator.rb
+++ b/lib/suspenders/generators/production/manifest_generator.rb
@@ -17,7 +17,7 @@ module Suspenders
             RACK_ENV: {required: true},
             SECRET_KEY_BASE: {generator: "secret"}
           },
-          addons: ["heroku-postgresql"]
+          addons: ["heroku-postgresql", "heroku-redis"]
         )
       end
     end

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -184,19 +184,14 @@ RSpec.describe "Suspend a new project with default configuration", type: :featur
   it "configs active job queue adapter" do
     application_config = IO.read("#{project_path}/config/application.rb")
 
-    expect(application_config).to match(
-      /^ +config.active_job.queue_adapter = :delayed_job$/
-    )
+    expect(application_config).to match(/^ +config.active_job.queue_adapter = :sidekiq$/) &
+      match(/^ +config.action_mailer.deliver_later_queue_name = nil$/) &
+      match(/^ +config.action_mailbox.queues.routing = nil$/) &
+      match(/^ +config.active_storage.queues.analysis = nil$/) &
+      match(/^ +config.active_storage.queues.purge = nil$/) &
+      match(/^ +config.active_storage.queues.mirror = nil$/)
     expect(test_config).to match(
       /^ +config.active_job.queue_adapter = :inline$/
-    )
-  end
-
-  it "configs background jobs for rspec" do
-    delayed_job = IO.read("#{project_path}/bin/delayed_job")
-
-    expect(delayed_job).to match(
-      /^require 'delayed\/command'$/
     )
   end
 

--- a/templates/Procfile
+++ b/templates/Procfile
@@ -1,2 +1,2 @@
 web: bundle exec puma -p $PORT -C ./config/puma.rb
-worker: bundle exec rails jobs:work
+worker: bundle exec sidekiq

--- a/templates/descriptions/jobs.md
+++ b/templates/descriptions/jobs.md
@@ -1,3 +1,3 @@
 Set up our favorite job runner.
 
-Currently we like DelayedJob. Run all tests inline by default.
+Currently we like Sidekiq. Run all tests inline by default.

--- a/templates/descriptions/runner.md
+++ b/templates/descriptions/runner.md
@@ -1,6 +1,6 @@
 Set up the app to run locally with ease.
 
-Use Puma and the Rails jobs runner to run the app. This can be done via either
+Use Puma and Sidekiq to run the app. This can be done via either
 `heroku local` or any Foreman-compatible project runner (e.g. `foreman start`).
 
 Configure your app using `.env`. Installs a basic `.sample.env` that is meant

--- a/templates/sample_env
+++ b/templates/sample_env
@@ -3,6 +3,7 @@ ASSET_HOST=localhost:3000
 APPLICATION_HOST=localhost:3000
 PORT=3000
 RACK_ENV=development
+REDIS_URL=localhost:6379
 SECRET_KEY_BASE=development_secret
 SMTP_ADDRESS=smtp.example.com
 SMTP_DOMAIN=example.com


### PR DESCRIPTION
Closes #1074 

All jobs are enqueued to "default" queue. In Rails 6.1 we won't need the application.rb tweak for action_mailer, action_mailbox and active_storage (https://github.com/mperham/sidekiq/wiki/Active-Job#queues).

Using Sidekiq through ActiveJob is significantly slower than using pure Sidekiq workers (https://github.com/mperham/sidekiq/wiki/Active-Job#performance), maybe a migration would be nice in the future