### PR TITLE
Introduce `suspenders:setup` generator

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@ Unreleased
 * Introduce `suspenders:lint` generator
 * Introduce `suspenders:rake` generator
 * Introduce `suspenders:views` generator
+* Introduce `suspenders:setup` generator
 
 20230113.0 (January, 13, 2023)
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,20 @@ document [lang][].
 [title]: https://github.com/calebhearth/title
 [lang]: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang
 
+### Setup
+
+A holistic setup script.
+
+```sh
+bin/setup
+```
+
+or
+
+```sh
+WIPE_DATABASE=true bin/setup
+```
+
 ## Contributing
 
 See the [CONTRIBUTING] document.

--- a/README.md
+++ b/README.md
@@ -142,12 +142,6 @@ A holistic setup script.
 bin/setup
 ```
 
-or
-
-```sh
-WIPE_DATABASE=true bin/setup
-```
-
 ## Contributing
 
 See the [CONTRIBUTING] document.

--- a/lib/generators/suspenders/setup_generator.rb
+++ b/lib/generators/suspenders/setup_generator.rb
@@ -10,10 +10,6 @@ module Suspenders
         ```
       TEXT
 
-      def create_brewfile
-        copy_file "brewfile", "Brewfile"
-      end
-
       def create_dev_prime
         copy_file "dev_prime.rb", "lib/tasks/dev.rake"
       end

--- a/lib/generators/suspenders/setup_generator.rb
+++ b/lib/generators/suspenders/setup_generator.rb
@@ -8,12 +8,6 @@ module Suspenders
         ```sh
         bin/setup
         ```
-
-        or
-
-        ```sh
-        WIPE_DATABASE=true bin/setup
-        ```
       TEXT
 
       def create_brewfile

