### PR TITLE
Introduce `suspenders:rake` generator

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@ Unreleased
 * Introduce `suspenders:styles` generator
 * Introduce `suspenders:jobs` generator
 * Introduce `suspenders:lint` generator
+* Introduce `suspenders:rake` generator
 
 20230113.0 (January, 13, 2023)
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,16 @@ Installs [Sidekiq][] for background job processing and configures ActiveJob for 
 
   [Sidekiq]: https://github.com/sidekiq/sidekiq
 
+### Rake
+
+Configures the default Rake task to audit and lint the codebase with
+[bundler-audit][] and [standard][] in addition to running the test suite.
+
+`bin/rails g suspenders:rake`
+
+  [bundler-audit]: https://github.com/rubysec/bundler-audit
+  [standard]: https://github.com/standardrb/standard
+
 ## Contributing
 
 See the [CONTRIBUTING] document.

--- a/bin/rails
+++ b/bin/rails
@@ -3,6 +3,7 @@
 # installed from the root of your application.
 
 ENGINE_ROOT = File.expand_path("..", __dir__)
+ENGINE_PATH = File.expand_path("../lib/suspenders/engine", __dir__)
 APP_PATH = File.expand_path("../test/dummy/config/application", __dir__)
 
 # Set up gems listed in the Gemfile.

--- a/lib/generators/suspenders/rake_generator.rb
+++ b/lib/generators/suspenders/rake_generator.rb
@@ -1,0 +1,15 @@
+module Suspenders
+  module Generators
+    class RakeGenerator < Rails::Generators::Base
+      source_root File.expand_path("../../templates/rake", __FILE__)
+      desc(<<~TEXT)
+        Configures the default Rake task to audit and lint the codebase with
+        `bundler-audit` and `standard`, in addition to running the test suite.
+      TEXT
+
+      def configure_default_rake_task
+        append_to_file "Rakefile", %(task default: "suspenders:rake")
+      end
+    end
+  end
+end

--- a/lib/suspenders.rb
+++ b/lib/suspenders.rb
@@ -1,4 +1,5 @@
 require "suspenders/version"
+require "suspenders/engine"
 require "suspenders/railtie"
 require "suspenders/generators"
 

--- a/lib/suspenders/engine.rb
+++ b/lib/suspenders/engine.rb
@@ -1,0 +1,5 @@
+module Suspenders
+  class Engine < ::Rails::Engine
+    isolate_namespace Suspenders
+  end
+end

--- a/lib/tasks/suspenders.rake
+++ b/lib/tasks/suspenders.rake
@@ -1,0 +1,12 @@
+namespace :suspenders do
+  desc "Extend the default Rails Rake task"
+  task :rake do
+    if Bundler.rubygems.find_name("bundler-audit").any?
+      Rake::Task[:"bundle:audit"].invoke
+    end
+
+    if Bundler.rubygems.find_name("standard").any?
+      Rake::Task[:standard].invoke
+    end
+  end
+end

--- a/test/generators/suspenders/rake_generator_test.rb
+++ b/test/generators/suspenders/rake_generator_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+require "generators/suspenders/rake_generator"
+
+module Suspenders
+  module Generators
+    class RakeGeneratorTest < Rails::Generators::TestCase
+      include Suspenders::TestHelpers
+
+      tests Suspenders::Generators::RakeGenerator
+      destination Rails.root
+      setup :prepare_destination
+      teardown :restore_destination
+
+      test "modifies existing Rakefile" do
+        run_generator
+
+        assert_file app_root("Rakefile") do |file|
+          assert_match /task default: "suspenders:rake"/, file
+        end
+      end
+
+      test "generator has a description" do
+        description = <<~TEXT
+          Configures the default Rake task to audit and lint the codebase with
+          `bundler-audit` and `standard`, in addition to running the test suite.
+        TEXT
+
+        assert_equal description, generator_class.desc
+      end
+
+      private
+
+      def prepare_destination
+        touch "Gemfile"
+        backup_file "Rakefile"
+      end
+
+      def restore_destination
+        remove_file_if_exists "Gemfile"
+        restore_file "Rakefile"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add necessary files to make the [plugin][] an [engine][], which
automatically loads Rake tasks located in `lib/tasks`. This means when
the `suspenders` gem is installed, the consumer can run `bundle exec
rake suspenders:rake`, and any future tasks.

Because `suspenders:lint` and `suspenders:advisories` may not
necessarily have been invoked, we need to check if those gems are
installed.

[plugin]: https://guides.rubyonrails.org/plugins.html
[engine]: https://guides.rubyonrails.org/engines.html

## How to review this pull request

1. Spin up a new Rails application.

    ```sh
    rails new rake_demo
    ```

1. Scaffold a domain in order to generate passing tests.

    ```sh
    bin/rails g scaffold post title
    bin/rails db:migrate
    ```

1. Install suspenders on this branch.

    ```ruby
    group :development, :test do
      gem "suspenders", github: "thoughtbot/suspenders", branch: "suspenders-3-0-0-rake-generator"
    end
    ```

1. Run the following generators.

    ```sh
    bin/rails g suspenders:advisories
    bin/rails g suspenders:lint
    bin/rails g suspenders:rake
    ```

1. Run Rake and note the output. It should run the test suite, run `standard`
   and run `bundler-audit`.

    ```sh
    bundle exec rake
    ```

Co-authored-by: Mike Burns <mburns@thoughtbot.com>
