### PR TITLE
Remove redundant Capybara config

### DIFF
--- a/lib/suspenders/generators/js_driver_generator.rb
+++ b/lib/suspenders/generators/js_driver_generator.rb
@@ -9,10 +9,6 @@ module Suspenders
 
     def configure_capybara
       copy_file "chromedriver.rb", "spec/support/chromedriver.rb"
-      copy_file(
-        "capybara_silence_puma.rb",
-        "spec/support/capybara_silence_puma.rb"
-      )
     end
   end
 end

--- a/templates/capybara_silence_puma.rb
+++ b/templates/capybara_silence_puma.rb
@@ -1,1 +1,0 @@
-Capybara.server = :puma, {Silent: true}


### PR DESCRIPTION
Capybara was configured to silence Puma in #981 to prevent Puma 
startup messages being output when running specs with `js: true`.

This configuration has since been updated in [rspec-rails](https://github.com/rspec/rspec-rails/pull/2289), so we can 
remove it here.