### PR TITLE
Test Cleanup: Improve test setup

### DIFF
--- a/lib/generators/suspenders/testing_generator.rb
+++ b/lib/generators/suspenders/testing_generator.rb
@@ -43,7 +43,7 @@ module Suspenders
             allow_localhost: true,
             allow: [
               /(chromedriver|storage).googleapis.com/,
-              "googlechromelabs.github.io",
+              "googlechromelabs.github.io"
             ]
           )
         RUBY

--- a/test/fixtures/files/Rakefile
+++ b/test/fixtures/files/Rakefile
@@ -1,0 +1,5 @@
+require_relative "config/application"
+require "bundler/audit/task"
+Bundler::Audit::Task.new
+
+Rails.application.load_tasks

--- a/test/fixtures/files/_flashes.html.erb
+++ b/test/fixtures/files/_flashes.html.erb
@@ -1,0 +1,7 @@
+<% if flash.any? %>
+  <div class="flashes">
+    <% flash.each do |type, message| -%>
+      <div class="flash-<%= type %>"><%= message %></div>
+    <% end -%>
+  </div>
+<% end %>

--- a/test/fixtures/files/action_mailer.rb
+++ b/test/fixtures/files/action_mailer.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.before(:each) do
+    ActionMailer::Base.deliveries.clear
+  end
+end

--- a/test/fixtures/files/active_job.rb
+++ b/test/fixtures/files/active_job.rb
@@ -1,0 +1,14 @@
+require "active_job/logging"
+require "active_job/log_subscriber"
+
+ActiveSupport::Notifications.unsubscribe("enqueue.active_job")
+
+module ActiveJob
+  module Logging
+    class EnqueueLogSubscriber < LogSubscriber
+      define_method :enqueue, instance_method(:enqueue)
+    end
+  end
+end
+
+ActiveJob::Logging::EnqueueLogSubscriber.attach_to(:active_job)

--- a/test/fixtures/files/better_html.rb
+++ b/test/fixtures/files/better_html.rb
@@ -1,0 +1,9 @@
+Rails.configuration.to_prepare do
+  if Rails.env.test?
+    require "better_html"
+
+    BetterHtml.config = BetterHtml::Config.new(Rails.configuration.x.better_html)
+
+    BetterHtml.config.template_exclusion_filter = proc { |filename| !filename.start_with?(Rails.root.to_s) }
+  end
+end

--- a/test/fixtures/files/driver.rb
+++ b/test/fixtures/files/driver.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
+  end
+end

--- a/test/fixtures/files/email_interceptor.rb
+++ b/test/fixtures/files/email_interceptor.rb
@@ -1,0 +1,11 @@
+class EmailInterceptor
+  include ActiveSupport::Configurable
+
+  config_accessor :interceptor_addresses, default: []
+
+  def self.delivering_email(message)
+    to = interceptor_addresses
+
+    message.to = to if to.any?
+  end
+end

--- a/test/fixtures/files/email_interceptor_initializer.rb
+++ b/test/fixtures/files/email_interceptor_initializer.rb
@@ -1,0 +1,5 @@
+Rails.application.configure do
+  if ENV["INTERCEPTOR_ADDRESSES"].present?
+    config.action_mailer.interceptors = %w[EmailInterceptor]
+  end
+end