--- a/lib/generators/suspenders/setup_generator.rb
+++ b/lib/generators/suspenders/setup_generator.rb
@@ -10,10 +10,6 @@ module Suspenders
         ```
       TEXT
 
-      def create_dev_prime
-        copy_file "dev_prime.rb", "lib/tasks/dev.rake"
-      end
-
       def replace_bin_setup
         copy_file "bin_setup.rb", "bin/setup", force: true
       end

--- a/lib/generators/suspenders/setup_generator.rb
+++ b/lib/generators/suspenders/setup_generator.rb
@@ -1,0 +1,32 @@
+module Suspenders
+  module Generators
+    class SetupGenerator < Rails::Generators::Base
+      source_root File.expand_path("../../templates/setup", __FILE__)
+      desc <<~TEXT
+        A holistic setup script.
+
+        ```sh
+        bin/setup
+        ```
+
+        or
+
+        ```sh
+        WIPE_DATABASE=true bin/setup
+        ```
+      TEXT
+
+      def create_brewfile
+        copy_file "brewfile", "Brewfile"
+      end
+
+      def create_dev_prime
+        copy_file "dev_prime.rb", "lib/tasks/dev.rake"
+      end
+
+      def replace_bin_setup
+        copy_file "bin_setup.rb", "bin/setup", force: true
+      end
+    end
+  end
+end

--- a/lib/generators/templates/setup/bin_setup.rb
+++ b/lib/generators/templates/setup/bin_setup.rb
@@ -41,11 +41,7 @@ FileUtils.chdir APP_ROOT do
   system("yarn install --check-files") if using_node?
 
   puts "\n== Preparing database and adding development seed data =="
-  if ENV["WIPE_DATABASE"] == true
-    system! "bin/rails db:reset dev:prime"
-  else
-    system! "bin/rails dev:prime"
-  end
+  system! "bin/rails dev:prime"
 
   # https://github.com/rails/rails/pull/47719/files
   puts "\n== Setup test environment =="

--- a/lib/generators/templates/setup/bin_setup.rb
+++ b/lib/generators/templates/setup/bin_setup.rb
@@ -20,7 +20,11 @@ FileUtils.chdir APP_ROOT do
   system("yarn install --check-files") if using_node?
 
   puts "\n== Preparing database and adding development seed data =="
-  system! "bin/rails dev:prime"
+  if File.exist? "lib/tasks/dev.rake"
+    system! "bin/rails dev:rake"
+  else
+    system! "bin/rails db:prepare"
+  end
 
   if Bundler.rubygems.find_name("sprockets")
     puts "\n== Generating assets =="

--- a/lib/generators/templates/setup/bin_setup.rb
+++ b/lib/generators/templates/setup/bin_setup.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 require "fileutils"
 require "open3"
+require "bundler"
 
 # path to your application root.
 APP_ROOT = File.expand_path("..", __dir__)
@@ -42,6 +43,11 @@ FileUtils.chdir APP_ROOT do
 
   puts "\n== Preparing database and adding development seed data =="
   system! "bin/rails dev:prime"
+
+  if Bundler.rubygems.find_name("sprockets")
+    puts "\n== Generating assets =="
+    system! "bin/rails assets:clobber assets:precompile"
+  end
 
   # https://github.com/rails/rails/pull/47719/files
   puts "\n== Setup test environment =="

--- a/lib/generators/templates/setup/bin_setup.rb
+++ b/lib/generators/templates/setup/bin_setup.rb
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+require "fileutils"
+require "open3"
+
+# path to your application root.
+APP_ROOT = File.expand_path("..", __dir__)
+
+def system!(*args)
+  system(*args, exception: true)
+end
+
+def using_node?
+  File.exist? "package.json"
+end
+
+FileUtils.chdir APP_ROOT do
+  if ENV["CI"].nil?
+    puts "\n== Installing Homebrew Bundle from Brewfile =="
+    system! "brew bundle"
+
+    puts "\n== Starting postgresql@15 =="
+    system! "brew services restart postgresql@15"
+
+    puts "\n== Starting redis =="
+    system! "brew services restart redis"
+
+    _, _, status = Open3.capture3("which asdf")
+    if status.success?
+      puts "\n== Installing tool dependecies via asdf =="
+      system! "asdf plugin-add ruby https://github.com/asdf-vm/asdf-ruby"
+      system! "asdf plugin-add nodejs https://github.com/asdf-vm/asdf-nodejs" if using_node?
+      system! "asdf plugin-add yarn https://github.com/twuni/asdf-yarn" if using_node?
+      system! "asdf plugin-update --all"
+      system! "asdf install"
+    end
+  end
+
+  puts "\n== Installing dependencies =="
+  system! "gem install bundler --conservative"
+  system("bundle check") || system!("bundle install")
+  system("yarn install --check-files") if using_node?
+
+  puts "\n== Preparing database and adding development seed data =="
+  if ENV["WIPE_DATABASE"] == true
+    system! "bin/rails db:reset dev:prime"
+  else
+    system! "bin/rails dev:prime"
+  end
+
+  # https://github.com/rails/rails/pull/47719/files
+  puts "\n== Setup test environment =="
+  system! "bin/rails test:prepare"
+
+  puts "\n== Removing old logs and tempfiles =="
+  system! "bin/rails log:clear tmp:clear"
+
+  puts "\n== Restarting application server =="
+  system! "bin/rails restart"
+end

--- a/lib/generators/templates/setup/bin_setup.rb
+++ b/lib/generators/templates/setup/bin_setup.rb
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 require "fileutils"
-require "open3"
 require "bundler"
 
 # path to your application root.
@@ -15,28 +14,7 @@ def using_node?
 end
 
 FileUtils.chdir APP_ROOT do
-  if ENV["CI"].nil?
-    puts "\n== Installing Homebrew Bundle from Brewfile =="
-    system! "brew bundle"
-
-    puts "\n== Starting postgresql@15 =="
-    system! "brew services restart postgresql@15"
-
-    puts "\n== Starting redis =="
-    system! "brew services restart redis"
-
-    _, _, status = Open3.capture3("which asdf")
-    if status.success?
-      puts "\n== Installing tool dependecies via asdf =="
-      system! "asdf plugin-add ruby https://github.com/asdf-vm/asdf-ruby"
-      system! "asdf plugin-add nodejs https://github.com/asdf-vm/asdf-nodejs" if using_node?
-      system! "asdf plugin-add yarn https://github.com/twuni/asdf-yarn" if using_node?
-      system! "asdf plugin-update --all"
-      system! "asdf install"
-    end
-  end
-
-  puts "\n== Installing dependencies =="
+  puts "== Installing dependencies =="
   system! "gem install bundler --conservative"
   system("bundle check") || system!("bundle install")
   system("yarn install --check-files") if using_node?

--- a/lib/generators/templates/setup/bin_setup.rb
+++ b/lib/generators/templates/setup/bin_setup.rb
@@ -21,7 +21,7 @@ FileUtils.chdir APP_ROOT do
 
   puts "\n== Preparing database and adding development seed data =="
   if File.exist? "lib/tasks/dev.rake"
-    system! "bin/rails dev:rake"
+    system! "bin/rails dev:prime"
   else
     system! "bin/rails db:prepare"
   end

--- a/lib/generators/templates/setup/brewfile
+++ b/lib/generators/templates/setup/brewfile
@@ -1,0 +1,9 @@
+# https://formulae.brew.sh/formula/vips
+brew "vips"
+
+# https://formulae.brew.sh/formula/redis
+brew "redis"
+
+# https://formulae.brew.sh/formula/postgresql@15
+# Change version to match production
+brew "postgresql@15"

--- a/lib/generators/templates/setup/brewfile
+++ b/lib/generators/templates/setup/brewfile
@@ -1,9 +1,0 @@
-# https://formulae.brew.sh/formula/vips
-brew "vips"
-
-# https://formulae.brew.sh/formula/redis
-brew "redis"
-
-# https://formulae.brew.sh/formula/postgresql@15
-# Change version to match production
-brew "postgresql@15"

--- a/lib/generators/templates/setup/dev_prime.rb
+++ b/lib/generators/templates/setup/dev_prime.rb
@@ -1,0 +1,12 @@
+if Rails.env.development? || Rails.env.test?
+  require "factory_bot" if Bundler.rubygems.find_name("factory_bot_rails").any?
+
+  namespace :dev do
+    desc "Sample data for local development environment"
+    task prime: "db:setup" do
+      include FactoryBot::Syntax::Methods if Bundler.rubygems.find_name("factory_bot_rails").any?
+
+      # create(:user, email: "user@example.com", password: "password")
+    end
+  end
+end

--- a/test/generators/suspenders/setup_generator_test.rb
+++ b/test/generators/suspenders/setup_generator_test.rb
@@ -11,26 +11,6 @@ module Suspenders
       setup :prepare_destination
       teardown :restore_destination
 
-      test "creates Brewfile" do
-        expected = <<~TEXT
-          # https://formulae.brew.sh/formula/vips
-          brew "vips"
-
-          # https://formulae.brew.sh/formula/redis
-          brew "redis"
-
-          # https://formulae.brew.sh/formula/postgresql@15
-          # Change version to match production
-          brew "postgresql@15"
-        TEXT
-
-        run_generator
-
-        assert_file app_root("Brewfile") do |file|
-          assert_equal expected, file
-        end
-      end
-
       test "modifies bin/setup" do
         expected = bin_setup
 

--- a/test/generators/suspenders/setup_generator_test.rb
+++ b/test/generators/suspenders/setup_generator_test.rb
@@ -21,29 +21,6 @@ module Suspenders
         end
       end
 
-      test "creates dev:prime task" do
-        expected = <<~RUBY
-          if Rails.env.development? || Rails.env.test?
-            require "factory_bot" if Bundler.rubygems.find_name("factory_bot_rails").any?
-
-            namespace :dev do
-              desc "Sample data for local development environment"
-              task prime: "db:setup" do
-                include FactoryBot::Syntax::Methods if Bundler.rubygems.find_name("factory_bot_rails").any?
-
-                # create(:user, email: "user@example.com", password: "password")
-              end
-            end
-          end
-        RUBY
-
-        run_generator
-
-        assert_file app_root("lib/tasks/dev.rake") do |file|
-          assert_equal expected, file
-        end
-      end
-
       test "has a custom description" do
         assert_no_match(/Description:/, generator_class.desc)
       end

--- a/test/generators/suspenders/setup_generator_test.rb
+++ b/test/generators/suspenders/setup_generator_test.rb
@@ -1,0 +1,88 @@
+require "test_helper"
+require "generators/suspenders/setup_generator"
+
+module Suspenders
+  module Generators
+    class SetupGeneratorTest < Rails::Generators::TestCase
+      include Suspenders::TestHelpers
+
+      tests Suspenders::Generators::SetupGenerator
+      destination Rails.root
+      setup :prepare_destination
+      teardown :restore_destination
+
+      test "creates Brewfile" do
+        expected = <<~TEXT
+          # https://formulae.brew.sh/formula/vips
+          brew "vips"
+
+          # https://formulae.brew.sh/formula/redis
+          brew "redis"
+
+          # https://formulae.brew.sh/formula/postgresql@15
+          # Change version to match production
+          brew "postgresql@15"
+        TEXT
+
+        run_generator
+
+        assert_file app_root("Brewfile") do |file|
+          assert_equal expected, file
+        end
+      end
+
+      test "modifies bin/setup" do
+        expected = bin_setup
+
+        run_generator
+
+        assert_file app_root("bin/setup") do |file|
+          assert_equal expected, file
+        end
+      end
+
+      test "creates dev:prime task" do
+        expected = <<~RUBY
+          if Rails.env.development? || Rails.env.test?
+            require "factory_bot" if Bundler.rubygems.find_name("factory_bot_rails").any?
+
+            namespace :dev do
+              desc "Sample data for local development environment"
+              task prime: "db:setup" do
+                include FactoryBot::Syntax::Methods if Bundler.rubygems.find_name("factory_bot_rails").any?
+
+                # create(:user, email: "user@example.com", password: "password")
+              end
+            end
+          end
+        RUBY
+
+        run_generator
+
+        assert_file app_root("lib/tasks/dev.rake") do |file|
+          assert_equal expected, file
+        end
+      end
+
+      test "has a custom description" do
+        assert_no_match(/Description:/, generator_class.desc)
+      end
+
+      private
+
+      def prepare_destination
+        backup_file "bin/setup"
+      end
+
+      def restore_destination
+        remove_file_if_exists "Brewfile"
+        restore_file "bin/setup"
+        remove_dir_if_exists "lib/tasks"
+      end
+
+      def bin_setup
+        File.read("./lib/generators/templates/setup/bin_setup.rb")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Replaces the [default setup script][] provided by Rails. The trade-off being
that the implementation is simple, but the cost is we risk drifting from Rails.
After attempting to use [gsub_file][] and [insert_into_file][], it felt simpler
to just override the file completely.

Clobber and precompile assets during setup if using [Sprockets][]. This
is helpful in cases where one might switch branches frequently, which
can result in broken assets.

Additionally, we [setup the test environment][] to avoid issues with asset
compilation in tests.

[default setup script]: https://github.com/rails/rails/blob/main/railties/lib/rails/generators/rails/app/templates/bin/setup.tt
[gsub_file]: https://rubydoc.info/gems/thor/Thor/Actions#gsub_file-instance_method
[insert_into_file]: https://rubydoc.info/gems/thor/Thor/Actions#insert_into_file-instance_method
[Sprockets]: https://github.com/rails/sprockets
[setup the test environment]: https://github.com/rails/rails/pull/47719/files
