### PR TITLE
Add pathname which is implicitly referenced

### DIFF
--- a/lib/suspenders/version.rb
+++ b/lib/suspenders/version.rb
@@ -1,3 +1,5 @@
+require "pathname"
+
 module Suspenders
   RAILS_VERSION = "~> 7.0.0".freeze
 


### PR DESCRIPTION
On Ruby 3.2.2 - and especially when installing the current `main` version of the Gem via `specific_install` - installing fails because there's an implicit reference to `pathname`:

```
$ gem specific_install thoughtbot/suspenders
git version 2.42.0
Installing from git@github.com:thoughtbot/suspenders.git
Cloning into '/var/folders/z_/7_lg8ty95s9f7gybbr5_5nqr0000gn/T/d20231013-60937-72rbst'...
remote: Enumerating objects: 7101, done.
remote: Counting objects: 100% (590/590), done.
remote: Compressing objects: 100% (329/329), done.
remote: Total 7101 (delta 310), reused 422 (delta 232), pack-reused 6511
Receiving objects: 100% (7101/7101), 1.72 MiB | 3.33 MiB/s, done.
Resolving deltas: 100% (3672/3672), done.
Invalid gemspec in [suspenders.gemspec]: undefined method `Pathname' for Suspenders:Module
ERROR:  While executing gem ... (NoMethodError)
   undefined method `file_name' for nil:NilClass

   gem_file = file_name || spec.file_name
```

This commit adds `pathname` so that it can be installed.