--- a/test/fixtures/files/erb-lint.yml
+++ b/test/fixtures/files/erb-lint.yml
@@ -1,0 +1,63 @@
+---
+glob: "app/views/**/*.{html,turbo_stream}{+*,}.erb"
+
+linters:
+  AllowedScriptType:
+    enabled: true
+    allowed_types:
+      - "module"
+      - "text/javascript"
+  ErbSafety:
+    enabled: true
+    better_html_config: "config/better_html.yml"
+  GitHub::Accessibility::AvoidBothDisabledAndAriaDisabledCounter:
+    enabled: true
+  GitHub::Accessibility::AvoidGenericLinkTextCounter:
+    enabled: true
+  GitHub::Accessibility::DisabledAttributeCounter:
+    enabled: true
+  GitHub::Accessibility::IframeHasTitleCounter:
+    enabled: true
+  GitHub::Accessibility::ImageHasAltCounter:
+    enabled: true
+  GitHub::Accessibility::LandmarkHasLabelCounter:
+    enabled: true
+  GitHub::Accessibility::LinkHasHrefCounter:
+    enabled: true
+  GitHub::Accessibility::NestedInteractiveElementsCounter:
+    enabled: true
+  GitHub::Accessibility::NoAriaLabelMisuseCounter:
+    enabled: true
+  GitHub::Accessibility::NoPositiveTabIndexCounter:
+    enabled: true
+  GitHub::Accessibility::NoRedundantImageAltCounter:
+    enabled: true
+  GitHub::Accessibility::NoTitleAttributeCounter:
+    enabled: true
+  GitHub::Accessibility::SvgHasAccessibleTextCounter:
+    enabled: true
+  Rubocop:
+    enabled: true
+    rubocop_config:
+      inherit_from:
+        - .rubocop.yml
+
+      Lint/EmptyBlock:
+        Enabled: false
+      Layout/InitialIndentation:
+        Enabled: false
+      Layout/TrailingEmptyLines:
+        Enabled: false
+      Layout/TrailingWhitespace:
+        Enabled: false
+      Layout/LeadingEmptyLines:
+        Enabled: false
+      Style/FrozenStringLiteralComment:
+        Enabled: false
+      Style/MultilineTernaryOperator:
+        Enabled: false
+      Lint/UselessAssignment:
+        Exclude:
+          - "app/views/**/*"
+
+EnableDefaultLinters: true

--- a/test/fixtures/files/eslintrc.json
+++ b/test/fixtures/files/eslintrc.json
@@ -1,0 +1,7 @@
+{
+  "extends": ["@thoughtbot/eslint-config/prettier"],
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  }
+}

--- a/test/fixtures/files/factories.rb
+++ b/test/fixtures/files/factories.rb
@@ -1,0 +1,2 @@
+FactoryBot.define do
+end

--- a/test/fixtures/files/factories_spec_lint.rb
+++ b/test/fixtures/files/factories_spec_lint.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+RSpec.describe "Factories" do
+  it "has valid factoties" do
+    FactoryBot.lint traits: true
+  end
+end

--- a/test/fixtures/files/factories_test_lint.rb
+++ b/test/fixtures/files/factories_test_lint.rb
@@ -1,0 +1,9 @@
+require "test_helper"
+
+class FactoryBotsTest < ActiveSupport::TestCase
+  class FactoryLintingTest < FactoryBotsTest
+    test "linting of factories" do
+      FactoryBot.lint traits: true
+    end
+  end
+end

--- a/test/fixtures/files/i18n.rb
+++ b/test/fixtures/files/i18n.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include ActionView::Helpers::TranslationHelper
+end

--- a/test/fixtures/files/inline_svg.rb
+++ b/test/fixtures/files/inline_svg.rb
@@ -1,0 +1,3 @@
+InlineSvg.configure do |config|
+  config.raise_on_file_not_found = true
+end

--- a/test/fixtures/files/prettierignore
+++ b/test/fixtures/files/prettierignore
@@ -1,0 +1,1 @@
+vendor/bundle/**

--- a/test/fixtures/files/prettierrc.json
+++ b/test/fixtures/files/prettierrc.json
@@ -1,0 +1,11 @@
+{
+  "singleQuote": true,
+  "overrides": [
+    {
+      "files": ["**/*.css", "**/*.scss", "**/*.html"],
+      "options": {
+        "singleQuote": false
+      }
+    }
+  ]
+}

--- a/test/fixtures/files/shoulda_matchers.rb
+++ b/test/fixtures/files/shoulda_matchers.rb
@@ -1,0 +1,6 @@
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end

--- a/test/fixtures/files/spec_helper.rb
+++ b/test/fixtures/files/spec_helper.rb
@@ -1,0 +1,23 @@
+require "webmock/rspec"
+
+RSpec.configure do |config|
+  config.example_status_persistence_file_path = "tmp/rspec_examples.txt"
+  config.order = :random
+
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+end
+
+WebMock.disable_net_connect!(
+  allow_localhost: true,
+  allow: [
+    /(chromedriver|storage).googleapis.com/,
+    "googlechromelabs.github.io"
+  ]
+)

