### PR TITLE
Lint Generator: No longer fix violations after invocation

### DIFF
--- a/lib/generators/suspenders/lint_generator.rb
+++ b/lib/generators/suspenders/lint_generator.rb
@@ -55,13 +55,6 @@ module Suspenders
         File.write package_json, JSON.pretty_generate(json)
       end
 
-      # This needs to be the last method definition to ensure everything is
-      # properly configured
-      def fix_violations
-        run "yarn run fix:prettier"
-        run "bundle exec rake standard:fix_unsafely"
-      end
-
       private
 
       def package_json

--- a/test/generators/suspenders/lint_generator_test.rb
+++ b/test/generators/suspenders/lint_generator_test.rb
@@ -248,15 +248,6 @@ module Suspenders
         assert_equal desc, generator_class.desc
       end
 
-      test "fixes violations" do
-        capture(:stderr) do
-          output = run_generator
-
-          assert_match(/yarn run fix:prettier/, output)
-          assert_match(/bundle exec rake standard:fix_unsafely/, output)
-        end
-      end
-
       private
 
       def prepare_destination


### PR DESCRIPTION
Supports #1152

We found that we needed to run this generator last in `suspenders:install:web` to ensure any potential violation was resolved.

Instead, we'll just make that the responsibility of `suspenders:install:web`.