### PR TITLE
Lint Generator: Introduce `.prettierignore`

### DIFF
--- a/lib/generators/suspenders/lint_generator.rb
+++ b/lib/generators/suspenders/lint_generator.rb
@@ -30,6 +30,7 @@ module Suspenders
 
       def configure_prettier
         copy_file "prettierrc", ".prettierrc"
+        copy_file "prettierignore", ".prettierignore"
       end
 
       def configure_erb_lint

--- a/lib/generators/templates/lint/prettierignore
+++ b/lib/generators/templates/lint/prettierignore
@@ -1,0 +1,1 @@
+vendor/bundle/**

--- a/test/generators/suspenders/lint_generator_test.rb
+++ b/test/generators/suspenders/lint_generator_test.rb
@@ -91,6 +91,14 @@ module Suspenders
         assert_file app_root(".prettierrc") do |file|
           assert_equal expected_content, file
         end
+
+        assert_file app_root(".prettierignore") do |file|
+          expected = <<~TEXT
+            vendor/bundle/**
+          TEXT
+
+          assert_equal expected, file
+        end
       end
 
       test "configures erb-lint" do


### PR DESCRIPTION
The upcoming `suspenders:ci` generator caches Ruby dependencies in `vendor/bundle`.

This commit ensures we ignore that path.