### PR TITLE
Lint HTML Templates with ERBLint and BetterHtml

### DIFF
--- a/lib/suspenders/generators/lint_generator.rb
+++ b/lib/suspenders/generators/lint_generator.rb
@@ -10,5 +10,28 @@ module Suspenders
       gem "standard", group: :development
       prepend_to_file("Rakefile", 'require "standard/rake"')
     end
+
+    def set_up_erblint
+      gem "better_html", group: [:development, :test]
+      gem "erb_lint", require: false, group: [:development, :test]
+      gem "erblint-github", require: false, group: [:development, :test]
+
+      copy_file "erb-lint.yml", ".erb-lint.yml"
+      copy_file "config_better_html.yml", "config/better_html.yml"
+      copy_file "config_initializers_better_html.rb", "config/initializers/better_html.rb"
+      copy_file "erblint.rake", "lib/tasks/erblint.rake"
+
+      if using_rspec?
+        copy_file "better_html_spec.rb", "spec/views/better_html_spec.rb"
+      else
+        copy_file "better_html_test.rb", "test/views/better_html_test.rb"
+      end
+    end
+
+    private
+
+    def using_rspec?
+      File.exist?("spec/spec_helper.rb")
+    end
   end
 end

--- a/templates/better_html_spec.rb
+++ b/templates/better_html_spec.rb
@@ -1,0 +1,17 @@
+require "spec_helper"
+
+describe "ERB Implementation" do
+  def self.erb_lint
+    configuration = ActiveSupport::ConfigurationFile.parse(".erb-lint.yml")
+
+    ActiveSupport::OrderedOptions.new.merge!(configuration.deep_symbolize_keys!)
+  end
+
+  Rails.root.glob(erb_lint.glob).each do |template|
+    it "raises html errors in #{template.relative_path_from(Rails.root)}" do
+      validator = BetterHtml::BetterErb::ErubiImplementation.new(template.read)
+
+      validator.validate!
+    end
+  end
+end

--- a/templates/better_html_test.rb
+++ b/templates/better_html_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class ErbImplementationTest < ActiveSupport::TestCase
+  def self.erb_lint
+    configuration = ActiveSupport::ConfigurationFile.parse(".erb-lint.yml")
+
+    ActiveSupport::OrderedOptions.new.merge!(configuration.deep_symbolize_keys!)
+  end
+
+  Rails.root.glob(erb_lint.glob).each do |template|
+    test "html errors in #{template.relative_path_from(Rails.root)}" do
+      validator = BetterHtml::BetterErb::ErubiImplementation.new(template.read)
+
+      validator.validate!
+    end
+  end
+end

--- a/templates/config_better_html.yml
+++ b/templates/config_better_html.yml
@@ -1,0 +1,2 @@
+---
+allow_single_quoted_attributes: false

--- a/templates/config_initializers_better_html.rb
+++ b/templates/config_initializers_better_html.rb
@@ -1,0 +1,5 @@
+Rails.configuration.to_prepare do
+  config = ActiveSupport::ConfigurationFile.parse("config/better_html.yml")
+
+  BetterHtml.config = BetterHtml::Config.new(config)
+end

--- a/templates/erb-lint.yml
+++ b/templates/erb-lint.yml
@@ -1,0 +1,63 @@
+---
+glob: "app/views/**/*.{html,turbo_stream}{+*,}.erb"
+
+linters:
+  AllowedScriptType:
+    enabled: true
+    allowed_types:
+      - "module"
+      - "text/javascript"
+  ErbSafety:
+    enabled: true
+    better_html_config: "config/better_html.yml"
+  GitHub::Accessibility::AvoidBothDisabledAndAriaDisabledCounter:
+    enabled: true
+  GitHub::Accessibility::AvoidGenericLinkTextCounter:
+    enabled: true
+  GitHub::Accessibility::DisabledAttributeCounter:
+    enabled: true
+  GitHub::Accessibility::IframeHasTitleCounter:
+    enabled: true
+  GitHub::Accessibility::ImageHasAltCounter:
+    enabled: true
+  GitHub::Accessibility::LandmarkHasLabelCounter:
+    enabled: true
+  GitHub::Accessibility::LinkHasHrefCounter:
+    enabled: true
+  GitHub::Accessibility::NestedInteractiveElementsCounter:
+    enabled: true
+  GitHub::Accessibility::NoAriaLabelMisuseCounter:
+    enabled: true
+  GitHub::Accessibility::NoPositiveTabIndexCounter:
+    enabled: true
+  GitHub::Accessibility::NoRedundantImageAltCounter:
+    enabled: true
+  GitHub::Accessibility::NoTitleAttributeCounter:
+    enabled: true
+  GitHub::Accessibility::SvgHasAccessibleTextCounter:
+    enabled: true
+  Rubocop:
+    enabled: true
+    rubocop_config:
+      inherit_from:
+        - .rubocop.yml
+
+      Lint/EmptyBlock:
+        Enabled: false
+      Layout/InitialIndentation:
+        Enabled: false
+      Layout/TrailingEmptyLines:
+        Enabled: false
+      Layout/TrailingWhitespace:
+        Enabled: false
+      Layout/LeadingEmptyLines:
+        Enabled: false
+      Style/FrozenStringLiteralComment:
+        Enabled: false
+      Style/MultilineTernaryOperator:
+        Enabled: false
+      Lint/UselessAssignment:
+        Exclude:
+          - "app/views/**/*"
+
+EnableDefaultLinters: true

