### PR TITLE
Introduce Accessibility tooling Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ And testing gems like:
 * [Capybara](https://github.com/jnicklas/capybara) and
   [Google Chromedriver]
   integration testing
+* [capybara_accessibility_audit](https://github.com/thoughtbot/capybara_accessibility_audit) and
+  [capybara_accessible_selectors](https://github.com/citizensadvice/capybara_accessible_selectors)
 * [Factory Bot](https://github.com/thoughtbot/factory_bot) for test data
 * [Formulaic](https://github.com/thoughtbot/formulaic) for integration testing
   HTML forms

--- a/lib/suspenders.rb
+++ b/lib/suspenders.rb
@@ -1,5 +1,6 @@
 require "suspenders/version"
 require "suspenders/exit_on_failure"
+require "suspenders/generators/accessibility_generator"
 require "suspenders/generators/advisories_generator"
 require "suspenders/generators/app_generator"
 require "suspenders/generators/static_generator"

--- a/lib/suspenders/generators/accessibility_generator.rb
+++ b/lib/suspenders/generators/accessibility_generator.rb
@@ -1,0 +1,12 @@
+require_relative "base"
+
+module Suspenders
+  class AccessibilityGenerator < Generators::Base
+    def capybara_gems
+      gem "capybara_accessibility_audit", group: [:test]
+      gem "capybara_accessible_selectors", group: [:test],
+        github: "citizensadvice/capybara_accessible_selectors"
+      Bundler.with_unbundled_env { run "bundle install" }
+    end
+  end
+end

--- a/spec/suspenders/generators/accessibility_generator_spec.rb
+++ b/spec/suspenders/generators/accessibility_generator_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+RSpec.describe Suspenders::AccessibilityGenerator, type: :generator do
+  describe "invoke" do
+    it "bundles the capybara_accessibility_audit gem" do
+      with_fake_app do
+        invoke! Suspenders::AccessibilityGenerator
+
+        expect("Gemfile")
+          .to have_bundled("install").matching(/capybara_accessibility_audit/)
+          .and have_no_syntax_error
+      end
+    end
+
+    it "bundles the citizensadvice/capybara_accessible_selectors GitHub repository gem" do
+      with_fake_app do
+        invoke! Suspenders::AccessibilityGenerator
+
+        expect("Gemfile")
+          .to have_bundled("install").matching(/capybara_accessible_selectors/)
+          .and have_no_syntax_error
+      end
+    end
+  end
+
+  describe "revoke" do
+    it "removes the gems from Gemfile" do
+      with_fake_app do
+        invoke_then_revoke! Suspenders::AccessibilityGenerator
+
+        expect("Gemfile")
+          .to have_no_syntax_error
+          .and match_original_file
+          .and not_have_bundled
+      end
+    end
+  end
+end


### PR DESCRIPTION
Create the `Suspenders::AccessibilityGenerator` to install
[capybara_accessibility_audit][] and [capybara_accessible_selectors][].

[capybara_accessibility_audit]: https://github.com/thoughtbot/capybara_accessibility_audit
[capybara_accessible_selectors]: https://github.com/citizensadvice/capybara_accessible_selectors