### PR TITLE
Prerequisites: Raise if Node version unsupported

### DIFF
--- a/lib/generators/suspenders/install/web_generator.rb
+++ b/lib/generators/suspenders/install/web_generator.rb
@@ -5,6 +5,7 @@ module Suspenders
         include Suspenders::Generators::APIAppUnsupported
         include Suspenders::Generators::DatabaseUnsupported
         include Suspenders::Generators::NodeNotInstalled
+        include Suspenders::Generators::NodeVersionUnsupported
 
         source_root File.expand_path("../../../templates/install/web", __FILE__)
         desc <<~MARKDOWN

--- a/lib/generators/suspenders/prerequisites_generator.rb
+++ b/lib/generators/suspenders/prerequisites_generator.rb
@@ -3,6 +3,7 @@ module Suspenders
     class PrerequisitesGenerator < Rails::Generators::Base
       include Suspenders::Generators::Helpers
       include Suspenders::Generators::NodeNotInstalled
+      include Suspenders::Generators::NodeVersionUnsupported
 
       source_root File.expand_path("../../templates/prerequisites", __FILE__)
 

--- a/lib/install/web.rb
+++ b/lib/install/web.rb
@@ -1,4 +1,17 @@
+extend Suspenders::Generators::Helpers
+
 def apply_template!
+  if node_not_installed? || node_version_unsupported?
+    message = <<~ERROR
+
+
+    === Node version unsupported ===
+
+    Suspenders requires Node >= #{Suspenders::MINIMUM_NODE_VERSION}
+    ERROR
+
+    fail Rails::Generators::Error, message
+  end
   if options[:database] == "postgresql" && options[:skip_test]
     after_bundle do
       gem_group :development, :test do

--- a/lib/install/web.rb
+++ b/lib/install/web.rb
@@ -1,4 +1,14 @@
-extend Suspenders::Generators::Helpers
+def node_version
+  ENV["NODE_VERSION"] || `node --version`[/\d+\.\d+\.\d+/]
+end
+
+def node_not_installed?
+  !node_version.present?
+end
+
+def node_version_unsupported?
+  node_version < "20.0.0"
+end
 
 def apply_template!
   if node_not_installed? || node_version_unsupported?
@@ -7,7 +17,7 @@ def apply_template!
 
     === Node version unsupported ===
 
-    Suspenders requires Node >= #{Suspenders::MINIMUM_NODE_VERSION}
+    Suspenders requires Node >= 20.0.0
     ERROR
 
     fail Rails::Generators::Error, message

--- a/lib/install/web.rb
+++ b/lib/install/web.rb
@@ -15,9 +15,9 @@ def apply_template!
     message = <<~ERROR
 
 
-    === Node version unsupported ===
+      === Node version unsupported ===
 
-    Suspenders requires Node >= 20.0.0
+      Suspenders requires Node >= 20.0.0
     ERROR
 
     fail Rails::Generators::Error, message

--- a/lib/suspenders/version.rb
+++ b/lib/suspenders/version.rb
@@ -2,4 +2,5 @@ module Suspenders
   VERSION = "3.0.0".freeze
   RAILS_VERSION = "~> 7.0".freeze
   MINIMUM_RUBY_VERSION = ">= 3.1".freeze
+  MINIMUM_NODE_VERSION = "20.0.0".freeze
 end

--- a/test/generators/suspenders/install/web_generator_test.rb
+++ b/test/generators/suspenders/install/web_generator_test.rb
@@ -38,6 +38,16 @@ module Suspenders
           end
         end
 
+        test "raises if Node is unsupported" do
+          Object.any_instance.stubs(:`).returns("v19.9.9\n")
+
+          with_database "postgresql" do
+            assert_raises Suspenders::Generators::NodeVersionUnsupported::Error do
+              run_generator
+            end
+          end
+        end
+
         private
 
         def prepare_destination

--- a/test/generators/suspenders/prerequisites_generator_test.rb
+++ b/test/generators/suspenders/prerequisites_generator_test.rb
@@ -12,22 +12,22 @@ module Suspenders
       teardown :restore_destination
 
       test "generates .node-version file (from ENV)" do
-        ClimateControl.modify NODE_VERSION: "1.2.3" do
+        ClimateControl.modify NODE_VERSION: "20.0.0" do
           run_generator
 
           assert_file app_root(".node-version") do |file|
-            assert_match(/1\.2\.3/, file)
+            assert_match(/20\.0\.0/, file)
           end
         end
       end
 
       test "generates .node-version file (from system)" do
-        Object.any_instance.stubs(:`).returns("v1.2.3\n")
+        Object.any_instance.stubs(:`).returns("v20.0.0\n")
 
         run_generator
 
         assert_file app_root(".node-version") do |file|
-          assert_match(/1\.2\.3/, file)
+          assert_match(/20\.0\.0/, file)
         end
       end
 
@@ -35,6 +35,16 @@ module Suspenders
         Object.any_instance.stubs(:`).returns("")
 
         assert_raises Suspenders::Generators::NodeNotInstalled::Error do