--- a/templates/erblint.rake
+++ b/templates/erblint.rake
@@ -1,0 +1,47 @@
+module ERBLint
+  module RakeSupport
+    # Allow command line flags set in STANDARDOPTS (like MiniTest's TESTOPTS)
+    def self.argvify
+      if ENV["ERBLINTOPTS"]
+        ENV["ERBLINTOPTS"].split(/\s+/)
+      else
+        []
+      end
+    end
+
+    # DELETE THIS FILE AFTER MERGE:
+    #
+    #   * https://github.com/Shopify/better-html/pull/95
+    #
+    def self.backport!
+      BetterHtml::TestHelper::SafeErb::AllowedScriptType::VALID_JAVASCRIPT_TAG_TYPES.push("module")
+    end
+  end
+end
+
+desc "Lint templates with erb_lint"
+task "erblint" do
+  require "erb_lint/cli"
+  require "erblint-github/linters"
+
+  ERBLint::RakeSupport.backport!
+
+  cli = ERBLint::CLI.new
+  success = cli.run(ERBLint::RakeSupport.argvify + ["--lint-all", "--format=compact"])
+  fail unless success
+end
+
+desc "Lint and automatically fix templates with erb_lint"
+task "erblint:autocorrect" do
+  require "erb_lint/cli"
+  require "erblint-github/linters"
+
+  ERBLint::RakeSupport.backport!
+
+  cli = ERBLint::CLI.new
+  success = cli.run(ERBLint::RakeSupport.argvify + ["--lint-all", "--autocorrect"])
+  fail unless success
+end
+
+task "standard" => "erblint"
+task "standard:fix" => "erblint:autocorrect"


### PR DESCRIPTION
Configure the [erb_lint][] utility to apply our `standard`-backed RuboCop linting tool to our application's `.erb` files.

The initial `.erb-lint.yml` file is configured according to the gem's [README.md][]. Additionally, there are some key RuboCop rules that we're disabling [according to some feedback from the community of `erb_lint` users][issue].

The Rails tasks defined in `lib/tasks/erblint.rake` are inspired by those defined in [standard/rake.rb][]. They define the `erblint:autocorrect` and `erblint` tasks to execute the `erblint` command with and without the `--autocorrect` flag. Additional arguments can be passed in with the `ERBLINTOPTS` environment variable.

By default, executing `rails standard` will execute `rails erblint`, and `rails standard:fix` will execute `rails erblint:autocorrect`.

Also depend on the [erblint-github][] gem to provide additional, accessibility-focused rules for how we statically analyze ERB templates.

Finally, the [ERBLint][] tool depends on [BetterHtml][], and claims to execute BetterHtml's [ERBSafety][] test suite. In our experience, this isn't the case, and [requires manual configuration][better_html_tests].

This commit also introduces the `config/better_html.yml` configuration file, and makes sure that `BetterHtml` and `ERBLint` consistently read its contents.

[erb_lint]: https://github.com/Shopify/erb-lint
[README.md]: https://github.com/Shopify/erb-lint#configuration
[standard/rake.rb]: https://github.com/testdouble/standard/blob/main/lib/standard/rake.rb
[exe/erblint]: https://github.com/Shopify/erb-lint/blob/main/exe/erblint
[issue]: Shopify/erb-lint#222 (comment)
[erblint-github]: https://github.com/github/erblint-github
[ERBLint]: https://github.com/Shopify/erb-lint
[ERBSafety]: https://github.com/Shopify/erb-lint#erbsafety
[BetterHtml]: https://github.com/Shopify/better-html
[better_html_tests]: https://github.com/Shopify/better-html#testing-for-valid-html-and-erb