### PR TITLE
Add `suspenders:development:environment` generator

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@ Unreleased
 * Introduce `suspenders:cleanup:organize_gemfile` task
 * Introduce `suspenders:production:environment` generator
 * Introduce `suspenders:test:environment` generator
+* Introduce `suspenders:development:environment` generator
 
 20230113.0 (January, 13, 2023)
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,6 @@ bin/rails g suspenders:ci
 
 ### Environments
 
-<<<<<<< HEAD
 #### Production
 
 Configures the production environment.
@@ -208,11 +207,7 @@ Configures the production environment.
 
 [require_master_key]: https://guides.rubyonrails.org/configuring.html#config-require-master-key
 
-```
-bin/rails g suspenders:production:environment
-```
 
-=======
 #### Test
 
 Configures test environment.
@@ -227,7 +222,24 @@ bin/rails g suspenders:test:environment
 [raise_on_missing_translations]: https://guides.rubyonrails.org/configuring.html#config-i18n-raise-on-missing-translations
 [action_dispatch.show_exceptions]: https://edgeguides.rubyonrails.org/configuring.html#config-action-dispatch-show-exceptions
 
->>>>>>> 9102851 (Introduce `suspenders:test:environment` generator)
+#### Development
+
+Configures the development environment.
+
+```
+bin/rails g suspenders:development:evironment
+```
+
+- Enables [raise_on_missing_translations][]
+- Enables [annotate_rendered_view_with_filenames][]
+- Enables [i18n_customize_full_message][]
+- Enables [query_log_tags_enabled][]
+
+[raise_on_missing_translations]: https://guides.rubyonrails.org/configuring.html#config-i18n-raise-on-missing-translations
+[annotate_rendered_view_with_filenames]: https://guides.rubyonrails.org/configuring.html#config-action-view-annotate-rendered-view-with-filenames
+[i18n_customize_full_message]: https://guides.rubyonrails.org/configuring.html#config-active-model-i18n-customize-full-message
+[query_log_tags_enabled]: https://guides.rubyonrails.org/configuring.html#config-active-record-query-log-tags-enabled
+
 ## Contributing
 
 See the [CONTRIBUTING] document.

