### PR TITLE
Introduce `suspenders:tasks` generator

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ Unreleased
 * Introduce `suspenders:rake` generator
 * Introduce `suspenders:views` generator
 * Introduce `suspenders:setup` generator
+* Introduce `suspenders:tasks` generator
 
 20230113.0 (January, 13, 2023)
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,14 @@ A holistic setup script.
 bin/setup
 ```
 
+### Tasks
+
+Creates local Rake tasks for development
+
+```sh
+bin/rails dev:prime
+```
+
 ## Contributing
 
 See the [CONTRIBUTING] document.

--- a/lib/generators/suspenders/tasks_generator.rb
+++ b/lib/generators/suspenders/tasks_generator.rb
@@ -1,0 +1,20 @@
+module Suspenders
+  module Generators
+    class TasksGenerator < Rails::Generators::Base
+      source_root File.expand_path("../../templates/tasks", __FILE__)
+      desc <<~TEXT
+        Creates local Rake tasks for development
+
+        bin/rails dev:prime # Sample data for local development environment
+      TEXT
+
+      def create_dev_rake
+        if Bundler.rubygems.find_name("factory_bot").any?
+          copy_file "dev.rake", "lib/tasks/dev.rake"
+        else
+          say "This generator requires Factory Bot"
+        end
+      end
+    end
+  end
+end

--- a/lib/generators/templates/tasks/dev.rake
+++ b/lib/generators/templates/tasks/dev.rake
@@ -1,0 +1,12 @@
+if Rails.env.development? || Rails.env.test?
+  require "factory_bot"
+
+  namespace :dev do
+    desc "Sample data for local development environment"
+    task prime: "db:setup" do
+      include FactoryBot::Syntax::Methods
+
+      # create(:user, email: "user@example.com", password: "password")
+    end
+  end
+end

--- a/test/generators/suspenders/tasks_generator_test.rb
+++ b/test/generators/suspenders/tasks_generator_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+require "generators/suspenders/tasks_generator"
+
+module Suspenders
+  module Generators
+    class TasksGeneratorTest < Rails::Generators::TestCase
+      include Suspenders::TestHelpers
+
+      tests Suspenders::Generators::TasksGenerator
+      destination Rails.root
+      teardown :restore_destination
+
+      test "creates dev.rake file" do
+        Bundler.rubygems.stubs(:find_name).with("factory_bot").returns([true])
+
+        expected = dev_rake
+
+        run_generator
+
+        assert_file app_root("lib/tasks/dev.rake") do |file|
+          assert_equal expected, file
+        end
+      end
+
+      test "returns early if factory_bot_rails is not installed" do
+        output = run_generator
+
+        assert_match /This generator requires Factory Bot/, output
+        assert_no_file app_root("lib/tasks/dev.rake")
+      end
+
+      test "has a custom description" do
+        assert_no_match(/Description:/, generator_class.desc)
+      end
+
+      private
+
+      def dev_rake
+        File.read("./lib/generators/templates/tasks/dev.rake")
+      end
+
+      def restore_destination
+        remove_file_if_exists "lib/tasks/dev.rake"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Relates to #1157

For now, this generator simply creates `dev.rake` which contains [dev:prime][].

Note that we'll want this generator to run **after** `suspenders:factories`.

If future application specific tasks need to be added, we can use this
generator. However, this should not be confused with the existing pattern of
creating tasks under the suspenders namespace, such as the existing
`lib/tasks/suspenders.rake`. Tasks under this namespace cannot be edited by the
consumer, whereas tasks generated by `suspenders:tasks` are intended to be
edited by the consumer.

[dev:prime]: https://thoughtbot.com/blog/priming-the-pump
