### PR TITLE
Introduce `suspenders:test:environment` generator

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@ Unreleased
 * Introduce `suspenders:ci` generator
 * Introduce `suspenders:cleanup:organize_gemfile` task
 * Introduce `suspenders:production:environment` generator
+* Introduce `suspenders:test:environment` generator
 
 20230113.0 (January, 13, 2023)
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ bin/rails g suspenders:ci
 
 ### Environments
 
+<<<<<<< HEAD
 #### Production
 
 Configures the production environment.
@@ -211,6 +212,22 @@ Configures the production environment.
 bin/rails g suspenders:production:environment
 ```
 
+=======
+#### Test
+
+Configures test environment.
+
+```
+bin/rails g suspenders:test:environment
+```
+
+- Enables [raise_on_missing_translations][]
+- Disables [action_dispatch.show_exceptions][]
+
+[raise_on_missing_translations]: https://guides.rubyonrails.org/configuring.html#config-i18n-raise-on-missing-translations
+[action_dispatch.show_exceptions]: https://edgeguides.rubyonrails.org/configuring.html#config-action-dispatch-show-exceptions
+
+>>>>>>> 9102851 (Introduce `suspenders:test:environment` generator)
 ## Contributing
 
 See the [CONTRIBUTING] document.

--- a/lib/generators/suspenders/test/environment_generator.rb
+++ b/lib/generators/suspenders/test/environment_generator.rb
@@ -1,0 +1,45 @@
+module Suspenders
+  module Generators
+    module Test
+      class EnvironmentGenerator < Rails::Generators::Base
+        desc <<~MARKDOWN
+          Configures test environment.
+
+          ```
+          bin/rails g suspenders:test:environment
+          ```
+
+          - Enables [raise_on_missing_translations][]
+          - Disables [action_dispatch.show_exceptions][]
+
+          [raise_on_missing_translations]: https://guides.rubyonrails.org/configuring.html#config-i18n-raise-on-missing-translations
+          [action_dispatch.show_exceptions]: https://edgeguides.rubyonrails.org/configuring.html#config-action-dispatch-show-exceptions
+        MARKDOWN
+
+        def raise_on_missing_translations
+          if test_config.match?(/^\s*#\s*config\.i18n\.raise_on_missing_translations\s*=\s*true/)
+            uncomment_lines "config/environments/test.rb", /config\.i18n\.raise_on_missing_translations\s*=\s*true/
+          else
+            environment %(config.i18n.raise_on_missing_translations = true), env: "test"
+          end
+        end
+
+        def disable_action_dispatch_show_exceptions
+          if test_config.match?(/^\s*config\.action_dispatch\.show_exceptions\s*=\s*:rescuable/)
+            gsub_file "config/environments/test.rb", /^\s*config\.action_dispatch\.show_exceptions\s*=\s*:rescuable/,
+              "config.action_dispatch.show_exceptions = :none"
+            gsub_file "config/environments/test.rb", /^\s*#\s*Raise exceptions instead of rendering exception templates/i, ""
+          else
+            environment %(config.action_dispatch.show_exceptions = :none), env: "test"
+          end
+        end
+
+        private
+
+        def test_config
+          File.read(Rails.root.join("config/environments/test.rb"))
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures/files/environments/test.rb
+++ b/test/fixtures/files/environments/test.rb
@@ -1,0 +1,2 @@
+Rails.application.configure do
+end

--- a/test/generators/suspenders/test/environment_generator_test.rb
+++ b/test/generators/suspenders/test/environment_generator_test.rb
@@ -1,0 +1,69 @@
+require "test_helper"
+require "generators/suspenders/test/environment_generator"
+
+module Suspenders
+  module Generators
+    module Test
+      class EnvironmentGeneratorTest < Rails::Generators::TestCase
+        include Suspenders::TestHelpers
+
+        tests Suspenders::Generators::Test::EnvironmentGenerator
+        destination Rails.root
+        setup :prepare_destination
+        teardown :restore_destination
+
+        test "raise on missing translations" do
+          run_generator
+
+          assert_file app_root("config/environments/test.rb") do |file|
+            assert_match(/^\s*config\.i18n\.raise_on_missing_translations\s*=\s*true/, file)
+          end
+        end
+
+        test "raise on missing translations (when config is not commented out)" do
+          content = file_fixture("environments/test.rb").read
+          remove_file_if_exists "config/environments/test.rb"
+          touch "config/environments/test.rb", content: content
+
+          run_generator
+
+          assert_file app_root("config/environments/test.rb") do |file|
+            assert_match(/^\s*config\.i18n\.raise_on_missing_translations\s*=\s*true/, file)
+          end
+        end
+
+        test "disable action_dispatch.show_exceptions" do
+          run_generator
+
+          assert_file app_root("config/environments/test.rb") do |file|
+            assert_match(/^\s*config\.action_dispatch\.show_exceptions\s*=\s*:none/, file)
+            assert_no_match(/^\s*config\.action_dispatch\.show_exceptions\s*=\s*:rescuable/, file)
+            assert_no_match(/^\s*#\s*Raise exceptions instead of rendering exception templates/i, file)
+          end
+        end
+
+        test "disable action_dispatch.show_exceptions (when config does not exist)" do
+          content = file_fixture("environments/test.rb").read
+          remove_file_if_exists "config/environments/test.rb"
+          touch "config/environments/test.rb", content: content
+
+          run_generator
+
+          assert_file app_root("config/environments/test.rb") do |file|
+            assert_match(/^\s*config\.action_dispatch\.show_exceptions\s*=\s*:none/, file)
+          end
+        end
+
+        private
+
+        def prepare_destination
+          backup_file "config/environments/test.rb"
+        end
+
+        def restore_destination
+          restore_file "config/environments/test.rb"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Configures test environment. This differs from #1156 in that this commit is concerned with configuration, where that commit was concerned with generating a holistic test suite. It's also possible to run each generator independently, and the two should not rely on one another.

Disables [action_dispatch.show_exceptions][] in an effort to [improve failure output][comment].

Enables [raise_on_missing_translations][] to keep parity with the same setting in development #1149

[action_dispatch.show_exceptions]: https://edgeguides.rubyonrails.org/configuring.html#config-action-dispatch-show-exceptions
[comment]: https://github.com/thoughtbot/suspenders/pull/1149#discussion_r1424458925
[raise_on_missing_translations]: https://guides.rubyonrails.org/configuring.html#config-i18n-raise-on-missing-translations