### PR TITLE
Test Cleanup: Remove generator description tests

### DIFF
--- a/test/generators/suspenders/accessibility_generator_test.rb
+++ b/test/generators/suspenders/accessibility_generator_test.rb
@@ -59,12 +59,6 @@ module Suspenders
         end
       end
 
-      test "generator has a description" do
-        description = "Installs capybara_accessibility_audit and capybara_accessible_selectors"
-
-        assert_match description, Suspenders::Generators::AccessibilityGenerator.desc
-      end
-
       private
 
       def prepare_destination

--- a/test/generators/suspenders/advisories_generator_test.rb
+++ b/test/generators/suspenders/advisories_generator_test.rb
@@ -31,17 +31,6 @@ module Suspenders
         assert_match(/bundle install/, output)
       end
 
-      test "generator has a description" do
-        description = <<~TEXT
-          Show security advisories during development.
-
-          Uses the `bundler-audit` gem to update the local security database and
-          show any relevant issues with the app's dependencies via a Rake task.
-        TEXT
-
-        assert_equal description, Suspenders::Generators::AdvisoriesGenerator.desc
-      end
-
       test "modifies Rakefile" do
         touch "Rakefile", content: <<~TEXT
           require_relative "config/application"

--- a/test/generators/suspenders/email_generator_test.rb
+++ b/test/generators/suspenders/email_generator_test.rb
@@ -49,10 +49,6 @@ module Suspenders
         assert_file app_root("config/environments/test.rb"), /config\.action_mailer\.default_url_options\s*=\s*{\s*host:\s*"www\.example\.com"\s*}/
       end
 
-      test "has custom description" do
-        assert_no_match(/Description/, generator_class.desc)
-      end
-
       private
 
       def prepare_destination

--- a/test/generators/suspenders/factories_generator_test.rb
+++ b/test/generators/suspenders/factories_generator_test.rb
@@ -11,25 +11,6 @@ module Suspenders
       setup :prepare_destination
       teardown :restore_destination
 
-      test "generator has a description" do
-        description = <<~TEXT
-          Build test data with clarity and ease.
-
-          This uses FactoryBot to help you define dummy and test data for your test
-          suite. The `create`, `build`, and `build_stubbed` class methods are directly
-          available to all tests.
-
-          We recommend putting FactoryBot definitions in one `spec/factories.rb` (or
-          `test/factories`) file, at least until it grows unwieldy. This helps reduce
-          confusion around circular dependencies and makes it easy to jump between
-          definitions.
-
-          Supports the default test suite and RSpec.
-        TEXT
-
-        assert_equal description, FactoriesGenerator.desc
-      end
-
       test "installs gem with Bundler" do
         with_test_suite :minitest do
           Bundler.stubs(:with_unbundled_env).yields

--- a/test/generators/suspenders/inline_svg_generator_test.rb
+++ b/test/generators/suspenders/inline_svg_generator_test.rb
@@ -54,12 +54,6 @@ module Suspenders
         end
       end
 
-      test "generator has a description" do
-        description = "Render SVG images inline, as a potential performance improvement for the viewer."
-
-        assert_match description, Suspenders::Generators::InlineSvgGenerator.desc
-      end
-
       test "configures raising an error when an SVG file is not found" do
         expected_configuration = file_fixture("inline_svg.rb").read
 

--- a/test/generators/suspenders/jobs_generator_test.rb
+++ b/test/generators/suspenders/jobs_generator_test.rb
@@ -29,12 +29,6 @@ module Suspenders
         assert_match(/bundle install/, output)
       end
 
-      test "generator has a description" do
-        description = "Installs Sidekiq for background job processing."
-
-        assert_match description, Suspenders::Generators::JobsGenerator.desc
-      end
-
       test "configures ActiveJob logging" do
         expected_configuration = file_fixture("active_job.rb").read
 

--- a/test/generators/suspenders/lint_generator_test.rb
+++ b/test/generators/suspenders/lint_generator_test.rb
@@ -141,12 +141,6 @@ module Suspenders
         end
       end
 
-      test "description" do
-        desc = "Creates a holistic linting solution that covers JavaScript, CSS, Ruby and ERB."
-
-        assert_match desc, generator_class.desc
-      end
-
       test "created package.json if one does not exist" do
         remove_file_if_exists "package.json"
 

--- a/test/generators/suspenders/prerequisites_generator_test.rb
+++ b/test/generators/suspenders/prerequisites_generator_test.rb
@@ -18,10 +18,6 @@ module Suspenders
         end
       end
 
-      test "has custom description" do
-        assert_no_match(/Description/, generator.class.desc)
-      end
-
       private
 
       def restore_destination

--- a/test/generators/suspenders/rake_generator_test.rb
+++ b/test/generators/suspenders/rake_generator_test.rb
@@ -21,15 +21,6 @@ module Suspenders
         end
       end
 
-      test "generator has a description" do
-        description = <<~TEXT
-          Configures the default Rake task to audit and lint the codebase with
-          `bundler-audit` and `standard`, in addition to running the test suite.
-        TEXT
-
-        assert_equal description, generator_class.desc
-      end
-
       private
 
       def prepare_destination

--- a/test/generators/suspenders/setup_generator_test.rb
+++ b/test/generators/suspenders/setup_generator_test.rb
@@ -21,10 +21,6 @@ module Suspenders
         end
       end
 
-      test "has a custom description" do
-        assert_no_match(/Description:/, generator_class.desc)
-      end
-
       private
 
       def prepare_destination

--- a/test/generators/suspenders/styles_generator_test.rb
+++ b/test/generators/suspenders/styles_generator_test.rb
@@ -108,10 +108,6 @@ module Suspenders
         assert_file app_root("app/assets/static/.gitkeep")
       end
 
-      test "generator has a custom description" do
-        assert_no_match(/Description/, generator_class.desc)
-      end
-
       private
 
       def prepare_destination

--- a/test/generators/suspenders/tasks_generator_test.rb
+++ b/test/generators/suspenders/tasks_generator_test.rb
@@ -29,10 +29,6 @@ module Suspenders
         assert_no_file app_root("lib/tasks/dev.rake")
       end
 
-      test "has a custom description" do
-        assert_no_match(/Description:/, generator_class.desc)
-      end
-
       private
 
       def dev_rake

--- a/test/generators/suspenders/testing_generator_test.rb
+++ b/test/generators/suspenders/testing_generator_test.rb
@@ -114,10 +114,6 @@ module Suspenders
         end
       end
 
-      test "has custom description" do
-        assert_no_match(/Description/, generator_class.desc)
-      end
-
       private
 
       def prepare_destination

--- a/test/generators/suspenders/views_generator_test.rb
+++ b/test/generators/suspenders/views_generator_test.rb
@@ -75,10 +75,6 @@ module Suspenders
         end
       end
 
-      test "has a custom description" do
-        assert_no_match(/Description:\n/, generator_class.desc)
-      end
-
       test "disables InstantClick" do
         run_generator
 


### PR DESCRIPTION
I no longer thing it's valuable to test if a generator has a custom description, because contributors would have to know to add these tests in the first place.