### PR TITLE
CI Generator: Fix indentation and linting violations.

### DIFF
--- a/lib/generators/templates/ci/ci.yml.tt
+++ b/lib/generators/templates/ci/ci.yml.tt
@@ -130,9 +130,9 @@ jobs:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
           # REDIS_URL: redis://localhost:6379/0
         <%- if using_rspec? -%>
-          run: bin/rails db:setup spec
+        run: bin/rails db:setup spec
         <%- else -%>
-          run: bin/rails db:setup test test:system
+        run: bin/rails db:setup test test:system
         <%- end -%>
 
       - name: Keep screenshots from failed system tests

--- a/lib/generators/templates/ci/dependabot.yml
+++ b/lib/generators/templates/ci/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
-- package-ecosystem: bundler
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
+  - package-ecosystem: bundler
+    directory: '/'
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Follow-up to #1172

Fixes indentation ensuring a valid syntax. Also fixes linting violations raised by `yarn lint`.