### PR TITLE
Modify `suspenders:styles`

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,7 @@ Configures applications to use [PostCSS][] or [Tailwind][] via
 [cssbundling-rails][]. Defaults to PostCSS with [modern-normalize][], with the
 option to override via `--css=tailwind`.
 
-Also creates a directory structure to store additional stylesheets if using
-PostCSS.
+Also creates additional stylesheets if using PostCSS.
 
 `bin/rails g suspenders:styles --css[postcss:tailwind]`
 

--- a/lib/generators/suspenders/styles_generator.rb
+++ b/lib/generators/suspenders/styles_generator.rb
@@ -11,8 +11,7 @@ module Suspenders
         Defaults to PostCSS with modern-normalize, with the option to override via
         --css=tailwind.
 
-        Also creates a directory structure to store additional stylesheets if using
-        PostCSS.
+        Also creates additional stylesheets if using PostCSS.
       TEXT
 
       def add_cssbundling_rails_gem

--- a/test/generators/suspenders/styles_generator_test.rb
+++ b/test/generators/suspenders/styles_generator_test.rb
@@ -51,8 +51,7 @@ module Suspenders
           Defaults to PostCSS with modern-normalize, with the option to override via
           --css=tailwind.
 
-          Also creates a directory structure to store additional stylesheets if using
-          PostCSS.
+          Also creates additional stylesheets if using PostCSS.
         TEXT
 
         assert_equal description, generator_class.desc
@@ -130,13 +129,13 @@ module Suspenders
         assert_match(/bin\/rails css:install:tailwind/, output)
       end
 
-      test "does not install normalize" do
+      test "does not install modern-normalize" do
         output = run_generator %w[--css=tailwind]
 
         assert_no_match(/add.*modern-normalize/, output)
       end
 
-      test "does not create directory structure" do
+      test "does not create stylesheets" do
         run_generator %w[--css=tailwind]
 
         assert_no_file app_root("app/assets/stylesheets/base.css")
@@ -168,7 +167,7 @@ module Suspenders
       setup :prepare_destination
       teardown :restore_destination
 
-      test "installs normalize and imports style sheets" do
+      test "installs modern-normalize and imports stylesheets" do
         output = run_generator %w[--css=postcss]
         application_stylesheet = <<~TEXT
           @import "modern-normalize";
@@ -184,7 +183,7 @@ module Suspenders
         end
       end
 
-      test "creates directory structure" do
+      test "creates stylesheets" do
         run_generator
 
         assert_file app_root("app/assets/stylesheets/base.css")


### PR DESCRIPTION
These modifications were not captured before merging #1145, presumably because
of an issue with GitHub CLI.

