### PR TITLE
Optimize for Heroku

### DIFF
--- a/lib/templates/Procfile
+++ b/lib/templates/Procfile
@@ -1,0 +1,2 @@
+release: bundle exec rails db:migrate; bundle exec rails db:seed
+web: bundle exec puma -C config/puma.rb

--- a/lib/templates/web.rb
+++ b/lib/templates/web.rb
@@ -9,11 +9,29 @@ end
 install_gems
 
 after_bundle do
+  # Initializers & Configuration
+  configure_database
+
+  # Deployment
+  add_procfiles
+
   # Finalization
   run_migrations
   lint_codebase
 
   print_message
+end
+
+def configure_database
+  gsub_file "config/database.yml", /^production:.*?password:.*?\n/m, <<~YAML
+    production:
+      <<: *default
+      url: <%= ENV["DATABASE_URL"] %>
+  YAML
+end
+
+def add_procfiles
+  copy_file "Procfile"
 end
 
 def run_migrations


### PR DESCRIPTION
Introduces [Procfile][1] to automatically start the server and run migrations during the [release phase][2].

Additionally, we update our [database connection preference][3] to account for [nuance in connecting with Heroku][4].

[1]: https://devcenter.heroku.com/articles/getting-started-with-rails8#create-a-procfile
[2]: https://devcenter.heroku.com/articles/release-phase
[3]: https://guides.rubyonrails.org/configuring.html#connection-preference
[4]: https://discuss.rubyonrails.org/t/brainstorming-approaches-to-reconcile-rails-8s-default-multi-db-setup-with-database-url/86769