### PR TITLE
Support Rails 6.1.6.1

### DIFF
--- a/lib/suspenders/actions.rb
+++ b/lib/suspenders/actions.rb
@@ -31,6 +31,27 @@ module Suspenders
       action ExpandJson.new(destination_root, file, data)
     end
 
+    def gem(*args)
+      options = args.extract_options!
+      name, *versions = args
+
+      parts = [quote(name)]
+
+      if (versions = versions.any? ? versions : options.delete(:version))
+        versions = Array(versions)
+        versions.each do |version|
+          parts << quote(version)
+        end
+      end
+
+      parts << quote(options) unless options.empty?
+
+      str = []
+      str << indentation
+      str << "gem #{parts.join(", ")}"
+      append_file "Gemfile", %(\n#{str.join}\n), verbose: false
+    end
+
     class ExpandJson
       def initialize(destination_root, file, data)
         @destination_root = destination_root

--- a/lib/suspenders/app_builder.rb
+++ b/lib/suspenders/app_builder.rb
@@ -100,8 +100,8 @@ module Suspenders
 
     def setup_asset_host
       replace_in_file "config/environments/production.rb",
-        "# config.action_controller.asset_host = 'http://assets.example.com'",
-        'config.action_controller.asset_host = ENV.fetch("ASSET_HOST", ENV.fetch("APPLICATION_HOST"))'
+        "# config.asset_host = 'http://assets.example.com'",
+        'config.asset_host = ENV.fetch("ASSET_HOST", ENV.fetch("APPLICATION_HOST"))'
 
       if File.exist?("config/initializers/assets.rb")
         replace_in_file "config/initializers/assets.rb",
@@ -250,7 +250,7 @@ module Suspenders
     end
 
     def raise_on_missing_translations_in(environment)
-      config = "config.action_view.raise_on_missing_translations = true"
+      config = "config.i18n.raise_on_missing_translations = true"
 
       uncomment_lines("config/environments/#{environment}.rb", config)
     end

--- a/lib/suspenders/generators/advisories_generator.rb
+++ b/lib/suspenders/generators/advisories_generator.rb
@@ -3,7 +3,7 @@ require_relative "base"
 module Suspenders
   class AdvisoriesGenerator < Generators::Base
     def bundler_audit_gem
-      gem "bundler-audit", ">= 0.7.0", require: false, group: %i[development test]
+      gem "bundler-audit", ">= 0.7.0", require: false, group: [:development, :test]
       Bundler.with_unbundled_env { run "bundle install" }
     end
 

--- a/lib/suspenders/generators/jobs_generator.rb
+++ b/lib/suspenders/generators/jobs_generator.rb
@@ -3,7 +3,7 @@ require_relative "base"
 module Suspenders
   class JobsGenerator < Generators::Base
     def add_jobs_gem
-      append_file "Gemfile", %(\ngem "sidekiq"\n)
+      gem "sidekiq"
       Bundler.with_unbundled_env { run "bundle install" }
     end
 

--- a/lib/suspenders/version.rb
+++ b/lib/suspenders/version.rb
@@ -1,5 +1,5 @@
 module Suspenders
-  RAILS_VERSION = "~> 6.0.0".freeze
+  RAILS_VERSION = "~> 6.1.6.1".freeze
   RUBY_VERSION = IO
     .read("#{File.dirname(__FILE__)}/../../.ruby-version")
     .strip

--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe "Suspend a new project with default configuration", type: :featur
   it "raises on missing translations in development and test" do
     [development_config, test_config].each do |environment_file|
       expect(environment_file).to match(
-        /^ +config.action_view.raise_on_missing_translations = true$/
+        /^ +config.i18n.raise_on_missing_translations = true$/
       )
     end
   end

--- a/templates/active_job.rb
+++ b/templates/active_job.rb
@@ -1,4 +1,5 @@
 require "active_job/logging"
+require "active_job/log_subscriber"
 
 ActiveSupport::Notifications.unsubscribe("enqueue.active_job")
 


### PR DESCRIPTION
This commit does the bare minimum to support Rails 6.1.6.1

Because the `gem` command is no longer reversible, we decided to override the method by borrowing as much from the [existing method](https://github.com/rails/rails/blob/04972d9b9ef60796dc8f0917817b5392d61fcf09/railties/lib/rails/generators/actions.rb#L22). The main difference being that we call `append_file` instead of `gsub_file`, so that we can preserve reversibility. However, https://github.com/thoughtbot/suspenders/pull/1066 provides a more elegant solution.

Closes https://github.com/thoughtbot/suspenders/issues/1060