### PR TITLE
Fix style guides broken link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Make sure the tests pass:
 Make your change. Write tests. Follow our [style guide][style]. Make the tests
 pass:
 
-[style]: https://github.com/thoughtbot/guides/tree/master/style
+[style]: https://github.com/thoughtbot/guides/blob/main/ruby/README.md
 
     rake
 


### PR DESCRIPTION
The link to the style guide shared in the CONTRIBUTING doc was broken. thoughtbot's guides changed location some time ago, and the Ruby style guide lives on this new URL.