### PR TITLE
Setup Generator: Remove call to `test:prepare`

### DIFF
--- a/lib/generators/templates/setup/bin_setup.rb
+++ b/lib/generators/templates/setup/bin_setup.rb
@@ -31,10 +31,6 @@ FileUtils.chdir APP_ROOT do
     system! "bin/rails assets:clobber assets:precompile"
   end
 
-  # https://github.com/rails/rails/pull/47719/files
-  puts "\n== Setup test environment =="
-  system! "bin/rails test:prepare"
-
   puts "\n== Removing old logs and tempfiles =="
   system! "bin/rails log:clear tmp:clear"
 


### PR DESCRIPTION
Follow-up to #1157

After merging #1156, this command no longer works, since it's assumed the app was generated with the `--skip-test` flag.