### PR TITLE
AccessibilityGenerator: Update gem declaration

### DIFF
--- a/lib/generators/suspenders/accessibility_generator.rb
+++ b/lib/generators/suspenders/accessibility_generator.rb
@@ -7,7 +7,7 @@ module Suspenders
 
       def add_capybara_gems
         gem_group :test do
-          gem "capybara_accessibility_audit"
+          gem "capybara_accessibility_audit", github: "thoughtbot/capybara_accessibility_audit"
           gem "capybara_accessible_selectors", github: "citizensadvice/capybara_accessible_selectors"
         end
         Bundler.with_unbundled_env { run "bundle install" }

--- a/test/generators/suspenders/accessibility_generator_test.rb
+++ b/test/generators/suspenders/accessibility_generator_test.rb
@@ -38,7 +38,7 @@ module Suspenders
       test "adds gems to Gemfile" do
         expected_output = <<~RUBY
           group :test do
-            gem "capybara_accessibility_audit"
+            gem "capybara_accessibility_audit", github: "thoughtbot/capybara_accessibility_audit"
             gem "capybara_accessible_selectors", github: "citizensadvice/capybara_accessible_selectors"
           end
         RUBY


### PR DESCRIPTION
In order to avoid the following failure in CI, we need to load the latest build (not release) of capybara_accessibility_audit.

```
NoMethodError: undefined method `configure' for module RSpec (NoMethodError)

      RSpec.configure do |config|
```

For reference, [this commit][] fixes the issue.

[this commit]: https://github.com/thoughtbot/capybara_accessibility_audit/commit/0ee6922ef19a391fb617778ef730af30b2680759