--- a/test/fixtures/files/stylelintrc.json
+++ b/test/fixtures/files/stylelintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@thoughtbot/stylelint-config"
+}

--- a/test/fixtures/files/test_helper.rb
+++ b/test/fixtures/files/test_helper.rb
@@ -1,0 +1,15 @@
+ENV["RAILS_ENV"] ||= "test"
+require_relative "../config/environment"
+require "rails/test_help"
+
+module ActiveSupport
+  class TestCase
+    # Run tests in parallel with specified workers
+    parallelize(workers: :number_of_processors)
+
+    # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
+    fixtures :all
+
+    # Add more helper methods to be used by all tests here...
+  end
+end

--- a/test/generators/suspenders/advisories_generator_test.rb
+++ b/test/generators/suspenders/advisories_generator_test.rb
@@ -43,20 +43,12 @@ module Suspenders
       end
 
       test "modifies Rakefile" do
-        touch "Rakefile"
-        content = <<~TEXT
+        touch "Rakefile", content: <<~TEXT
           require_relative "config/application"
 
           Rails.application.load_tasks
         TEXT
-        File.open(app_root("Rakefile"), "w") { _1.write content }
-        expected_rakefile = <<~TEXT
-          require_relative "config/application"
-          require "bundler/audit/task"
-          Bundler::Audit::Task.new
-
-          Rails.application.load_tasks
-        TEXT
+        expected_rakefile = file_fixture("Rakefile").read
 
         run_generator
 

--- a/test/generators/suspenders/email_generator_test.rb
+++ b/test/generators/suspenders/email_generator_test.rb
@@ -12,19 +12,7 @@ module Suspenders
       teardown :restore_destination
 
       test "creates a mailer intercepter" do
-        expected = <<~RUBY
-          class EmailInterceptor
-            include ActiveSupport::Configurable
-
-            config_accessor :interceptor_addresses, default: []
-
-            def self.delivering_email(message)
-              to = interceptor_addresses
-
-              message.to = to if to.any?
-            end
-          end
-        RUBY
+        expected = file_fixture("email_interceptor.rb").read
 
         run_generator
 
@@ -34,13 +22,7 @@ module Suspenders
       end
 
       test "creates initializer" do
-        expected = <<~RUBY
-          Rails.application.configure do
-            if ENV["INTERCEPTOR_ADDRESSES"].present?
-              config.action_mailer.interceptors = %w[EmailInterceptor]
-            end
-          end
-        RUBY
+        expected = file_fixture("email_interceptor_initializer.rb").read
 
         run_generator
 

--- a/test/generators/suspenders/factories_generator_test.rb
+++ b/test/generators/suspenders/factories_generator_test.rb
@@ -40,7 +40,7 @@ module Suspenders
       end
 
       test "removes fixture definitions" do
-        File.open(app_root("test/test_helper.rb"), "w") { _1.write test_helper }
+        touch "test/test_helper.rb", content: test_helper
 
         run_generator
 
@@ -58,7 +58,7 @@ module Suspenders
       end
 
       test "includes syntax methods" do
-        File.open(app_root("test/test_helper.rb"), "w") { _1.write test_helper }
+        touch "test/test_helper.rb", content: test_helper
 
         run_generator
 
@@ -68,10 +68,7 @@ module Suspenders
       end
 
       test "creates definition file" do
-        definition_file = <<~RUBY
-          FactoryBot.define do
-          end
-        RUBY
+        definition_file = file_fixture("factories.rb").read
 
         run_generator
 
@@ -81,17 +78,7 @@ module Suspenders
       end
 
       test "creates linting test" do
-        factories_test = <<~RUBY
-          require "test_helper"
-
-          class FactoryBotsTest < ActiveSupport::TestCase
-            class FactoryLintingTest < FactoryBotsTest
-              test "linting of factories" do
-                FactoryBot.lint traits: true
-              end
-            end
-          end
-        RUBY
+        factories_test = file_fixture("factories_test_lint.rb").read
 
         run_generator
 
