### PR TITLE
Introduce `suspenders:prerequisites` generator

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@ Unreleased
 * Introduce `suspenders:db:migrate` task
 * Introduce `suspenders:email` generator
 * Introduce `suspenders:testing` generator
+* Introduce `suspenders:prerequisites` generator
 
 20230113.0 (January, 13, 2023)
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,14 @@ Set up the project for an in-depth test-driven development workflow via
 
 [rspec-rails]: https://github.com/rspec/rspec-rails
 
+#### Prerequisites
+
+Configures prerequisites. Currently Node.
+
+```
+bin/rails g suspenders:prerequisites
+```
+
 ## Contributing
 
 See the [CONTRIBUTING] document.

--- a/lib/generators/suspenders/prerequisites_generator.rb
+++ b/lib/generators/suspenders/prerequisites_generator.rb
@@ -1,0 +1,13 @@
+module Suspenders
+  module Generators
+    class PrerequisitesGenerator < Rails::Generators::Base
+      source_root File.expand_path("../../templates/prerequisites", __FILE__)
+
+      desc "Configures prerequisites. Currently Node."
+
+      def node_version
+        template "node-version", ".node-version"
+      end
+    end
+  end
+end

--- a/lib/generators/templates/prerequisites/node-version.tt
+++ b/lib/generators/templates/prerequisites/node-version.tt
@@ -1,0 +1,1 @@
+<%= Suspenders::NODE_LTS_VERSION %>

--- a/lib/suspenders/version.rb
+++ b/lib/suspenders/version.rb
@@ -2,4 +2,5 @@ module Suspenders
   VERSION = "3.0.0".freeze
   RAILS_VERSION = "~> 7.0".freeze
   MINIMUM_RUBY_VERSION = ">= 3.1".freeze
+  NODE_LTS_VERSION = "20.11.1".freeze
 end

--- a/test/generators/suspenders/prerequisites_generator_test.rb
+++ b/test/generators/suspenders/prerequisites_generator_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+require "generators/suspenders/prerequisites_generator"
+
+module Suspenders
+  module Generators
+    class PrerequisitesGeneratorTest < Rails::Generators::TestCase
+      include Suspenders::TestHelpers
+
+      tests Suspenders::Generators::PrerequisitesGenerator
+      destination Rails.root
+      teardown :restore_destination
+
+      test "generates .node-version file" do
+        run_generator
+
+        assert_file app_root(".node-version") do |file|
+          assert_match(/20\.11\.1/, file)
+        end
+      end
+
+      test "has custom description" do
+        assert_no_match(/Description/, generator.class.desc)
+      end
+
+      private
+
+      def restore_destination
+        remove_file_if_exists ".node-version"
+      end
+    end
+  end
+end

--- a/test/suspenders_test.rb
+++ b/test/suspenders_test.rb
@@ -12,4 +12,8 @@ class SuspendersTest < ActiveSupport::TestCase
   test "it has a Minimum Ruby version number" do
     assert Suspenders::MINIMUM_RUBY_VERSION
   end
+
+  test "it has a Node LTS version number" do
+    assert Suspenders::NODE_LTS_VERSION
+  end
 end


### PR DESCRIPTION
Follow-up to #1148 and #1145

In #1148 and #1145, we introduce the need for yarn to manage dependencies. Those commits failed to establish a `.node-version` file, which [normally would be generated][1] by Rails if **not** using `import-maps`.

This commit introduces that file, which compliments the existing `.ruby-version` file that is generated.

I chose to use `.node-version` and not `.nvm` or `.tool-versions` to keep parity with Rails.

The [current version][2] set by Rails is `18.15.0`, but a [future commit][3] aims to use the latest LTS value. This commit aims to use that version.

This commit will also benefit a future `suspenders:ci` generator, since the `.node-version` file will be used in CI.

[1]: https://github.com/rails/rails/blob/68b20b6513fe56ca80e4966628c231b4d6113bea/railties/lib/rails/generators/rails/app/app_generator.rb#L57-L59
[2]: https://github.com/rails/rails/blob/e8638c9a942e94f097dc8f37a3b58ac067a5ca16/railties/lib/rails/generators/app_base.rb#L18
[3]: https://github.com/rails/rails/pull/51393