### PR TITLE
Introduce `suspenders:production:environment` generator

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@ Unreleased
 * Introduce `suspenders:prerequisites` generator
 * Introduce `suspenders:ci` generator
 * Introduce `suspenders:cleanup:organize_gemfile` task
+* Introduce `suspenders:production:environment` generator
 
 20230113.0 (January, 13, 2023)
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,20 @@ Creates CI files for GitHub Actions.
 bin/rails g suspenders:ci
 ```
 
+### Environments
+
+#### Production
+
+Configures the production environment.
+
+ - Enables [require_master_key][]
+
+[require_master_key]: https://guides.rubyonrails.org/configuring.html#config-require-master-key
+
+```
+bin/rails g suspenders:production:environment
+```
+
 ## Contributing
 
 See the [CONTRIBUTING] document.

--- a/lib/generators/suspenders/production/environment_generator.rb
+++ b/lib/generators/suspenders/production/environment_generator.rb
@@ -1,0 +1,29 @@
+module Suspenders
+  module Generators
+    module Production
+      class EnvironmentGenerator < Rails::Generators::Base
+        desc <<~MARKDOWN
+          Configures the production environment.
+
+          - Enables [require_master_key][]
+
+          [require_master_key]: https://guides.rubyonrails.org/configuring.html#config-require-master-key
+        MARKDOWN
+
+        def require_master_key
+          if production_config.match?(/^\s*#\s*config\.require_master_key\s*=\s*true/)
+            uncomment_lines "config/environments/production.rb", /config\.require_master_key\s*=\s*true/
+          else
+            environment %(config.require_master_key = true), env: "production"
+          end
+        end
+
+        private
+
+        def production_config
+          File.read(Rails.root.join("config/environments/production.rb"))
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures/files/environments/production.rb
+++ b/test/fixtures/files/environments/production.rb
@@ -1,0 +1,2 @@
+Rails.application.configure do
+end

--- a/test/generators/suspenders/production/environment_generator_test.rb
+++ b/test/generators/suspenders/production/environment_generator_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+require "generators/suspenders/production/environment_generator"
+
+module Suspenders
+  module Generators
+    module Production
+      class EnvironmentGeneratorTest < Rails::Generators::TestCase
+        include Suspenders::TestHelpers
+
+        tests Suspenders::Generators::Production::EnvironmentGenerator
+        destination Rails.root
+        setup :prepare_destination
+        teardown :restore_destination
+
+        test "requires master key" do
+          run_generator
+
+          assert_file app_root("config/environments/production.rb") do |file|
+            assert_match(/^\s*config\.require_master_key\s*=\s*true/, file)
+          end
+        end
+
+        test "requires master key (when config is not commented out)" do
+          content = file_fixture("environments/production.rb").read
+          remove_file_if_exists "config/environments/production.rb"
+          touch "config/environments/production.rb", content: content
+
+          run_generator
+
+          assert_file app_root("config/environments/production.rb") do |file|
+            assert_match(/^\s*config\.require_master_key\s*=\s*true/, file)
+          end
+        end
+
+        private
+
+        def prepare_destination
+          backup_file "config/environments/production.rb"
+        end
+
+        def restore_destination
+          restore_file "config/environments/production.rb"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Creates generator to configuration the production environment. For now,
this means [requiring a master key][master key].

Drops configuration for [asset_host][], since that should be an
infrastructure decision.

In an effort to distinguish between the development environment
configuration in #1149, we use the `production` namespace.

[master key]: https://guides.rubyonrails.org/configuring.html#config-require-master-key
[asset_host]: https://guides.rubyonrails.org/configuring.html#config-asset-host