+          run_generator
+        end
+
+        assert_no_file app_root(".node-version")
+      end
+
+      test "raises if Node is unsupported" do
+        Object.any_instance.stubs(:`).returns("v19.9.9\n")
+
+        assert_raises Suspenders::Generators::NodeVersionUnsupported::Error do
           run_generator
         end
 

--- a/test/suspenders/cleanup/generate_readme_test.rb
+++ b/test/suspenders/cleanup/generate_readme_test.rb
@@ -6,7 +6,7 @@ module Suspenders
   module Cleanup
     class GenerateReadmeTest < ActiveSupport::TestCase
       test "generates README using generator descriptions" do
-        Object.any_instance.stubs(:`).returns("v1.2.3\n")
+        Object.any_instance.stubs(:`).returns("v20.0.0\n")
 
         Tempfile.create "README.md" do |readme|
           path = readme.path
@@ -20,7 +20,7 @@ module Suspenders
 
           assert_match "## Prerequisites", readme
           assert_match Suspenders::MINIMUM_RUBY_VERSION, readme
-          assert_match "Node: `1.2.3`", readme
+          assert_match "Node: `20.0.0`", readme
 
           assert_match "## Configuration", readme
           assert_match "### Test", readme

--- a/test/suspenders/generators_test.rb
+++ b/test/suspenders/generators_test.rb
@@ -17,7 +17,7 @@ class Suspenders::GeneratorsTest < ActiveSupport::TestCase
     end
   end
 
-  class NodeNotInstalledTest< ActiveSupport::TestCase
+  class NodeNotInstalledTest < ActiveSupport::TestCase
     test "message returns a custom message" do
       expected = "This generator requires Node"
 

--- a/test/suspenders/generators_test.rb
+++ b/test/suspenders/generators_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class Suspenders::GeneratorsTest < ActiveSupport::TestCase
-  class APIAppUnsupportedTest < Suspenders::GeneratorsTest
+  class APIAppUnsupportedTest < ActiveSupport::TestCase
     test "message returns a custom message" do
       expected = "This generator cannot be used on API only applications."
 
@@ -9,11 +9,27 @@ class Suspenders::GeneratorsTest < ActiveSupport::TestCase
     end
   end
 
-  class DatabaseUnsupportedTest < Suspenders::GeneratorsTest
+  class DatabaseUnsupportedTest < ActiveSupport::TestCase
     test "message returns a custom message" do
       expected = "This generator requires PostgreSQL"
 
       assert_equal expected, Suspenders::Generators::DatabaseUnsupported::Error.new.message
+    end
+  end
+
+  class NodeNotInstalledTest< ActiveSupport::TestCase
+    test "message returns a custom message" do
+      expected = "This generator requires Node"
+
+      assert_equal expected, Suspenders::Generators::NodeNotInstalled::Error.new.message
+    end
+  end
+
+  class NodeVersionUnsupportedTest < ActiveSupport::TestCase
+    test "message returns a custom message" do
+      expected = "This generator requires Node >= #{Suspenders::MINIMUM_NODE_VERSION}"
+
+      assert_equal expected, Suspenders::Generators::NodeVersionUnsupported::Error.new.message
     end
   end
 end

--- a/test/suspenders_test.rb
+++ b/test/suspenders_test.rb
@@ -12,4 +12,8 @@ class SuspendersTest < ActiveSupport::TestCase
   test "it has a Minimum Ruby version number" do
     assert Suspenders::MINIMUM_RUBY_VERSION
   end
+
+  test "it has a Minimum Node version number" do
+    assert Suspenders::MINIMUM_NODE_VERSION
+  end
 end


### PR DESCRIPTION
Follow-up to #1201

It's not enough to ensure Node is installed. We also need to ensure the consumer has the supported minimum version installed. Otherwise, subsequent generators will raise errors like so:

```
error stylelint-config-standard-scss@13.1.0: The engine "node" is incompatible with this module. Expected version ">=18.12.0". Got "18.0.0"
error Found incompatible module.
```

We select `v20.0.0` as our minimum supported version because it is slated for Active LTS, but is not bleeding edge at [this time][]

We also raise when calling the template to avoid unnecessarily generating a new Rails application.

[this time]: https://nodejs.org/en/about/previous-releases