@@ -114,23 +101,7 @@ module Suspenders
       end
 
       def test_helper
-        <<~RUBY
-          ENV["RAILS_ENV"] ||= "test"
-          require_relative "../config/environment"
-          require "rails/test_help"
-
-          module ActiveSupport
-            class TestCase
-              # Run tests in parallel with specified workers
-              parallelize(workers: :number_of_processors)
-
-              # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
-              fixtures :all
-
-              # Add more helper methods to be used by all tests here...
-            end
-          end
-        RUBY
+        file_fixture("test_helper.rb").read
       end
     end
 
@@ -163,10 +134,7 @@ module Suspenders
       end
 
       test "creates definition file" do
-        definition_file = <<~RUBY
-          FactoryBot.define do
-          end
-        RUBY
+        definition_file = file_fixture("factories.rb").read
 
         run_generator
 
@@ -176,11 +144,10 @@ module Suspenders
       end
 
       test "does not modify rails_helper if it's configured to include support files" do
-        touch("spec/rails_helper.rb")
         rails_helper = <<~RUBY
           Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |file| require file }
         RUBY
-        File.open(app_root("spec/rails_helper.rb"), "w") { _1.write rails_helper }
+        touch "spec/rails_helper.rb", content: rails_helper
 
         run_generator
 
@@ -190,15 +157,7 @@ module Suspenders
       end
 
       test "creates linting test" do
-        factories_spec = <<~RUBY
-          require "rails_helper"
-
-          RSpec.describe "Factories" do
-            it "has valid factoties" do
-              FactoryBot.lint traits: true
-            end
-          end
-        RUBY
+        factories_spec = file_fixture("factories_spec_lint.rb").read
 
         run_generator
 

--- a/test/generators/suspenders/inline_svg_generator_test.rb
+++ b/test/generators/suspenders/inline_svg_generator_test.rb
@@ -61,11 +61,7 @@ module Suspenders
       end
 
       test "configures raising an error when an SVG file is not found" do
-        expected_configuration = <<~RUBY
-          InlineSvg.configure do |config|
-            config.raise_on_file_not_found = true
-          end
-        RUBY
+        expected_configuration = file_fixture("inline_svg.rb").read
 
         run_generator
 

--- a/test/generators/suspenders/jobs_generator_test.rb
+++ b/test/generators/suspenders/jobs_generator_test.rb
@@ -36,22 +36,7 @@ module Suspenders
       end
 
       test "configures ActiveJob logging" do
-        expected_configuration = <<~RUBY
-          require "active_job/logging"
-          require "active_job/log_subscriber"
-
-          ActiveSupport::Notifications.unsubscribe("enqueue.active_job")
-
-          module ActiveJob
-            module Logging
-              class EnqueueLogSubscriber < LogSubscriber
-                define_method :enqueue, instance_method(:enqueue)
-              end
-            end
-          end
-
-          ActiveJob::Logging::EnqueueLogSubscriber.attach_to(:active_job)
-        RUBY
+        expected_configuration = file_fixture("active_job.rb").read
 
         run_generator
 
@@ -90,10 +75,7 @@ module Suspenders
       end
 
       test "adds Sidekiq configuration if procfile exists" do
-        proc_file = <<~TEXT
-        TEXT
-
-        File.write(app_root("Procfile.dev"), proc_file)
+        touch "Procfile.dev"
 
         run_generator
 

--- a/test/generators/suspenders/lint_generator_test.rb
+++ b/test/generators/suspenders/lint_generator_test.rb
@@ -40,11 +40,7 @@ module Suspenders
       end
 
       test "configures stylelint" do
-        expected_content = <<~TEXT
-          {
-            "extends": "@thoughtbot/stylelint-config"
-          }
-        TEXT
+        expected_content = file_fixture("stylelintrc.json").read
 
         capture(:stderr) { run_generator }
 
@@ -54,15 +50,7 @@ module Suspenders
       end
 
       test "configures eslint" do
