### PR TITLE
Introduce `./bin/rails` to fix broken test runner

### DIFF
--- a/bin/rails
+++ b/bin/rails
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+# This command will automatically be run when you run "rails" with Rails gems
+# installed from the root of your application.
+
+ENGINE_ROOT = File.expand_path("..", __dir__)
+APP_PATH = File.expand_path("../test/dummy/config/application", __dir__)
+
+# Set up gems listed in the Gemfile.
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
+
+require "rails/all"
+require "rails/engine/commands"


### PR DESCRIPTION
This is a work around for an [issue][] with `vim-test`. Borrowed an [existing][]
`./bin/rails` configuration from an [Engine][], which is very similar to a
[plugin][]. The only difference is that we do not need the `ENGINE_ROOT`
setting.

[issue]: https://github.com/vim-test/vim-test/issues/477
[existing]: https://github.com/rails/rails/blob/main/railties/lib/rails/generators/rails/plugin/templates/bin/rails.tt
[Engine]: https://guides.rubyonrails.org/engines.html
[plugin]: https://guides.rubyonrails.org/plugins.html
