### PR TITLE
Configure Standard to use Ruby 3.0

### DIFF
--- a/.standard.yml
+++ b/.standard.yml
@@ -1,3 +1,4 @@
+ruby_version: 3.0.5
 ignore:
   - "templates/partials/db_optimizations_configuration.rb"
   - "templates/partials/pull_requests_config.rb"


### PR DESCRIPTION
Since the current configuration for Standard defaults to the executing Ruby version, newer contributions are failing because the codebase doesn't use the [anonymous rest][] syntax made available in Ruby 3.2.

The gem current supports a [Ruby Version Range][] with 3.0.5 as the minimum, so we should pass that to Standard in its [YAML Options][].

[anonymous rest]: https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/
[Ruby Version Range]: https://github.com/thoughtbot/suspenders/blob/761c4134308f77f52dd25a228c7cedfd14dafe82/lib/suspenders/version.rb#L4-L7
[YAML Options]: https://github.com/standardrb/standard#yaml-options