### PR TITLE
Introduce `suspenders:accessibility` generator

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 Unreleased
 
 * Remove `suspenders` system executable
+* Introduce `suspenders:accessibility` generator
+* Introduce `Suspenders::Generators::APIAppUnsupported` module and concern
 
 20230113.0 (January, 13, 2023)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,14 @@ end
 
 ## Generators
 
-TODO
+### Accessibility
+
+Installs [capybara_accessibility_audit] and [capybara_accessible_selectors]
+
+`./bin/rails g suspenders:accessibility`
+
+  [capybara_accessibility_audit]: https://github.com/thoughtbot/capybara_accessibility_audit
+  [capybara_accessible_selectors]: https://github.com/citizensadvice/capybara_accessible_selectors
 
 ## Contributing
 

--- a/lib/generators/suspenders/accessibility_generator.rb
+++ b/lib/generators/suspenders/accessibility_generator.rb
@@ -1,0 +1,17 @@
+module Suspenders
+  module Generators
+    class AccessibilityGenerator < Rails::Generators::Base
+      include Suspenders::Generators::APIAppUnsupported
+
+      desc "Installs capybara_accessibility_audit and capybara_accessible_selectors"
+
+      def add_capybara_gems
+        gem_group :test do
+          gem "capybara_accessibility_audit"
+          gem "capybara_accessible_selectors", github: "citizensadvice/capybara_accessible_selectors"
+        end
+        Bundler.with_unbundled_env { run "bundle install" }
+      end
+    end
+  end
+end

--- a/lib/suspenders.rb
+++ b/lib/suspenders.rb
@@ -1,5 +1,6 @@
 require "suspenders/version"
 require "suspenders/railtie"
+require "suspenders/generators"
 
 module Suspenders
   # Your code goes here...

--- a/lib/suspenders/generators.rb
+++ b/lib/suspenders/generators.rb
@@ -1,0 +1,30 @@
+require "active_support/concern"
+
+module Suspenders
+  module Generators
+    module APIAppUnsupported
+      class Error < StandardError
+        def message
+          "This generator cannot be used on API only applications."
+        end
+      end
+
+      extend ActiveSupport::Concern
+
+      included do
+        def raise_if_api_only_app
+          if api_only_app?
+            raise Suspenders::Generators::APIAppUnsupported::Error
+          end
+        end
+      end
+
+      private
+
+      def api_only_app?
+        File.read(Rails.root.join("config/application.rb"))
+          .match?(/^\s*config\.api_only\s*=\s*true/i)
+      end
+    end
+  end
+end

--- a/test/generators/suspenders/accessibility_generator_test.rb
+++ b/test/generators/suspenders/accessibility_generator_test.rb
@@ -1,0 +1,83 @@
+require "test_helper"
+require "generators/suspenders/accessibility_generator"
+
+module Suspenders
+  module Generators
+    class AccessibilityGeneratorTest < Rails::Generators::TestCase
+      include Suspenders::TestHelpers
+
+      tests Suspenders::Generators::AccessibilityGenerator
+      destination Rails.root
+      setup :prepare_destination
+      teardown :restore_destination
+
+      test "raises if API only application" do
+        within_api_only_app do
+          assert_raises Suspenders::Generators::APIAppUnsupported::Error do
+            run_generator
+          end
+
+          assert_file app_root("Gemfile") do |file|
+            assert_no_match "capybara_accessibility_audit", file
+            assert_no_match "capybara_accessible_selectors", file
+          end
+        end
+      end
+
+      test "does not raise if API configuration is commented out" do
+        within_api_only_app do
+          path = app_root("config/application.rb")
+          content = File.binread(path).gsub!("config.api_only = true", "# config.api_only = true")
+          File.binwrite(path, content)
+
+          run_generator
+
+          assert_file app_root("Gemfile") do |file|
+            assert_match "capybara_accessibility_audit", file
+            assert_match "capybara_accessible_selectors", file
+          end
+        end
+      end
+
+      test "adds gems to Gemfile" do
+        expected_output = <<~RUBY
+          group :test do
+            gem "capybara_accessibility_audit"
+            gem "capybara_accessible_selectors", github: "citizensadvice/capybara_accessible_selectors"
+          end
+        RUBY
+
+        run_generator
+
+        assert_file app_root("Gemfile") do |file|
+          assert_match(expected_output, file)
+        end
+      end
+
+      test "installs gems with Bundler" do
+        Bundler.stubs(:with_unbundled_env).yields
+        generator.expects(:run).with("bundle install").once
+
+        capture(:stdout) do
+          generator.add_capybara_gems
+        end
+      end
+
+      test "generator has a description" do
+        description = "Installs capybara_accessibility_audit and capybara_accessible_selectors"
+
+        assert_equal description, Suspenders::Generators::AccessibilityGenerator.desc
+      end
+
+      private
+
+      def prepare_destination
+        touch "Gemfile"
+      end
+
+      def restore_destination
+        remove_file_if_exists "Gemfile"
+      end
+    end
+  end
+end

--- a/test/suspenders/generators_test.rb
+++ b/test/suspenders/generators_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class Suspenders::GeneratorsTest < ActiveSupport::TestCase
+  class APIAppUnsupportedTest < Suspenders::GeneratorsTest
+    test "message returns a custom message" do
+      expected = "This generator cannot be used on API only applications."
+
+      assert_equal expected, Suspenders::Generators::APIAppUnsupported::Error.new.message
+    end
+  end
+end


### PR DESCRIPTION
Introduce `suspenders:accessibility` generator

Ported over from #1105

Installs [capybara_accessibility_audit] and
[capybara_accessible_selectors].

`./bin/rails g suspenders:accessibility`

Introduces `Suspenders::Generators::APIAppUnsupported` module for
generators that cannot be run in an [API only][] application.

This uses a [concern][] to ensure we raise an error before the generator
including the module invokes any of its methods.

## How to manually review this pull-request

If you want to manually run this generator, simply do the following:

1. `cd test/dummy`
1. `touch Gemfile`
1. `./bin/rails g suspenders:accessibility`

Confirm the `Gemfile` and `Gemfile.lock` contains the gems.

To test that it won't work on an API only application, comment out or remove
`config.api_only = true` from `test/dummy/config/application.rb` and run the
steps above

[capybara_accessibility_audit]:
https://github.com/thoughtbot/capybara_accessibility_audit
[capybara_accessible_selectors]:
https://github.com/citizensadvice/capybara_accessible_selectors
[API only]: https://guides.rubyonrails.org/api_app.html
[concern]: https://api.rubyonrails.org/classes/ActiveSupport/Concern.html