-        expected_content = <<~JSON
-          {
-            "extends": ["@thoughtbot/eslint-config/prettier"],
-            "parserOptions": {
-              "ecmaVersion": "latest",
-              "sourceType": "module"
-            }
-          }
-        JSON
+        expected_content = file_fixture("eslintrc.json").read
 
         capture(:stderr) { run_generator }
 
@@ -72,32 +60,17 @@ module Suspenders
       end
 
       test "configures prettier" do
-        expected_content = <<~JSON
-          {
-            "singleQuote": true,
-            "overrides": [
-              {
-                "files": ["**/*.css", "**/*.scss", "**/*.html"],
-                "options": {
-                  "singleQuote": false
-                }
-              }
-            ]
-          }
-        JSON
+        prettierrc = file_fixture("prettierrc.json").read
+        prettierignore = file_fixture("prettierignore").read
 
         capture(:stderr) { run_generator }
 
         assert_file app_root(".prettierrc") do |file|
-          assert_equal expected_content, file
+          assert_equal prettierrc, file
         end
 
         assert_file app_root(".prettierignore") do |file|
-          expected = <<~TEXT
-            vendor/bundle/**
-          TEXT
-
-          assert_equal expected, file
+          assert_equal prettierignore, file
         end
       end
 
@@ -111,71 +84,7 @@ module Suspenders
       end
 
       test "erb-lint.yml configuration" do
-        expected_content = <<~YAML
-          ---
-          glob: "app/views/**/*.{html,turbo_stream}{+*,}.erb"
-
-          linters:
-            AllowedScriptType:
-              enabled: true
-              allowed_types:
-                - "module"
-                - "text/javascript"
-            ErbSafety:
-              enabled: true
-              better_html_config: "config/better_html.yml"
-            GitHub::Accessibility::AvoidBothDisabledAndAriaDisabledCounter:
-              enabled: true
-            GitHub::Accessibility::AvoidGenericLinkTextCounter:
-              enabled: true
-            GitHub::Accessibility::DisabledAttributeCounter:
-              enabled: true
-            GitHub::Accessibility::IframeHasTitleCounter:
-              enabled: true
-            GitHub::Accessibility::ImageHasAltCounter:
-              enabled: true
-            GitHub::Accessibility::LandmarkHasLabelCounter:
-              enabled: true
-            GitHub::Accessibility::LinkHasHrefCounter:
-              enabled: true
-            GitHub::Accessibility::NestedInteractiveElementsCounter:
-              enabled: true
-            GitHub::Accessibility::NoAriaLabelMisuseCounter:
-              enabled: true
-            GitHub::Accessibility::NoPositiveTabIndexCounter:
-              enabled: true
-            GitHub::Accessibility::NoRedundantImageAltCounter:
-              enabled: true
-            GitHub::Accessibility::NoTitleAttributeCounter:
-              enabled: true
-            GitHub::Accessibility::SvgHasAccessibleTextCounter:
-              enabled: true
-            Rubocop:
-              enabled: true
-              rubocop_config:
-                inherit_from:
-                  - .rubocop.yml
-
-                Lint/EmptyBlock:
-                  Enabled: false
-                Layout/InitialIndentation:
-                  Enabled: false
-                Layout/TrailingEmptyLines:
-                  Enabled: false
-                Layout/TrailingWhitespace:
-                  Enabled: false
-                Layout/LeadingEmptyLines:
-                  Enabled: false
-                Style/FrozenStringLiteralComment:
-                  Enabled: false
-                Style/MultilineTernaryOperator:
-                  Enabled: false
-                Lint/UselessAssignment:
-                  Exclude:
-                    - "app/views/**/*"
-
-          EnableDefaultLinters: true
-        YAML
+        expected_content = file_fixture("erb-lint.yml").read
 
         capture(:stderr) { run_generator }
 
@@ -185,17 +94,7 @@ module Suspenders
       end
 
       test "better html configuration" do
