### PR TITLE
Configure development environment

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -34,14 +34,12 @@ Running `bin/setup` will run `dev:prime`.
 ### Development
 
 - Enables [raise_on_missing_translations][].
-- Enables [annotate_rendered_view_with_filenames][].
 - Enables [i18n_customize_full_message][].
-- Enables [query_log_tags_enabled][].
+- Enables [apply_rubocop_autocorrect_after_generate!][].
 
 [raise_on_missing_translations]: https://guides.rubyonrails.org/configuring.html#config-i18n-raise-on-missing-translations
-[annotate_rendered_view_with_filenames]: https://guides.rubyonrails.org/configuring.html#config-action-view-annotate-rendered-view-with-filenames
 [i18n_customize_full_message]: https://guides.rubyonrails.org/configuring.html#config-active-model-i18n-customize-full-message
-[query_log_tags_enabled]: https://guides.rubyonrails.org/configuring.html#config-active-record-query-log-tags-enabled
+[apply_rubocop_autocorrect_after_generate!]: https://guides.rubyonrails.org/configuring.html#configuring-generators
 
 ### Production
 

--- a/lib/templates/web.rb
+++ b/lib/templates/web.rb
@@ -39,6 +39,9 @@ after_bundle do
   configure_mailer_intercepter
   configure_inline_svg
 
+  # Environments
+  setup_development_environment
+
   # Deployment and server
   update_bin_dev
   add_procfiles
@@ -229,6 +232,12 @@ def configure_inline_svg
       config.raise_on_file_not_found = true
     end
   RUBY
+end
+
+def setup_development_environment
+  environment "config.active_model.i18n_customize_full_message = true", env: "development"
+  uncomment_lines "config/environments/development.rb", /config\.i18n\.raise_on_missing_translations/
+  uncomment_lines "config/environments/development.rb", /config\.generators\.apply_rubocop_autocorrect_after_generate!/
 end
 
 def update_bin_dev


### PR DESCRIPTION
Lifted from [development_generator][]. However, we do not need to enable `annotate_rendered_view_with_filenames` or `query_log_tags_enabled`, since those are now enabled by default. Also enables
`apply_rubocop_autocorrect_after_generate!` since this is a new option since the last release.

[development_generator]: https://github.com/thoughtbot/suspenders/blob/main/lib/generators/suspenders/environments/development_generator.rb