### PR TITLE
Force creation of GitHub Actions CI workflow

### DIFF
--- a/lib/generators/suspenders/ci_generator.rb
+++ b/lib/generators/suspenders/ci_generator.rb
@@ -12,8 +12,7 @@ module Suspenders
       MARKDOWN
 
       def ci_files
-        empty_directory ".github/workflows"
-        template "ci.yml", ".github/workflows/ci.yml"
+        template "ci.yml", ".github/workflows/ci.yml", force: true
       end
 
       private

--- a/test/generators/suspenders/ci_generator_test.rb
+++ b/test/generators/suspenders/ci_generator_test.rb
@@ -11,6 +11,9 @@ module Suspenders
       teardown :restore_destination
 
       test "generates CI files" do
+        mkdir(".github/workflows")
+        touch(".github/workflows/ci.yml")
+
         with_database "postgresql" do
           run_generator
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,7 +35,7 @@ module Suspenders::TestHelpers
   def mkdir(dir)
     path = app_root dir
 
-    FileUtils.mkdir path
+    FileUtils.mkdir_p path
   end
 
   def touch(file, **options)


### PR DESCRIPTION
Since we switched to using `.yml` for YAML files in #1246, generating the CI config would clash and request the user intervene. We force the template to overwrite instead.

Completes #1243.