### PR TITLE
Disable Turbo's InstantClick

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,10 +129,13 @@ Configures the default Rake task to audit and lint the codebase with
 ### Views
 
 Configures flash messages, page titles via the [title][] gem, and sets the
-document [lang][].
+document [lang][]. Disables Turbo's [InstantClick][] to account for page
+requests that are [not debounced][].
 
 [title]: https://github.com/calebhearth/title
 [lang]: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang
+[InstantClick]: https://turbo.hotwired.dev/handbook/drive#prefetching-links-on-hover
+[not debounced]: https://github.com/hotwired/turbo/pull/1181#issuecomment-1936505362
 
 ### Setup
 

--- a/lib/generators/suspenders/views_generator.rb
+++ b/lib/generators/suspenders/views_generator.rb
@@ -3,7 +3,7 @@ module Suspenders
     class ViewsGenerator < Rails::Generators::Base
       include Suspenders::Generators::APIAppUnsupported
 
-      desc "Configures flash messages, page titles and the document lang."
+      desc "Configures flash messages, page titles and the document lang. Disables Turbo's InstantClick."
       source_root File.expand_path("../../templates/views", __FILE__)
 
       def install_gems
@@ -20,6 +20,7 @@ module Suspenders
         insert_into_file "app/views/layouts/application.html.erb", "    <%= render \"flashes\" -%>\n", after: "<body>\n"
         gsub_file "app/views/layouts/application.html.erb", /<html>/, "<html lang=\"<%= I18n.locale %>\">"
         gsub_file "app/views/layouts/application.html.erb", /<title>.*<\/title>/, "<title><%= title %></title>"
+        insert_into_file "app/views/layouts/application.html.erb", "    <meta name=\"turbo-prefetch\" content=\"false\">\n", after: "</title>"
       end
     end
   end

--- a/test/generators/suspenders/views_generator_test.rb
+++ b/test/generators/suspenders/views_generator_test.rb
@@ -87,6 +87,14 @@ module Suspenders
         assert_no_match(/Description:\n/, generator_class.desc)
       end
 
+      test "disables InstantClick" do
+        run_generator
+
+        assert_file app_root("app/views/layouts/application.html.erb") do |file|
+          assert_match(/<head>.*<\/title>\s{4}<meta\s*name="turbo-prefetch"\s*content=\s*"false">/m, file)
+        end
+      end
+
       private
 
       def prepare_destination


### PR DESCRIPTION
Turbo 8 introduced [InstantClick][]. An unintended side-effect of this
feature is that page requests are [not debounced][] when a user hovers
over a link. This is a concern for two reasons:

1. It creates an unnecessary burden on the server, which could affect
   rate limiting.
2. It can artificially inflate our metrics.

[InstantClick]: https://turbo.hotwired.dev/handbook/drive#prefetching-links-on-hover
[not debounced]:https://github.com/hotwired/turbo/pull/1181#issuecomment-1936505362
