### PR TITLE
Adds bundle install after standard gem addition

### DIFF
--- a/lib/suspenders/generators/lint_generator.rb
+++ b/lib/suspenders/generators/lint_generator.rb
@@ -2,12 +2,16 @@ require_relative "base"
 
 module Suspenders
   class LintGenerator < Generators::Base
+    def add_standard
+      gem "standard", group: :development
+      Bundler.with_unbundled_env { run "bundle install" }
+    end
+
     def set_up_hound
       copy_file "hound.yml", ".hound.yml"
     end
 
     def set_up_standard
-      gem "standard", group: :development
       prepend_to_file("Rakefile", 'require "standard/rake"')
     end
   end

--- a/spec/suspenders/generators/lint_generator_spec.rb
+++ b/spec/suspenders/generators/lint_generator_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Suspenders::LintGenerator, type: :generator do
 
         expect("Gemfile")
           .to match_contents(/gem .standard./)
+          .and have_bundled("install")
           .and have_no_syntax_error
       end
     end


### PR DESCRIPTION
Adds a bundle install run after the standard gem is added to the Gemfile. Without the bundle install suspenders runs into the following error when the gems are bundle into vendor/path by default:

"Could not find gem 'standard' in locally installed gems."