### PR TITLE
Configure test suite

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,8 +73,8 @@ jobs:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
         working-directory: /tmp/test_app
         run: |
-          bin/rails db:test:prepare
-          bin/rails test:all
+          bin/rails db:setup
+          bin/rails spec
       - name: Verify app can start
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432

--- a/lib/templates/spec/factories_spec.rb
+++ b/lib/templates/spec/factories_spec.rb
@@ -1,0 +1,7 @@
+require "rails_helper"
+
+RSpec.describe "Factories" do
+  it "has valid factoties" do
+    FactoryBot.lint traits: true
+  end
+end

--- a/lib/templates/spec/support/action_mailer.rb
+++ b/lib/templates/spec/support/action_mailer.rb
@@ -1,0 +1,11 @@
+RSpec.configure do |config|
+  # https://guides.rubyonrails.org/testing.html#the-basic-test-case
+  #
+  # The ActionMailer::Base.deliveries array is only reset automatically in
+  # ActionMailer::TestCase and ActionDispatch::IntegrationTest tests. If
+  # you want to have a clean slate outside these test cases, you can reset
+  # it manually with: ActionMailer::Base.deliveries.clear
+  config.before(:each) do
+    ActionMailer::Base.deliveries.clear
+  end
+end

--- a/lib/templates/spec/support/driver.rb
+++ b/lib/templates/spec/support/driver.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.before(:each, type: :system) do
+    driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
+  end
+end

--- a/lib/templates/spec/support/factory_bot.rb
+++ b/lib/templates/spec/support/factory_bot.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end

--- a/lib/templates/spec/support/i18n.rb
+++ b/lib/templates/spec/support/i18n.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include ActionView::Helpers::TranslationHelper
+end

--- a/lib/templates/spec/support/shoulda_matchers.rb
+++ b/lib/templates/spec/support/shoulda_matchers.rb
@@ -1,0 +1,6 @@
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
Lifts from the existing [testing][], [factories][] and [ci][] generators, while also relying on the fact that some of these files will already exist. For example, `.github/workflows/ci.yml` will be generated by Rails, we just need to modify the file.

The previous version of Suspenders could be invoked on an **existing** application, but this new version is intended to be used when creating **new** applications. Since we're calling `rails new` with `--skip-test` we know that the `.github/workflows/ci.yml` will be missing the test steps.

Also, this commit enables all the "recommended" settings in `spec_helper`, which
is a change from the current version.

This commit also updates the library's CI script to account for the fact that the generated applicaiton uses RSpec.

[testing]: https://github.com/thoughtbot/suspenders/blob/main/lib/generators/suspenders/ci_generator.rb
[factories]: https://github.com/thoughtbot/suspenders/blob/main/lib/generators/suspenders/ci_generator.rb
[ci]: https://github.com/thoughtbot/suspenders/blob/main/lib/generators/suspenders/ci_generator.rb
