### PR TITLE
Add support for SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This approach uses an [application template][] to generate a new Rails
 application with Suspenders.
 
 We skip the [default test framework][] in favor of [RSpec][], and [prefer
-PostgreSQL][] as our database.
+PostgreSQL][] as our database, although we do support SQLite.
 
 We skip [RuboCop rules by default][] in favor of our [holistic linting rules][].
 

--- a/lib/generators/suspenders/ci_generator.rb
+++ b/lib/generators/suspenders/ci_generator.rb
@@ -36,6 +36,10 @@ module Suspenders
         File.exist? "package.json"
       end
 
+      def using_postgres?
+        database_adapter == "postgresql"
+      end
+
       def has_gem?(name)
         Bundler.rubygems.find_name(name).any?
       end

--- a/lib/generators/templates/ci/ci.yml.tt
+++ b/lib/generators/templates/ci/ci.yml.tt
@@ -86,6 +86,7 @@ jobs:
     runs-on: ubuntu-latest
 
     services:
+      <%- if using_postgres? -%>
       postgres:
         image: postgres
         env:
@@ -94,6 +95,7 @@ jobs:
         ports:
           - 5432:5432
         options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
+      <%- end %>
 
       # redis:
       #   image: redis
@@ -127,7 +129,9 @@ jobs:
       - name: Run tests
         env:
           RAILS_ENV: test
+          <%- if using_postgres? -%>
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
+          <%- end -%>
           # REDIS_URL: redis://localhost:6379/0
         <%- if using_rspec? -%>
         run: bin/rails db:setup spec

--- a/lib/install/web.rb
+++ b/lib/install/web.rb
@@ -10,6 +10,10 @@ def node_version_unsupported?
   node_version < "20.0.0"
 end
 
+def database_supported?
+  ["postgresql", "sqlite"].include?(options[:database])
+end
+
 def apply_template!
   if node_not_installed? || node_version_unsupported?
     message = <<~ERROR
@@ -22,7 +26,7 @@ def apply_template!
 
     fail Rails::Generators::Error, message
   end
-  if options[:database] == "postgresql" && options[:skip_test] && options[:skip_rubocop]
+  if database_supported? && options[:skip_test] && options[:skip_rubocop]
     after_bundle do
       gem_group :development, :test do
         if ARGV.include?("--suspenders-main")

--- a/lib/suspenders/generators.rb
+++ b/lib/suspenders/generators.rb
@@ -3,6 +3,12 @@ require "active_support/concern"
 module Suspenders
   module Generators
     module Helpers
+      def database_adapter
+        configuration = File.read(Rails.root.join("config/database.yml"))
+        configuration = YAML.safe_load(configuration, aliases: true)
+        configuration["default"]["adapter"]
+      end
+
       def default_test_suite?
         File.exist? Rails.root.join("test")
       end
@@ -62,7 +68,7 @@ module Suspenders
 
       class Error < StandardError
         def message
-          "This generator requires PostgreSQL"
+          "This generator requires either PostgreSQL or SQLite"
         end
       end
 
@@ -78,11 +84,7 @@ module Suspenders
         private
 
         def database_unsupported?
-          configuration = File.read(Rails.root.join("config/database.yml"))
-          configuration = YAML.safe_load(configuration, aliases: true)
-          adapter = configuration["default"]["adapter"]
-
-          adapter != "postgresql"
+          database_adapter != ("postgresql" || "sqlite")
         end
       end
     end

--- a/test/generators/suspenders/ci_generator_test.rb
+++ b/test/generators/suspenders/ci_generator_test.rb
@@ -21,7 +21,7 @@ module Suspenders
 
       test "raises if PostgreSQL is not the adapter" do
         with_database "unsupported" do
-          assert_raises Suspenders::Generators::DatabaseUnsupported::Error, match: "This generator requires PostgreSQL" do
+          assert_raises Suspenders::Generators::DatabaseUnsupported::Error, match: "This generator requires either PostgreSQL or SQLite" do
             run_generator
 
             assert_no_file app_root(".github/workflows/ci.yaml")

--- a/test/generators/suspenders/install/web_generator_test.rb
+++ b/test/generators/suspenders/install/web_generator_test.rb
@@ -20,7 +20,7 @@ module Suspenders
           end
         end
 
-        test "raises if PostgreSQL is not the adapter" do
+        test "raises if the provided database is not supported" do
           with_database "unsupported" do
             assert_raises Suspenders::Generators::DatabaseUnsupported::Error do
               run_generator

--- a/test/suspenders/generators_test.rb
+++ b/test/suspenders/generators_test.rb
@@ -1,6 +1,17 @@
 require "test_helper"
 
 class Suspenders::GeneratorsTest < ActiveSupport::TestCase
+  class HelpersTest < ActiveSupport::TestCase
+    include Suspenders::TestHelpers
+    include Suspenders::Generators::Helpers
+
+    test "database_adapter returns the current database" do
+      with_database "postgresql" do
+        assert_equal database_adapter, "postgresql"
+      end
+    end
+  end
+
   class APIAppUnsupportedTest < ActiveSupport::TestCase
     test "message returns a custom message" do
       expected = "This generator cannot be used on API only applications."
@@ -11,7 +22,7 @@ class Suspenders::GeneratorsTest < ActiveSupport::TestCase
 
   class DatabaseUnsupportedTest < ActiveSupport::TestCase
     test "message returns a custom message" do
-      expected = "This generator requires PostgreSQL"
+      expected = "This generator requires either PostgreSQL or SQLite"
 
       assert_equal expected, Suspenders::Generators::DatabaseUnsupported::Error.new.message
     end


### PR DESCRIPTION
With increasing interest in SQLite across the Rails community as a whole, it's valuable for us to start exploring it too. This expands the existing checks for PostgreSQL to also include SQLite so that where we want to try out SQLite we're able to. It also adjusts the CI workflow to exclude PostgreSQL when generating a SQLite-based application.

https://rubyonrails.org/2024/11/7/rails-8-no-paas-required
https://fractaledmind.github.io/tags/sqlite/

Closes #1245