### PR TITLE
Spend less time waiting for Postgres in CI

### DIFF
--- a/lib/generators/templates/ci/ci.yml.tt
+++ b/lib/generators/templates/ci/ci.yml.tt
@@ -93,7 +93,7 @@ jobs:
           POSTGRES_PASSWORD: postgres
         ports:
           - 5432:5432
-        options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: --health-cmd="pg_isready" --health-interval=10ms --health-timeout=500ms --health-retries=15
 
       # redis:
       #   image: redis


### PR DESCRIPTION
Postgres boots fairly quickly on GitHub, so we can check sooner and save some time instead of waiting.

In informal testing, this consistently sped up the "Initialize containers" step of CI by 10 seconds.

P.S. I took this tip from [this excellent article on Boring Rails](https://boringrails.com/articles/building-a-rails-ci-pipeline-with-github-actions/). (Cmd-F `postgresql service`.)