### PR TITLE
Application Template: Used released version

### DIFF
--- a/lib/install/web.rb
+++ b/lib/install/web.rb
@@ -25,7 +25,7 @@ def apply_template!
   if options[:database] == "postgresql" && options[:skip_test]
     after_bundle do
       gem_group :development, :test do
-        gem "suspenders", github: "thoughtbot/suspenders"
+        gem "suspenders"
       end
 
       run "bundle install"


### PR DESCRIPTION
Follow-up to #1206

Now that we've released `20240516.0`, we update the application template
to reference the released version on RubyGems.

This change doesn't require a new release, since this change just
affects the application template, and not the Gem itself.
