### PR TITLE
Specify a tag when installing capybara_accessible_selectors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 Unreleased
 
 * Require `--skip-rubocop` in favor of our [linting configuration][]
+* Fixed: [Specify a tag when installing capybara_accessible_selectors](https://github.com/thoughtbot/suspenders/issues/1228)
 
 [linting configuration]: https://github.com/thoughtbot/suspenders/blob/main/FEATURES.md#linting
 

--- a/lib/generators/suspenders/accessibility_generator.rb
+++ b/lib/generators/suspenders/accessibility_generator.rb
@@ -15,7 +15,7 @@ module Suspenders
       def add_capybara_gems
         gem_group :test do
           gem "capybara_accessibility_audit", github: "thoughtbot/capybara_accessibility_audit"
-          gem "capybara_accessible_selectors", github: "citizensadvice/capybara_accessible_selectors"
+          gem "capybara_accessible_selectors", github: "citizensadvice/capybara_accessible_selectors", tag: "v0.12.0"
         end
         Bundler.with_unbundled_env { run "bundle install" }
       end

--- a/test/generators/suspenders/accessibility_generator_test.rb
+++ b/test/generators/suspenders/accessibility_generator_test.rb
@@ -39,7 +39,7 @@ module Suspenders
         expected_output = <<~RUBY
           group :test do
             gem "capybara_accessibility_audit", github: "thoughtbot/capybara_accessibility_audit"
-            gem "capybara_accessible_selectors", github: "citizensadvice/capybara_accessible_selectors"
+            gem "capybara_accessible_selectors", github: "citizensadvice/capybara_accessible_selectors", tag: "v0.12.0"
           end
         RUBY
 


### PR DESCRIPTION
**This PR:**
- Closes [Issue 1228: Accessibility generator for capybara_accessible_selectors fails](https://github.com/thoughtbot/suspenders/issues/1228)
- Specifies a tag when installing capybara_accessible_selectors based on the [instructions](https://github.com/citizensadvice/capybara_accessible_selectors?tab=readme-ov-file#usage)

**Error without tag:**
```
Git error: command `git fetch --force --quiet --no-tags --depth 1 
-- https://github.com/citizensadvice/capybara_accessible_selectors.git 
refs/heads/HEAD:refs/heads/HEAD` 
in directory 
~/.asdf/installs/ruby/3.3.3/lib/ruby/gems/3.3.0/cache/bundler/git/capybara_accessible_selectors-7e28584b80a657a0689a0e8e8831f0d4fc91cb20 has failed.
Revision  does not exist in the repository 
https://github.com/citizensadvice/capybara_accessible_selectors.git. 
Maybe you misspelled it?
```

Co-authored-by: Steve Polito <stevepolito@hey.com>