### PR TITLE
Test Cleanup: Update bundle assertions

### DIFF
--- a/test/generators/suspenders/accessibility_generator_test.rb
+++ b/test/generators/suspenders/accessibility_generator_test.rb
@@ -51,12 +51,9 @@ module Suspenders
       end
 
       test "installs gems with Bundler" do
-        Bundler.stubs(:with_unbundled_env).yields
-        generator.expects(:run).with("bundle install").once
+        output = run_generator
 
-        capture(:stdout) do
-          generator.add_capybara_gems
-        end
+        assert_match(/bundle install/, output)
       end
 
       test "generator has a description" do

--- a/test/generators/suspenders/factories_generator_test.rb
+++ b/test/generators/suspenders/factories_generator_test.rb
@@ -32,12 +32,9 @@ module Suspenders
 
       test "installs gem with Bundler" do
         with_test_suite :minitest do
-          Bundler.stubs(:with_unbundled_env).yields
-          generator.expects(:run).with("bundle install").once
+          output = run_generator
 
-          capture(:stdout) do
-            generator.add_factory_bot
-          end
+          assert_match(/bundle install/, output)
         end
       end
 

--- a/test/generators/suspenders/inline_svg_generator_test.rb
+++ b/test/generators/suspenders/inline_svg_generator_test.rb
@@ -46,12 +46,9 @@ module Suspenders
       end
 
       test "installs gems with Bundler" do
-        Bundler.stubs(:with_unbundled_env).yields
-        generator.expects(:run).with("bundle install").once
+        output = run_generator
 
-        capture(:stdout) do
-          generator.add_inline_svg_gem
-        end
+        assert_match(/bundle install/, output)
       end
 
       test "generator has a description" do


### PR DESCRIPTION
Rather than stub calls on Bundler, we simply assert the output of the generator to see if `bundle install` is called.