### PR TITLE
Remove reference to `Timecop` from `spec_helper.rb`

### DIFF
--- a/spec/features/new_project_spec.rb
+++ b/spec/features/new_project_spec.rb
@@ -271,11 +271,6 @@ RSpec.describe "Suspend a new project with default configuration", type: :featur
     expect(gemfile).to match(/sassc-rails/)
   end
 
-  it "configures Timecop safe mode" do
-    spec_helper = read_project_file(%w[spec spec_helper.rb])
-    expect(spec_helper).to match(/Timecop.safe_mode = true/)
-  end
-
   it "adds and configures a bundler strategy for css and js" do
     gemfile = read_project_file("Gemfile")
 

--- a/templates/spec_helper.rb
+++ b/templates/spec_helper.rb
@@ -1,5 +1,4 @@
 require "webmock/rspec"
-require "timecop"
 
 # http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
@@ -20,6 +19,3 @@ WebMock.disable_net_connect!(
   allow_localhost: true,
   allow: "chromedriver.storage.googleapis.com"
 )
-
-# Only allow Timecop with block syntax
-Timecop.safe_mode = true


### PR DESCRIPTION
Follow-up to #351

Now that `Timecop` has been removed, we no longer need to configure
RSpec to use it.