--- a/lib/generators/suspenders/development/environment_generator.rb
+++ b/lib/generators/suspenders/development/environment_generator.rb
@@ -1,0 +1,52 @@
+module Suspenders
+  module Generators
+    module Development
+      class EnvironmentGenerator < Rails::Generators::Base
+        desc <<~MARKDOWN
+          Configures the development environment.
+
+          - Enables [raise_on_missing_translations][]
+          - Enables [annotate_rendered_view_with_filenames][]
+          - Enables [i18n_customize_full_message][]
+          - Enables [query_log_tags_enabled][]
+
+          [raise_on_missing_translations]: https://guides.rubyonrails.org/configuring.html#config-i18n-raise-on-missing-translations
+          [annotate_rendered_view_with_filenames]: https://guides.rubyonrails.org/configuring.html#config-action-view-annotate-rendered-view-with-filenames
+          [i18n_customize_full_message]: https://guides.rubyonrails.org/configuring.html#config-active-model-i18n-customize-full-message
+          [query_log_tags_enabled]: https://guides.rubyonrails.org/configuring.html#config-active-record-query-log-tags-enabled
+        MARKDOWN
+
+        def raise_on_missing_translations
+          if development_config.match?(/^\s#\s*config\.i18n\.raise_on_missing_translations/)
+            uncomment_lines "config/environments/development.rb", "config.i18n.raise_on_missing_translations = true"
+          else
+            environment %(config.i18n.raise_on_missing_translations = true), env: "development"
+          end
+        end
+
+        def annotate_render_view_with_filename
+          if development_config.match?(/^\s#\s*config\.action_view\.annotate_render_view_with_filename/)
+            uncomment_lines "config/environments/development.rb",
+              "config.action_view.annotate_rendered_view_with_filenames = true"
+          else
+            environment %(config.action_view.annotate_rendered_view_with_filenames = true), env: "development"
+          end
+        end
+
+        def enable_i18n_customize_full_message
+          environment %(config.active_model.i18n_customize_full_message = true), env: "development"
+        end
+
+        def enable_query_log_tags_enabled
+          environment %(config.active_record.query_log_tags_enabled = true), env: "development"
+        end
+
+        private
+
+        def development_config
+          File.read(Rails.root.join("config/environments/development.rb"))
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures/files/environments/development.rb
+++ b/test/fixtures/files/environments/development.rb
@@ -1,0 +1,2 @@
+Rails.application.configure do
+end

--- a/test/generators/suspenders/development/environment_generator_test.rb
+++ b/test/generators/suspenders/development/environment_generator_test.rb
@@ -1,0 +1,95 @@
+require "test_helper"
+require "generators/suspenders/development/environment_generator"
+
+module Suspenders
+  module Generators
+    module Development
+      class EnvironmentGenerator::DefaultTest < Rails::Generators::TestCase
+        include Suspenders::TestHelpers
+
+        tests Suspenders::Generators::Development::EnvironmentGenerator
+        destination Rails.root
+        setup :prepare_destination
+        teardown :restore_destination
+
+        test "raise on missing translations" do
+          run_generator
+
+          assert_file app_root("config/environments/development.rb") do |file|
+            assert_match(
+              /^ +config.i18n.raise_on_missing_translations = true$/,
+              file
+            )
+          end
+        end
+
+        test "raise on missing translations (when config is not commented out)" do
+          content = file_fixture("environments/development.rb").read
+          remove_file_if_exists "config/environments/development.rb"
+          touch "config/environments/development.rb", content: content
+
+          run_generator
+
+          assert_file app_root("config/environments/development.rb") do |file|
+            assert_match(
+              /^ +config.i18n.raise_on_missing_translations = true$/,
+              file
+            )
+          end
+        end
+
+        test "annotate rendered view with file names" do
+          run_generator
+
+          assert_file app_root("config/environments/development.rb") do |file|
+            assert_match(
+              /^ +config.action_view.annotate_rendered_view_with_filenames = true$/,
+              file
+            )
+          end
+        end
+
+        test "annotate rendered view with file names (when config is not commented out)" do
+          content = file_fixture("environments/development.rb").read
+          remove_file_if_exists "config/environments/development.rb"
+          touch "config/environments/development.rb", content: content
+
+          run_generator
+
+          assert_file app_root("config/environments/development.rb") do |file|
+            assert_match(
+              /^ +config.action_view.annotate_rendered_view_with_filenames = true$/,
+              file
+            )
+          end
+        end
+
+        test "enable active_model.i18n_customize_full_message" do
+          run_generator
+
+          assert_file app_root("config/environments/development.rb") do |file|
+            assert_match(/^\s*config\.active_model\.i18n_customize_full_message\s*=\s*true/, file)
+          end
+        end
+
+        test "enable active_record.query_log_tags_enabled" do
+          run_generator
+
+          assert_file app_root("config/environments/development.rb") do |file|
+            assert_match(/^\s*config\.active_record\.query_log_tags_enabled\s*=\s*true/, file)
+          end
+        end
+
+        private
+
+        def prepare_destination
+          backup_file "config/environments/development.rb"
+        end
+
+        def restore_destination
+          restore_file "config/environments/development.rb"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Creates generator to configure the development environment. Keeps parity
with Rails as much as possible in an effort to avoid drift with Rails
standards.

It's possible a future release of Rails will alleviate us from having to
do the following:

- enable `active_model.i18n_customize_full_message` which is being
  addressed in [#50406][]
- enable `active_record.query_log_tags_enabled` which is being addressed
  in [#51342][]

[#50406]: https://github.com/rails/rails/pull/50406
[#51342]: https://github.com/rails/rails/pull/51342
