### PR TITLE
Introduce `suspenders:inline_svg` generator

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ Unreleased
 * Remove `suspenders` system executable
 * Introduce `suspenders:accessibility` generator
 * Introduce `Suspenders::Generators::APIAppUnsupported` module and concern
+* Introduce `suspenders:inline_svg` generator
 
 20230113.0 (January, 13, 2023)
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ Installs [capybara_accessibility_audit] and [capybara_accessible_selectors]
   [capybara_accessibility_audit]: https://github.com/thoughtbot/capybara_accessibility_audit
   [capybara_accessible_selectors]: https://github.com/citizensadvice/capybara_accessible_selectors
 
+### Inline SVG
+
+Render SVG images inline using the [inline_svg] gem, as a potential performance
+improvement for the viewer.
+
+`bin/rails g suspenders:inline_svg`
+
+  [inline_svg]: https://github.com/jamesmartin/inline_svg
+
 ## Contributing
 
 See the [CONTRIBUTING] document.

--- a/lib/generators/suspenders/inline_svg_generator.rb
+++ b/lib/generators/suspenders/inline_svg_generator.rb
@@ -1,0 +1,18 @@
+module Suspenders
+  module Generators
+    class InlineSvgGenerator < Rails::Generators::Base
+      include Suspenders::Generators::APIAppUnsupported
+      source_root File.expand_path("../../templates/inline_svg", __FILE__)
+      desc "Render SVG images inline, as a potential performance improvement for the viewer."
+
+      def add_inline_svg_gem
+        gem "inline_svg"
+        Bundler.with_unbundled_env { run "bundle install" }
+      end
+
+      def configure_inline_svg
+        copy_file "inline_svg.rb", "config/initializers/inline_svg.rb"
+      end
+    end
+  end
+end

--- a/lib/generators/templates/inline_svg/inline_svg.rb
+++ b/lib/generators/templates/inline_svg/inline_svg.rb
@@ -1,0 +1,3 @@
+InlineSvg.configure do |config|
+  config.raise_on_file_not_found = true
+end

--- a/test/generators/suspenders/inline_svg_generator_test.rb
+++ b/test/generators/suspenders/inline_svg_generator_test.rb
@@ -1,0 +1,93 @@
+require "test_helper"
+require "generators/suspenders/inline_svg_generator"
+
+module Suspenders
+  module Generators
+    class InlinveSvgGeneratorTest < Rails::Generators::TestCase
+      include Suspenders::TestHelpers
+
+      tests Suspenders::Generators::InlineSvgGenerator
+      destination Rails.root
+      setup :prepare_destination
+      teardown :restore_destination
+
+      test "raises if API only application" do
+        within_api_only_app do
+          assert_raises Suspenders::Generators::APIAppUnsupported::Error do
+            run_generator
+          end
+
+          assert_file app_root("Gemfile") do |file|
+            assert_no_match "inline_svg", file
+          end
+        end
+      end
+
+      test "does not raise if API configuration is commented out" do
+        within_api_only_app do
+          path = app_root("config/application.rb")
+          content = File.binread(path).gsub!("config.api_only = true", "# config.api_only = true")
+          File.binwrite(path, content)
+
+          run_generator
+
+          assert_file app_root("Gemfile") do |file|
+            assert_match "inline_svg", file
+          end
+        end
+      end
+
+      test "adds gems to Gemfile" do
+        expected_output = <<~RUBY
+          gem "inline_svg"
+        RUBY
+
+        run_generator
+
+        assert_file app_root("Gemfile") do |file|
+          assert_match(expected_output, file)
+        end
+      end
+
+      test "installs gems with Bundler" do
+        Bundler.stubs(:with_unbundled_env).yields
+        generator.expects(:run).with("bundle install").once
+
+        capture(:stdout) do
+          generator.add_inline_svg_gem
+        end
+      end
+
+      test "generator has a description" do
+        description = "Render SVG images inline, as a potential performance improvement for the viewer."
+
+        assert_equal description, Suspenders::Generators::InlineSvgGenerator.desc
+      end
+
+      test "configures raising an error when an SVG file is not found" do
+        expected_configuration = <<~RUBY
+          InlineSvg.configure do |config|
+            config.raise_on_file_not_found = true
+          end
+        RUBY
+
+        run_generator
+
+        assert_file app_root("config/initializers/inline_svg.rb") do |file|
+          assert_match(expected_configuration, file)
+        end
+      end
+
+      private
+
+      def prepare_destination
+        touch "Gemfile"
+      end
+
+      def restore_destination
+        remove_file_if_exists "Gemfile"
+        remove_file_if_exists "config/initializers/inline_svg.rb"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ports the existing generator to Suspenders 3.0.

To do:
- [x] Add documentation
- [x] Manually test the generator against a new Rails app

## How to test manually

Add suspenders to the `Gemfile`.

```ruby
group :development, :test do
  gem "suspenders", git: "https://github.com/thoughtbot/suspenders", branch: "suspenders-3-0-0-inline-svg-generator"
end
```

Install and run the generator:

```
bundle
bin/rails g suspenders:inline_svg
```