### PR TITLE
Lint Generator: Account for breaking changes in ESLint

### DIFF
--- a/lib/generators/suspenders/lint_generator.rb
+++ b/lib/generators/suspenders/lint_generator.rb
@@ -14,8 +14,10 @@ module Suspenders
         end
       end
 
+      # TODO: Remove eslint version pin once the follownig is solved
+      # https://github.com/thoughtbot/eslint-config/issues/10
       def install_dependencies
-        run "yarn add stylelint eslint @thoughtbot/stylelint-config @thoughtbot/eslint-config npm-run-all prettier --dev"
+        run "yarn add stylelint eslint@^8.9.0 @thoughtbot/stylelint-config @thoughtbot/eslint-config npm-run-all prettier --dev"
       end
 
       def install_gems

--- a/test/generators/suspenders/lint_generator_test.rb
+++ b/test/generators/suspenders/lint_generator_test.rb
@@ -15,7 +15,7 @@ module Suspenders
         capture(:stderr) do
           output = run_generator
 
-          assert_match(/yarn add stylelint eslint @thoughtbot\/stylelint-config @thoughtbot\/eslint-config npm-run-all prettier --dev/, output)
+          assert_match(/yarn add stylelint eslint@\^8\.9\.0 @thoughtbot\/stylelint-config @thoughtbot\/eslint-config npm-run-all prettier --dev/, output)
         end
       end
 


### PR DESCRIPTION
The recent release of [ESLint v9.0.0][] made it so [flat config][] is the new default.

Until we can update [thoughtbot/eslint-config][] to [support][] this version, we'll pin ESLint to `^8.9.0` in an effort to ship this next release of Suspenders.

[ESLint v9.0.0]: https://eslint.org/blog/2024/04/eslint-v9.0.0-released/
[flat config]:  https://eslint.org/blog/2024/04/eslint-v9.0.0-released/#flat-config-is-now-the-default-and-has-some-changes
[thoughtbot/eslint-config]: https://github.com/thoughtbot/eslint-config
[support]: https://github.com/thoughtbot/eslint-config/issues/10