### PR TITLE
Lint Generator: Handling missing `package.json`

### DIFF
--- a/lib/generators/suspenders/lint_generator.rb
+++ b/lib/generators/suspenders/lint_generator.rb
@@ -6,6 +6,12 @@ module Suspenders
       source_root File.expand_path("../../templates/lint", __FILE__)
       desc "Creates a holistic linting solution that covers JavaScript, CSS, Ruby and ERB."
 
+      def check_package_json
+        unless File.exist? Rails.root.join("package.json")
+          copy_file "package.json", "package.json"
+        end
+      end
+
       def install_dependencies
         run "yarn add stylelint eslint @thoughtbot/stylelint-config @thoughtbot/eslint-config npm-run-all prettier --dev"
       end

--- a/lib/generators/templates/lint/package.json
+++ b/lib/generators/templates/lint/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "app",
+  "private": "true"
+}

--- a/test/generators/suspenders/lint_generator_test.rb
+++ b/test/generators/suspenders/lint_generator_test.rb
@@ -248,6 +248,14 @@ module Suspenders
         assert_equal desc, generator_class.desc
       end
 
+      test "created package.json if one does not exist" do
+        remove_file_if_exists "package.json"
+
+        run_generator
+
+        assert_file app_root("package.json")
+      end
+
       private
 
       def prepare_destination


### PR DESCRIPTION
In order to avoid raising `No such file or directory`, we create a `package.json` file if one does not exist. We borrow a template from [cssbundling-rails][].

[cssbundling-rails]: https://github.com/rails/cssbundling-rails/blob/09d81cb0accf00abb77d8af5b24f5aad0b71a57a/lib/install/package.json#L3