### PR TITLE
Update front-end linting dependencies

### DIFF
--- a/lib/generators/suspenders/lint_generator.rb
+++ b/lib/generators/suspenders/lint_generator.rb
@@ -7,7 +7,7 @@ module Suspenders
       desc "Creates a holistic linting solution that covers JavaScript, CSS, Ruby and ERB."
 
       def install_dependencies
-        run "yarn add stylelint@^15.10.1 eslint @thoughtbot/stylelint-config@3.0.0 @thoughtbot/eslint-config npm-run-all prettier --dev"
+        run "yarn add stylelint eslint @thoughtbot/stylelint-config @thoughtbot/eslint-config npm-run-all prettier --dev"
       end
 
       def install_gems

--- a/test/generators/suspenders/lint_generator_test.rb
+++ b/test/generators/suspenders/lint_generator_test.rb
@@ -15,7 +15,7 @@ module Suspenders
         capture(:stderr) do
           output = run_generator
 
-          assert_match(/yarn add stylelint@\^15\.10\.1 eslint @thoughtbot\/stylelint-config@3\.0\.0 @thoughtbot\/eslint-config npm-run-all prettier --dev/, output)
+          assert_match(/yarn add stylelint eslint @thoughtbot\/stylelint-config @thoughtbot\/eslint-config npm-run-all prettier --dev/, output)
         end
       end
 


### PR DESCRIPTION
After the `v4.0.0` release of [@thoughtbot/stylelint-config][], the
errors mentioned in [this issue][] no longer appear.

This alleviates us from having to pin these dependencies.

[@thoughtbot/stylelint-config]:
https://github.com/thoughtbot/stylelint-config/releases/tag/v4.0.0
[this issue]: https://github.com/thoughtbot/stylelint-config/issues/46

