### PR TITLE
Generated README: Titleize app name

### DIFF
--- a/lib/suspenders/cleanup/generate_readme.rb
+++ b/lib/suspenders/cleanup/generate_readme.rb
@@ -31,7 +31,7 @@ module Suspenders
         File.open(readme, "w+") do |file|
           @file = file
 
-          heading app_name, level: 1
+          heading app_name.titleize, level: 1
 
           prerequisites
 

--- a/test/suspenders/cleanup/generate_readme_test.rb
+++ b/test/suspenders/cleanup/generate_readme_test.rb
@@ -9,7 +9,7 @@ module Suspenders
         Tempfile.create "README.md" do |readme|
           path = readme.path
 
-          Suspenders::Cleanup::GenerateReadme.perform(path, "Expected App Name")
+          Suspenders::Cleanup::GenerateReadme.perform(path, "ExpectedAppName")
 
           readme.rewind
           readme = readme.read


### PR DESCRIPTION
Follow-up to #1187

Since we derive the app name from a module name, we need to [titleize][] it so it reads better in the `README`.

Now `ExpectedAppName` will be rendered as `Expected App Name`.

[titleize]: https://api.rubyonrails.org/classes/ActiveSupport/Inflector.html#method-i-titleize