### PR TITLE
Test Cleanup: Refactor tests to use helper

### DIFF
--- a/test/fixtures/files/rails_helper.rb
+++ b/test/fixtures/files/rails_helper.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+ENV['RAILS_ENV'] ||= 'test'
+require_relative '../config/environment'
+
+abort("The Rails environment is running in production mode!") if Rails.env.production?
+require 'rspec/rails'
+
+# Rails.root.glob("spec/support/**/*.rb").sort.each { |f| require f }
+
+begin
+  ActiveRecord::Migration.maintain_test_schema!
+rescue ActiveRecord::PendingMigrationError => e
+  abort e.to_s.strip
+end
+RSpec.configure do |config|
+  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  config.use_transactional_fixtures = true
+  config.infer_spec_type_from_file_location!
+  config.filter_rails_from_backtrace!
+end
+Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |file| require file }

--- a/test/fixtures/files/rails_helper.rb
+++ b/test/fixtures/files/rails_helper.rb
@@ -1,9 +1,9 @@
-require 'spec_helper'
-ENV['RAILS_ENV'] ||= 'test'
-require_relative '../config/environment'
+require "spec_helper"
+ENV["RAILS_ENV"] ||= "test"
+require_relative "../config/environment"
 
 abort("The Rails environment is running in production mode!") if Rails.env.production?
-require 'rspec/rails'
+require "rspec/rails"
 
 # Rails.root.glob("spec/support/**/*.rb").sort.each { |f| require f }
 

--- a/test/generators/suspenders/factories_generator_test.rb
+++ b/test/generators/suspenders/factories_generator_test.rb
@@ -31,71 +31,77 @@ module Suspenders
       end
 
       test "installs gem with Bundler" do
-        Bundler.stubs(:with_unbundled_env).yields
-        generator.expects(:run).with("bundle install").once
+        with_test_suite :minitest do
+          Bundler.stubs(:with_unbundled_env).yields
+          generator.expects(:run).with("bundle install").once
 
-        capture(:stdout) do
-          generator.add_factory_bot
+          capture(:stdout) do
+            generator.add_factory_bot
+          end
         end
       end
 
       test "removes fixture definitions" do
-        touch "test/test_helper.rb", content: test_helper
+        with_test_suite :minitest do
+          run_generator
 
-        run_generator
-
-        assert_file app_root("test/test_helper.rb") do |file|
-          assert_match(/# fixtures :all/, file)
+          assert_file app_root("test/test_helper.rb") do |file|
+            assert_match(/# fixtures :all/, file)
+          end
         end
       end
 
       test "adds gem to Gemfile" do
-        run_generator
+        with_test_suite :minitest do
+          run_generator
 
-        assert_file app_root("Gemfile") do |file|
-          assert_match(/group :development, :test do\n  gem "factory_bot_rails"\nend/, file)
+          assert_file app_root("Gemfile") do |file|
+            assert_match(/group :development, :test do\n  gem "factory_bot_rails"\nend/, file)
+          end
         end
       end
 
       test "includes syntax methods" do
-        touch "test/test_helper.rb", content: test_helper
+        with_test_suite :minitest do
+          run_generator
 
-        run_generator
-
-        assert_file app_root("test/test_helper.rb") do |file|
-          assert_match(/class TestCase\n    include FactoryBot::Syntax::Methods/, file)
+          assert_file app_root("test/test_helper.rb") do |file|
+            assert_match(/class TestCase\n    include FactoryBot::Syntax::Methods/, file)
+          end
         end
       end
 
       test "creates definition file" do
-        definition_file = file_fixture("factories.rb").read
+        with_test_suite :minitest do
+          definition_file = file_fixture("factories.rb").read
 
-        run_generator
+          run_generator
 
-        assert_file app_root("test/factories.rb") do |file|
-          assert_match definition_file, file
+          assert_file app_root("test/factories.rb") do |file|
+            assert_match definition_file, file
+          end
         end
       end
 
       test "creates linting test" do
-        factories_test = file_fixture("factories_test_lint.rb").read
+        with_test_suite :minitest do
+          factories_test = file_fixture("factories_test_lint.rb").read
 
-        run_generator
+          run_generator
 
-        assert_file app_root("test/factory_bots/factories_test.rb") do |file|
-          assert_match factories_test, file
+          assert_file app_root("test/factory_bots/factories_test.rb") do |file|
+            assert_match factories_test, file
+          end
         end
       end
 
       private
 
       def prepare_destination
-        mkdir "test"
         touch "Gemfile"
       end
 
       def restore_destination
-        remove_dir_if_exists "test"
         remove_file_if_exists "Gemfile"
         remove_dir_if_exists "lib/tasks"
       end
@@ -114,68 +120,73 @@ module Suspenders
       teardown :restore_destination
 
       test "includes syntax methods" do
-        touch("spec/rails_helper.rb")
-        factory_bot_config = <<~RUBY
-          FactoryBot.use_parent_strategy = true
+        with_test_suite :rspec do
+          touch("spec/rails_helper.rb")
+          factory_bot_config = <<~RUBY
+            FactoryBot.use_parent_strategy = true
 
-          RSpec.configure do |config|
-            config.include FactoryBot::Syntax::Methods
+            RSpec.configure do |config|
+              config.include FactoryBot::Syntax::Methods
+            end
+          RUBY
+
+          run_generator
+
+          assert_file app_root("spec/support/factory_bot.rb") do |file|
+            assert_match factory_bot_config, file
           end
-        RUBY
-
-        run_generator
-
-        assert_file app_root("spec/support/factory_bot.rb") do |file|
-          assert_match factory_bot_config, file
-        end
-        assert_file app_root("spec/rails_helper.rb") do |file|
-          assert_match(/Dir\[Rails\.root\.join\("spec\/support\/\*\*\/\*\.rb"\)\]\.sort\.each { \|file\| require file }/, file)
+          assert_file app_root("spec/rails_helper.rb") do |file|
+            assert_match(/Dir\[Rails\.root\.join\("spec\/support\/\*\*\/\*\.rb"\)\]\.sort\.each { \|file\| require file }/, file)
+          end
         end
       end
 
       test "creates definition file" do
-        definition_file = file_fixture("factories.rb").read
+        with_test_suite :rspec do
+          definition_file = file_fixture("factories.rb").read
 
-        run_generator
+          run_generator
 
-        assert_file app_root("spec/factories.rb") do |file|
-          assert_match definition_file, file
+          assert_file app_root("spec/factories.rb") do |file|
+            assert_match definition_file, file
+          end
         end
       end
 
       test "does not modify rails_helper if it's configured to include support files" do
-        rails_helper = <<~RUBY
-          Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |file| require file }
-        RUBY
-        touch "spec/rails_helper.rb", content: rails_helper
+        with_test_suite :rspec do
+          rails_helper = <<~RUBY
+            Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |file| require file }
+          RUBY
+          touch "spec/rails_helper.rb", content: rails_helper
 
