### PR TITLE
Clean Up: Use `Environments` namespace

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,9 +18,9 @@ Unreleased
 * Introduce `suspenders:prerequisites` generator
 * Introduce `suspenders:ci` generator
 * Introduce `suspenders:cleanup:organize_gemfile` task
-* Introduce `suspenders:production:environment` generator
-* Introduce `suspenders:test:environment` generator
-* Introduce `suspenders:development:environment` generator
+* Introduce `suspenders:environments:production` generator
+* Introduce `suspenders:environments:test` generator
+* Introduce `suspenders:environments:development` generator
 
 20230113.0 (January, 13, 2023)
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,11 @@ bin/rails g suspenders:ci
 
 Configures the production environment.
 
- - Enables [require_master_key][]
+```
+bin/rails g suspenders:evironments:production
+```
+
+- Enables [require_master_key][]
 
 [require_master_key]: https://guides.rubyonrails.org/configuring.html#config-require-master-key
 
@@ -213,7 +217,7 @@ Configures the production environment.
 Configures test environment.
 
 ```
-bin/rails g suspenders:test:environment
+bin/rails g suspenders:environments:test
 ```
 
 - Enables [raise_on_missing_translations][]
@@ -227,7 +231,7 @@ bin/rails g suspenders:test:environment
 Configures the development environment.
 
 ```
-bin/rails g suspenders:development:evironment
+bin/rails g suspenders:evironments:development
 ```
 
 - Enables [raise_on_missing_translations][]

--- a/lib/generators/suspenders/environments/development_generator.rb
+++ b/lib/generators/suspenders/environments/development_generator.rb
@@ -1,7 +1,7 @@
 module Suspenders
   module Generators
-    module Development
-      class EnvironmentGenerator < Rails::Generators::Base
+    module Environments
+      class DevelopmentGenerator < Rails::Generators::Base
         desc <<~MARKDOWN
           Configures the development environment.
 

--- a/lib/generators/suspenders/environments/production_generator.rb
+++ b/lib/generators/suspenders/environments/production_generator.rb
@@ -1,7 +1,7 @@
 module Suspenders
   module Generators
-    module Production
-      class EnvironmentGenerator < Rails::Generators::Base
+    module Environments
+      class ProductionGenerator < Rails::Generators::Base
         desc <<~MARKDOWN
           Configures the production environment.
 

--- a/lib/generators/suspenders/environments/test_generator.rb
+++ b/lib/generators/suspenders/environments/test_generator.rb
@@ -1,7 +1,7 @@
 module Suspenders
   module Generators
-    module Test
-      class EnvironmentGenerator < Rails::Generators::Base
+    module Environments
+      class TestGenerator < Rails::Generators::Base
         desc <<~MARKDOWN
           Configures test environment.
 

--- a/test/generators/suspenders/environments/development_generator_test.rb
+++ b/test/generators/suspenders/environments/development_generator_test.rb
@@ -1,13 +1,13 @@
 require "test_helper"
-require "generators/suspenders/development/environment_generator"
+require "generators/suspenders/environments/development_generator"
 
 module Suspenders
   module Generators
-    module Development
-      class EnvironmentGenerator::DefaultTest < Rails::Generators::TestCase
+    module Environments
+      class DevelopmentGenerator::DefaultTest < Rails::Generators::TestCase
         include Suspenders::TestHelpers
 
-        tests Suspenders::Generators::Development::EnvironmentGenerator
+        tests Suspenders::Generators::Environments::DevelopmentGenerator
         destination Rails.root
         setup :prepare_destination
         teardown :restore_destination

--- a/test/generators/suspenders/environments/production_generator_test.rb
+++ b/test/generators/suspenders/environments/production_generator_test.rb
@@ -1,13 +1,13 @@
 require "test_helper"
-require "generators/suspenders/production/environment_generator"
+require "generators/suspenders/environments/production_generator"
 
 module Suspenders
   module Generators
-    module Production
-      class EnvironmentGeneratorTest < Rails::Generators::TestCase
+    module Environments
+      class ProductionGeneratorTest < Rails::Generators::TestCase
         include Suspenders::TestHelpers
 
-        tests Suspenders::Generators::Production::EnvironmentGenerator
+        tests Suspenders::Generators::Environments::ProductionGenerator
         destination Rails.root
         setup :prepare_destination
         teardown :restore_destination

--- a/test/generators/suspenders/environments/test_generator_test.rb
+++ b/test/generators/suspenders/environments/test_generator_test.rb
@@ -1,13 +1,13 @@
 require "test_helper"
-require "generators/suspenders/test/environment_generator"
+require "generators/suspenders/environments/test_generator"
 
 module Suspenders
   module Generators
-    module Test
-      class EnvironmentGeneratorTest < Rails::Generators::TestCase
+    module Environments
+      class TestGeneratorTest < Rails::Generators::TestCase
         include Suspenders::TestHelpers
 
-        tests Suspenders::Generators::Test::EnvironmentGenerator
+        tests Suspenders::Generators::Environments::TestGenerator
         destination Rails.root
         setup :prepare_destination
         teardown :restore_destination


### PR DESCRIPTION
Follow-up to #1151, #1182, and #1149

Using the `Environments` namespace feels more appropriate, since this keeps parity with Rails' directory structure.