### PR TITLE
Fix stylelint violations when using Tailwind

### DIFF
--- a/lib/generators/suspenders/lint_generator.rb
+++ b/lib/generators/suspenders/lint_generator.rb
@@ -21,7 +21,11 @@ module Suspenders
       end
 
       def configure_stylelint
-        copy_file "stylelintrc.json", ".stylelintrc.json"
+        if using_tailwind?
+          copy_file "tailwind.stylelintrc.json", ".stylelintrc.json"
+        else
+          copy_file "stylelintrc.json", ".stylelintrc.json"
+        end
       end
 
       def configure_eslint

--- a/lib/generators/templates/lint/tailwind.stylelintrc.json
+++ b/lib/generators/templates/lint/tailwind.stylelintrc.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@thoughtbot/stylelint-config",
+  "rules": {
+    "scss/at-rule-no-unknown": [
+      true,
+      {
+        "ignoreAtRules": ["tailwind"]
+      }
+    ]
+  }
+}

--- a/lib/suspenders/generators.rb
+++ b/lib/suspenders/generators.rb
@@ -18,6 +18,10 @@ module Suspenders
       def rspec_test_helper_present?
         File.exist? Rails.root.join("spec/rails_helper.rb")
       end
+
+      def using_tailwind?
+        File.exist? Rails.root.join("tailwind.config.js")
+      end
     end
 
     module APIAppUnsupported

--- a/test/generators/suspenders/lint_generator_test.rb
+++ b/test/generators/suspenders/lint_generator_test.rb
@@ -53,6 +53,30 @@ module Suspenders
         end
       end
 
+      test "configures stylelint for tailwind" do
+        expected_content = <<~TEXT
+          {
+            "extends": "@thoughtbot/stylelint-config",
+            "rules": {
+              "scss/at-rule-no-unknown": [
+                true,
+                {
+                  "ignoreAtRules": ["tailwind"]
+                }
+              ]
+            }
+          }
+        TEXT
+
+        with_css_option :tailwind do
+          capture(:stderr) { run_generator }
+
+          assert_file app_root(".stylelintrc.json") do |file|
+            assert_equal expected_content, file
+          end
+        end
+      end
+
       test "configures eslint" do
         expected_content = <<~JSON
           {

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -100,6 +100,21 @@ module Suspenders::TestHelpers
     remove_dir_if_exists "spec"
   end
 
+  def with_css_option(css, &block)
+    case css
+    when :postcss
+      touch "postcss.config.js"
+    when :tailwind
+      touch "tailwind.config.js"
+    else
+      raise ArgumentError, "unknown css option: #{css.inspect}"
+    end
+    yield
+  ensure
+    remove_file_if_exists "postcss.config.js"
+    remove_file_if_exists "tailwind.config.js"
+  end
+
   def backup_file(file)
     FileUtils.copy app_root(file), app_root("#{file}.bak")
   end


### PR DESCRIPTION
When we introduced #1148 we did not test it against applications that invoked
`suspenders:styles --css=tailwind`.