-        run_generator
+          run_generator
 
-        assert_file app_root("spec/rails_helper.rb") do |file|
-          assert_equal rails_helper, file
+          assert_file app_root("spec/rails_helper.rb") do |file|
+            assert_equal rails_helper, file
+          end
         end
       end
 
       test "creates linting test" do
-        factories_spec = file_fixture("factories_spec_lint.rb").read
+        with_test_suite :rspec do
+          factories_spec = file_fixture("factories_spec_lint.rb").read
 
-        run_generator
+          run_generator
 
-        assert_file app_root("spec/factory_bots/factories_spec.rb") do |file|
-          assert_match factories_spec, file
+          assert_file app_root("spec/factory_bots/factories_spec.rb") do |file|
+            assert_match factories_spec, file
+          end
         end
       end
 
       private
 
       def prepare_destination
-        mkdir "spec"
-        touch "spec/spec_helper.rb"
         touch "Gemfile"
       end
 
       def restore_destination
-        remove_dir_if_exists "spec"
         remove_file_if_exists "Gemfile"
         remove_dir_if_exists "lib/tasks"
       end

--- a/test/generators/suspenders/testing_generator_test.rb
+++ b/test/generators/suspenders/testing_generator_test.rb
@@ -133,48 +133,11 @@ module Suspenders
       end
 
       def rails_helper
-        # Generated from rails g rspec:install
-        # Comments removed
-        <<~RUBY
-          require 'spec_helper'
-          ENV['RAILS_ENV'] ||= 'test'
-          require_relative '../config/environment'
-
-          abort("The Rails environment is running in production mode!") if Rails.env.production?
-          require 'rspec/rails'
-
-          # Rails.root.glob("spec/support/**/*.rb").sort.each { |f| require f }
-
-          begin
-            ActiveRecord::Migration.maintain_test_schema!
-          rescue ActiveRecord::PendingMigrationError => e
-            abort e.to_s.strip
-          end
-          RSpec.configure do |config|
-            config.fixture_path = "#{::Rails.root}/spec/fixtures"
-            config.use_transactional_fixtures = true
-            config.infer_spec_type_from_file_location!
-            config.filter_rails_from_backtrace!
-          end
-          Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |file| require file }
-        RUBY
+        file_fixture("rails_helper.rb").read
       end
 
       def spec_helper
-        # Generated from rails g rspec:install
-        # Comments removed
-        <<~RUBY
-          RSpec.configure do |config|
-            config.expect_with :rspec do |expectations|
-              expectations.include_chain_clauses_in_custom_matcher_descriptions = true
-            end
-
-            config.mock_with :rspec do |mocks|
-              mocks.verify_partial_doubles = true
-            end
-            config.shared_context_metadata_behavior = :apply_to_host_groups
-          end
-        RUBY
+        file_fixture("spec_helper.rb").read
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -81,11 +81,11 @@ module Suspenders::TestHelpers
     restore_file "config/application.rb"
   end
 
-  # TODO: Refactor existing tests to use this
   def with_test_suite(test_suite, &block)
     case test_suite
     when :minitest
       mkdir "test"
+      touch "test/test_helper.rb", content: file_fixture("test_helper.rb").read
     when :rspec
       mkdir "spec"
       touch "spec/spec_helper.rb"


### PR DESCRIPTION
Use `with_test_suite` helper to clean up existing test setup. This was more relevant when exploring #1156, but is still helpful for generators that are test suite agnostic.

Also cleans up test setup by using a `file_fixture` that was missed in #1183