### PR TITLE
Ensure `bin/setup` works

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@ Unreleased
 * Fixed: [Specify a tag when installing capybara_accessible_selectors](https://github.com/thoughtbot/suspenders/issues/1228)
 * Fixed: [Issue 1229: How do we want to handle un-released versions?](https://github.com/thoughtbot/suspenders/issues/1229)
 * Fixed: [Issue 1222: README instructions for running the development server are wrong](https://github.com/thoughtbot/suspenders/issues/1222)
+* Fixed: [#1224](https://github.com/thoughtbot/suspenders/issues/1224)
 
 [linting configuration]: https://github.com/thoughtbot/suspenders/blob/main/FEATURES.md#linting
 

--- a/lib/install/web.rb
+++ b/lib/install/web.rb
@@ -36,6 +36,7 @@ def apply_template!
 
       generate "suspenders:install:web"
       rails_command "db:prepare"
+      rails_command "db:migrate"
 
       say "\nCongratulations! You just pulled our suspenders."
     end


### PR DESCRIPTION
Closes #1224

It's unclear why we need to run migrations, since we're already calling
[db:prepare][dbp] which does the following:

> If the database exists but the tables have not been created, the
command will load the schema, run any pending migrations, dump the
updated schema, and finally load the seed data. See the Seeding Data
documentation for more details.

However, I found that calling `db:migrate` in the application template
worked.

[dbp]: https://guides.rubyonrails.org/active_record_migrations.html#preparing-the-database
