### PR TITLE
Fix Layout/SpaceInsideHashLiteralBraces linter problem

### DIFF
--- a/spec/support/fixtures/dummy_app/config/environments/development.rb
+++ b/spec/support/fixtures/dummy_app/config/environments/development.rb
@@ -7,8 +7,7 @@ Rails.application.configure do
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
     config.cache_store = :memory_store
-    config.public_file_server.headers = {
-    }
+    config.public_file_server.headers = {}
   else
     config.action_controller.perform_caching = false
     config.cache_store = :null_store


### PR DESCRIPTION
When running the specs, the following linter message is displayed at the end:

```
standard: Run `rake standard:fix` to automatically fix some problems.

spec/support/fixtures/dummy_app/config/environments/development.rb:10:42: Layout/SpaceInsideHashLiteralBraces: Space inside empty hash literal braces detected.
```

This small PR fixes that problem. It's a small contribution to get started with contributing to the project :)