### PR TITLE
Improve CI script and fix broken layout

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,6 +67,22 @@ jobs:
           bundle install
           bin/setup --skip-server
           bin/rails db:migrate
+          bundle add high_voltage
+          mkdir app/views/pages
+          touch app/views/pages/home.html.erb
+          echo '<h1>Hello World!</h1>' >> app/views/pages/home.html.erb
+          touch spec/system/demo_system_spec.rb
+          cat << 'EOF' >> spec/system/demo_system_spec.rb
+          require "rails_helper"
+
+          RSpec.describe "Static page", type: :system do
+            it "passes" do
+              visit "/pages/home"
+
+              expect(page).to have_text("Hello World!")
+            end
+          end
+          EOF
       - name: Run tests in generated app
         env:
           RAILS_ENV: test

--- a/lib/templates/web.rb
+++ b/lib/templates/web.rb
@@ -299,7 +299,6 @@ def update_layout
   # Application Layout
   gsub_file "app/views/layouts/application.html.erb", /<html>/, "<html lang=\"<%= I18n.locale %>\">"
   application_html_erb = <<-ERB
-    <%= render "nav" %>
     <main class="container" aria-labelledby="main_label">
       <%= render "flashes" %>
       <%= yield %>


### PR DESCRIPTION
Prior to this commit, we had no specs to test.  This commit updates the CI script by adding a basic static page, and adding a corresponding system spec.

This revealed we had a broken layout, because we were including a partial that does not exist.