### PR TITLE
Rakefile: Conditionally require local dependencies

### DIFF
--- a/lib/generators/suspenders/advisories_generator.rb
+++ b/lib/generators/suspenders/advisories_generator.rb
@@ -17,10 +17,15 @@ module Suspenders
       end
 
       def modify_rakefile
-        insert_into_file "Rakefile", "\nrequire \"bundler/audit/task\"",
-          after: 'require_relative "config/application"'
-        insert_into_file "Rakefile", "\nBundler::Audit::Task.new",
-          after: 'require "bundler/audit/task"'
+        content = <<~RUBY
+
+          if Rails.env.local?
+            require "bundler/audit/task"
+            Bundler::Audit::Task.new
+          end
+        RUBY
+
+        insert_into_file "Rakefile", content, after: /require_relative "config\/application"\n/
       end
     end
   end

--- a/lib/generators/suspenders/rake_generator.rb
+++ b/lib/generators/suspenders/rake_generator.rb
@@ -8,7 +8,12 @@ module Suspenders
       TEXT
 
       def configure_default_rake_task
-        append_to_file "Rakefile", %(task default: "suspenders:rake")
+        append_to_file "Rakefile", <<~RUBY
+
+          if Rails.env.local?
+            task default: "suspenders:rake"
+          end
+        RUBY
       end
     end
   end

--- a/test/fixtures/files/Rakefile
+++ b/test/fixtures/files/Rakefile
@@ -1,5 +1,10 @@
+# Add your own tasks in files placed in lib/tasks ending in .rake,
+# for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
+
 require_relative "config/application"
-require "bundler/audit/task"
-Bundler::Audit::Task.new
 
 Rails.application.load_tasks
+
+if Rails.env.local?
+  task default: "suspenders:rake"
+end

--- a/test/fixtures/files/Rakefile_advisories
+++ b/test/fixtures/files/Rakefile_advisories
@@ -1,0 +1,8 @@
+require_relative "config/application"
+
+if Rails.env.local?
+  require "bundler/audit/task"
+  Bundler::Audit::Task.new
+end
+
+Rails.application.load_tasks

--- a/test/generators/suspenders/advisories_generator_test.rb
+++ b/test/generators/suspenders/advisories_generator_test.rb
@@ -48,7 +48,7 @@ module Suspenders
 
           Rails.application.load_tasks
         TEXT
-        expected_rakefile = file_fixture("Rakefile").read
+        expected_rakefile = file_fixture("Rakefile_advisories").read
 
         run_generator
 

--- a/test/generators/suspenders/rake_generator_test.rb
+++ b/test/generators/suspenders/rake_generator_test.rb
@@ -12,10 +12,12 @@ module Suspenders
       teardown :restore_destination
 
       test "modifies existing Rakefile" do
+        content = file_fixture("Rakefile").read
+
         run_generator
 
         assert_file app_root("Rakefile") do |file|
-          assert_match(/task default: "suspenders:rake"/, file)
+          assert_equal content, file
         end
       end
 


### PR DESCRIPTION
Prior to this commit, the Rakefile required `bundler-audit` and `standard` in all environments. This prevented Rake from running in production, because those dependencies are only loaded in `:development` and `:test`.