### PR TITLE
Allow running against suspenders main

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@ Unreleased
 
 * Require `--skip-rubocop` in favor of our [linting configuration][]
 * Fixed: [Specify a tag when installing capybara_accessible_selectors](https://github.com/thoughtbot/suspenders/issues/1228)
+* Fixed: [Issue 1229: How do we want to handle un-released versions?](https://github.com/thoughtbot/suspenders/issues/1229)
 
 [linting configuration]: https://github.com/thoughtbot/suspenders/blob/main/FEATURES.md#linting
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ We skip [RuboCop rules by default][] in favor of our [holistic linting rules][].
 
 ```
 rails new app_name \
- --skip_rubocop \
+ --skip-rubocop \
  --skip-test \
  -d=postgresql \
  -m=https://raw.githubusercontent.com/thoughtbot/suspenders/main/lib/install/web.rb
@@ -50,7 +50,7 @@ rails new app_name \
 ```
 rails new app_name \
  --suspenders-main \
- --skip_rubocop \
+ --skip-rubocop \
  --skip-test \
  -d=postgresql \
  -m=https://raw.githubusercontent.com/thoughtbot/suspenders/main/lib/install/web.rb
@@ -62,7 +62,7 @@ Alternatively, if you're using our [dotfiles][], then you can just run `rails ne
 app_name`, or create your own [railsrc][] file with the following configuration:
 
 ```
---skip_rubocop
+--skip-rubocop
 --skip-test
 --database=postgresql
 -m=https://raw.githubusercontent.com/thoughtbot/suspenders/main/lib/install/web.rb

--- a/README.md
+++ b/README.md
@@ -35,8 +35,21 @@ PostgreSQL][] as our database.
 
 We skip [RuboCop rules by default][] in favor of our [holistic linting rules][].
 
+#### Use the latest suspenders release:
+
 ```
 rails new app_name \
+ --skip_rubocop \
+ --skip-test \
+ -d=postgresql \
+ -m=https://raw.githubusercontent.com/thoughtbot/suspenders/main/lib/install/web.rb
+```
+
+#### OR use the current (possibly unreleased) `main` branch of suspenders:
+
+```
+rails new app_name \
+ --suspenders_main \
  --skip_rubocop \
  --skip-test \
  -d=postgresql \

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ rails new app_name \
 
 ```
 rails new app_name \
- --suspenders_main \
+ --suspenders-main \
  --skip_rubocop \
  --skip-test \
  -d=postgresql \

--- a/lib/generators/suspenders/install/web_generator.rb
+++ b/lib/generators/suspenders/install/web_generator.rb
@@ -27,7 +27,7 @@ module Suspenders
 
           ```
           rails new app_name \\
-          --suspenders_main \\
+          --suspenders-main \\
           --skip_rubocop \\
           --skip-test \\
           -d=postgresql \\

--- a/lib/generators/suspenders/install/web_generator.rb
+++ b/lib/generators/suspenders/install/web_generator.rb
@@ -13,11 +13,24 @@ module Suspenders
 
           This generatator is intended to be invoked as part of an [application template][].
 
+          #### Use the latest suspenders release:
+
           ```
-          rails new <app_name> \
+          rails new <app_name> \\
           --skip-rubocop \\
-          --skip-test \
-          -d=postgresql \
+          --skip-test \\
+          -d=postgresql \\
+          -m=https://raw.githubusercontent.com/thoughtbot/suspenders/main/lib/install/web.rb
+          ```
+
+          #### OR use the current (possibly unreleased) `main` branch of suspenders:
+
+          ```
+          rails new app_name \\
+          --suspenders_main \\
+          --skip_rubocop \\
+          --skip-test \\
+          -d=postgresql \\
           -m=https://raw.githubusercontent.com/thoughtbot/suspenders/main/lib/install/web.rb
           ```
 

--- a/lib/generators/suspenders/install/web_generator.rb
+++ b/lib/generators/suspenders/install/web_generator.rb
@@ -28,7 +28,7 @@ module Suspenders
           ```
           rails new app_name \\
           --suspenders-main \\
-          --skip_rubocop \\
+          --skip-rubocop \\
           --skip-test \\
           -d=postgresql \\
           -m=https://raw.githubusercontent.com/thoughtbot/suspenders/main/lib/install/web.rb

--- a/lib/install/web.rb
+++ b/lib/install/web.rb
@@ -25,7 +25,7 @@ def apply_template!
   if options[:database] == "postgresql" && options[:skip_test] && options[:skip_rubocop]
     after_bundle do
       gem_group :development, :test do
-        if ARGV.include?("--suspenders_main")
+        if ARGV.include?("--suspenders-main")
           gem "suspenders", github: "thoughtbot/suspenders", branch: "main"
         else
           gem "suspenders"
@@ -54,7 +54,7 @@ def apply_template!
 
       # OR use the current (possibly unreleased) `main` branch of suspenders:
       rails new <app_name> \\
-      --suspenders_main \\
+      --suspenders-main \\
       --skip-rubocop \\
       --skip-test \\
       -d=postgresql \\

--- a/lib/install/web.rb
+++ b/lib/install/web.rb
@@ -24,8 +24,14 @@ def apply_template!
   end
   if options[:database] == "postgresql" && options[:skip_test] && options[:skip_rubocop]
     after_bundle do
-      gem_group :development, :test do
-        gem "suspenders"
+      if ARGV.include?("--suspenders_main")
+        gem_group :development, :test do
+          gem "suspenders", github: "thoughtbot/suspenders", branch: "main"
+        end
+      else
+        gem_group :development, :test do
+          gem "suspenders"
+        end
       end
 
       run "bundle install"
@@ -41,12 +47,22 @@ def apply_template!
 
       === Please use the correct options ===
 
+      # Use the latest suspenders release:
       rails new <app_name> \\
       --skip-rubocop \\
       --skip-test \\
       -d=postgresql \\
       -m=https://raw.githubusercontent.com/thoughtbot/suspenders/main/lib/install/web.rb
-    ERROR
+
+      # OR use the current (possibly unreleased) `main` branch of suspenders:
+      rails new <app_name> \\
+      --suspenders_main \\
+      --skip-rubocop \\
+      --skip-test \\
+      -d=postgresql \\
+      -m=https://raw.githubusercontent.com/thoughtbot/suspenders/main/lib/install/web.rb
+
+      ERROR
 
     fail Rails::Generators::Error, message
   end

--- a/lib/install/web.rb
+++ b/lib/install/web.rb
@@ -60,7 +60,7 @@ def apply_template!
       -d=postgresql \\
       -m=https://raw.githubusercontent.com/thoughtbot/suspenders/main/lib/install/web.rb
 
-      ERROR
+    ERROR
 
     fail Rails::Generators::Error, message
   end

--- a/lib/install/web.rb
+++ b/lib/install/web.rb
@@ -24,12 +24,10 @@ def apply_template!
   end
   if options[:database] == "postgresql" && options[:skip_test] && options[:skip_rubocop]
     after_bundle do
-      if ARGV.include?("--suspenders_main")
-        gem_group :development, :test do
+      gem_group :development, :test do
+        if ARGV.include?("--suspenders_main")
           gem "suspenders", github: "thoughtbot/suspenders", branch: "main"
-        end
-      else
-        gem_group :development, :test do
+        else
           gem "suspenders"
         end
       end


### PR DESCRIPTION
**This PR:**
- Fixes [Issue 1229: How do we want to handle un-released versions?](https://github.com/thoughtbot/suspenders/issues/1229)
- Allows passing a `--suspenders-main` parameter to use the `main` branch of suspenders instead of the latest released version
- Updates documentation to suggest `skip-rubocop` over `skip_rubocop`

**Example:**
```
rails new app_name \
 --suspenders-main \
 --skip-rubocop \
 --skip-test \
 -d=postgresql \
 -m=https://raw.githubusercontent.com/thoughtbot/suspenders/main/lib/install/web.rb
```

Co-authored-by: Steve Polito <stevepolito@hey.com>