### PR TITLE
Prepare for "Tailored" release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    suspenders (3.0.0)
+    suspenders (20240516.0)
       rails (~> 7.0)
 
 GEM

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-Unreleased
+20240516.0 (May, 16, 2024)
+
+"Tailored" release
 
 * Remove `suspenders` system executable and introduce [application template][]
 * Introduce `suspenders:accessibility` generator

--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 [![CI](https://github.com/thoughtbot/suspenders/actions/workflows/main.yml/badge.svg)](https://github.com/thoughtbot/suspenders/actions/workflows/main.yml)
 
-> [!NOTE]
-> You are viewing the latest build of Suspenders, but not the latest release.
-
 Suspenders is a [Rails Engine][] containing generators for configuring Rails
 applications with these [features][].
 
@@ -68,7 +65,7 @@ Suspenders can be used on an existing Rails application by adding it to the
 
 ```ruby
 group :development, :test do
-  gem "suspenders", github: "thoughtbot/suspenders"
+  gem "suspenders"
 end
 ```
 

--- a/lib/suspenders/version.rb
+++ b/lib/suspenders/version.rb
@@ -1,5 +1,5 @@
 module Suspenders
-  VERSION = "3.0.0".freeze
+  VERSION = "20240516.0".freeze
   RAILS_VERSION = "~> 7.0".freeze
   MINIMUM_RUBY_VERSION = ">= 3.1".freeze
   MINIMUM_NODE_VERSION = "20.0.0".freeze


### PR DESCRIPTION
With the merge of #1135 and some subsequent follow-ups, we are ready to
officially release the next version of Suspenders.

Because we moved to [calver][] in #1106, we need to continue using
calver, since the latest release `20230113.0` is greater than `3.0.0`,
which was set in haste in ab3eb9735eabd3c3827c7b6a9cce7d59e079559e

In an effort to better brand this release, we give it the code name
"Tailored".

[calver]: https://calver.org

