### PR TITLE
Introduce `suspenders -v` and `suspenders new app_name`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,12 +53,12 @@ jobs:
         run: gem install rails
       - name: Install dependencies
         run: bundle install
-      - name: Install Staples
+      - name: Install Suspenders
         run: bundle exec rake install
       - name: Generate new Rails app with template
         run: |
           cd /tmp
-          suspenders test_app
+          suspenders new test_app
       - name: Set up generated app
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432

--- a/exe/suspenders
+++ b/exe/suspenders
@@ -2,19 +2,27 @@
 
 require_relative "../lib/suspenders"
 
-if ARGV[0].nil? || ARGV[0].empty?
-  puts "Error: Application name required"
-  puts "Usage: suspenders APP_NAME"
+if ARGV.length > 2 || ARGV.length == 0
+  puts "Error: Invalid command"
+  puts "Available commands are"
+  puts "suspenders new APP_NAME"
+  puts "suspenders -v"
   exit 1
 end
 
-if ARGV.length > 1
-  puts "Error: Too many arguments (#{ARGV.length} given)"
-  puts "Usage: suspenders APP_NAME"
-  exit 1
-end
+command = ARGV[0]
+app_name = ARGV[1]
 
-app_name = ARGV[0]
+if ["-v", "--version"].include?(command)
+  puts Suspenders::VERSION
+  exit 0
+elsif ["new"].include?(command)
+  if app_name.nil? || app_name.empty?
+    puts "Error: Application name required"
+    puts "Usage: suspenders new APP_NAME"
+    exit 1
+  end
+end
 
 begin
   Suspenders::CLI.run(app_name)


### PR DESCRIPTION
Currently we do not support the options `-v` or `new` in Suspenders.

In this PR we introduce these two options and deprecating `suspenders app_name`