### PR TITLE
Update layout

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -155,29 +155,6 @@ Configures the `test` environment to use the [inline][] adapter.
 
 ## Layout and Assets
 
-### Stylesheets
-
-- Uses [PostCSS][] via [cssbundling-rails][].
-- Uses [modern-normalize][] to normalize browsers' default style.
-
-Configuration can be found at `postcss.config.js`.
-
-Adds the following stylesheet structure.
-
-```
-app/assets/stylesheets/base.css
-app/assets/stylesheets/components.css
-app/assets/stylesheets/utilities.css
-```
-
-Adds `app/assets/static` so that [postcss-url][] has a directory to copy
-assets to.
-
-[PostCSS]: https://postcss.org
-[cssbundling-rails]: https://github.com/rails/cssbundling-rails
-[modern-normalize]: https://github.com/sindresorhus/modern-normalize
-[postcss-url]: https://github.com/postcss/postcss-url
-
 ### Inline SVG
 
 Uses [inline_svg][] for embedding SVG documents into views.
@@ -189,8 +166,8 @@ Configuration can be found at `config/initializers/inline_svg.rb`
 ### Layout
 
 - A [partial][] for [flash messages][] is located in `app/views/application/_flashes.html.erb`.
+- A [partial][] for form errors is located in `app/views/application/_form_errors.html.erb`.
 - Sets [lang][] attribute on `<html>` element to `en` via `I18n.local`.
-- Dynamically sets `<title>` via the [title][] gem.
 - Disables Turbo's [Prefetch][] in an effort to reduce unnecessary network requests.
 
 [partial]: https://guides.rubyonrails.org/layouts_and_rendering.html#using-partials

--- a/lib/templates/app/views/application/_flashes.html.erb
+++ b/lib/templates/app/views/application/_flashes.html.erb
@@ -1,0 +1,9 @@
+<% if flash.any? %>
+  <div>
+    <% flash.each do |type, message| -%>
+      <div role="alert">
+        <%= message %>
+      </div>
+    <% end -%>
+  </div>
+<% end %>

--- a/lib/templates/app/views/application/_form_errors.html.erb
+++ b/lib/templates/app/views/application/_form_errors.html.erb
@@ -1,0 +1,11 @@
+<%# locals: (resource: ) %>
+
+<% if resource.errors.any? %>
+  <div id="error_explanation" role="alert" data-turbo-cache="false">
+    <ul>
+      <% resource.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/lib/templates/web.rb
+++ b/lib/templates/web.rb
@@ -36,6 +36,9 @@ after_bundle do
   update_bin_dev
   add_procfiles
 
+  # Views
+  update_layout
+
   # Finalization
   run_migrations
   lint_codebase
@@ -222,6 +225,24 @@ end
 def add_procfiles
   copy_file "Procfile"
   copy_file "Procfile.dev"
+end
+
+def update_layout
+  # General partials
+  copy_file "app/views/application/_form_errors.html.erb"
+  copy_file "app/views/application/_flashes.html.erb"
+
+  # Application Layout
+  gsub_file "app/views/layouts/application.html.erb", /<html>/, "<html lang=\"<%= I18n.locale %>\">"
+  application_html_erb = <<-ERB
+    <%= render "nav" %>
+    <main class="container" aria-labelledby="main_label">
+      <%= render "flashes" %>
+      <%= yield %>
+    </main>
+  ERB
+  gsub_file "app/views/layouts/application.html.erb", /^    <%= yield %>\n/, application_html_erb
+  insert_into_file "app/views/layouts/application.html.erb", "    <meta name=\"turbo-prefetch\" content=\"false\">\n", after: "</title>\n"
 end
 
 def run_migrations


### PR DESCRIPTION
Lifted from existing [views generator][]. Note that we add a new `app/views/application/_form_errors.html.erb` partial, and no longer depend on the `title` gem, since Rails ships with a similar solution.

We also do not concern ourselves with any CSS framework (for now).

[views generator]: https://github.com/thoughtbot/suspenders/blob/main/lib/generators/suspenders/views_generator.rb