-        expected_content = <<~RUBY
-          Rails.configuration.to_prepare do
-            if Rails.env.test?
-              require "better_html"
-
-              BetterHtml.config = BetterHtml::Config.new(Rails.configuration.x.better_html)
-
-              BetterHtml.config.template_exclusion_filter = proc { |filename| !filename.start_with?(Rails.root.to_s) }
-            end
-          end
-        RUBY
+        expected_content = file_fixture("better_html.rb").read
 
         capture(:stderr) { run_generator }
 

--- a/test/generators/suspenders/testing_generator_test.rb
+++ b/test/generators/suspenders/testing_generator_test.rb
@@ -59,31 +59,7 @@ module Suspenders
 
       test "configures spec_helper" do
         touch "spec/spec_helper.rb", content: spec_helper
-        expected = <<~RUBY
-          require "webmock/rspec"
-
-          RSpec.configure do |config|
-            config.example_status_persistence_file_path = "tmp/rspec_examples.txt"
-            config.order = :random
-
-            config.expect_with :rspec do |expectations|
-              expectations.include_chain_clauses_in_custom_matcher_descriptions = true
-            end
-
-            config.mock_with :rspec do |mocks|
-              mocks.verify_partial_doubles = true
-            end
-            config.shared_context_metadata_behavior = :apply_to_host_groups
-          end
-
-          WebMock.disable_net_connect!(
-            allow_localhost: true,
-            allow: [
-              /(chromedriver|storage).googleapis.com/,
-              "googlechromelabs.github.io",
-            ]
-          )
-        RUBY
+        expected = file_fixture("spec_helper.rb").read
 
         run_generator
 
@@ -93,13 +69,7 @@ module Suspenders
       end
 
       test "configures driver" do
-        expected = <<~RUBY
-          RSpec.configure do |config|
-            config.before(:each, type: :system) do
-              driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
-            end
-          end
-        RUBY
+        expected = file_fixture("driver.rb").read
 
         run_generator
 
@@ -115,14 +85,7 @@ module Suspenders
       end
 
       test "configures Should Matchers" do
-        expected = <<~RUBY
-          Shoulda::Matchers.configure do |config|
-            config.integrate do |with|
-              with.test_framework :rspec
-              with.library :rails
-            end
-          end
-        RUBY
+        expected = file_fixture("shoulda_matchers.rb").read
 
         run_generator
 
@@ -132,11 +95,7 @@ module Suspenders
       end
 
       test "configures i18n" do
-        expected = <<~RUBY
-          RSpec.configure do |config|
-            config.include ActionView::Helpers::TranslationHelper
-          end
-        RUBY
+        expected = file_fixture("i18n.rb").read
 
         run_generator
 
@@ -146,13 +105,7 @@ module Suspenders
       end
 
       test "configures Action Mailer" do
-        expected = <<~RUBY
-          RSpec.configure do |config|
-            config.before(:each) do
-              ActionMailer::Base.deliveries.clear
-            end
-          end
-        RUBY
+        expected = file_fixture("action_mailer.rb").read
 
         run_generator
 

--- a/test/generators/suspenders/views_generator_test.rb
+++ b/test/generators/suspenders/views_generator_test.rb
@@ -24,15 +24,7 @@ module Suspenders
       end
 
       test "creates flash partial" do
-        expected = <<~ERB
-          <% if flash.any? %>
-            <div class="flashes">
-              <% flash.each do |type, message| -%>
-                <div class="flash-<%= type %>"><%= message %></div>
-              <% end -%>
-            </div>
-          <% end %>
-        ERB
+        expected = file_fixture("_flashes.html.erb").read
 
         run_generator
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -38,7 +38,6 @@ module Suspenders::TestHelpers
     FileUtils.mkdir path
   end
 
-  # TODO: Update existing tests to use the content: option
   def touch(file, **options)
     content = options[:content]
     path = app_root file


### PR DESCRIPTION
Use `touch` test helper instead of directly working with the `File` class during the setup phase.

Also create [file_fixtures][] to simplify test setup.

Because the newly added file fixtures are processed with standard, I needed to adjust the testing generator to account for a minor violation.

[file_fixtures]: https://api.rubyonrails.org/classes/ActiveSupport/Testing/FileFixtures.html#method-i-file_fixture