### PR TITLE
Ignore `/spec/examples.txt`

### DIFF
--- a/lib/templates/web.rb
+++ b/lib/templates/web.rb
@@ -102,6 +102,9 @@ def configure_test_suite
   copy_file "spec/factories_spec.rb"
   empty_directory "spec/system"
   create_file "spec/system/.gitkeep"
+
+  # Ignore spec/examples.txt
+  append_to_file ".gitignore", "/spec/examples.txt"
 end
 
 def configure_ci


### PR DESCRIPTION
Since we enable all the "recommended" RSpec features, we need to ignore `/spec/examples.txt`, since that feature is enabled.