### PR TITLE
Fix application layout

### DIFF
--- a/lib/templates/web.rb
+++ b/lib/templates/web.rb
@@ -276,7 +276,7 @@ def update_layout
   # Application Layout
   gsub_file "app/views/layouts/application.html.erb", /<html>/, "<html lang=\"<%= I18n.locale %>\">"
   application_html_erb = <<-ERB
-    <main class="container" aria-labelledby="main_label">
+    <main>
       <%= render "flashes" %>
       <%= yield %>
     </main>


### PR DESCRIPTION
The previous code was lifted from Staples. Although there wasn't anything incorrect about it, we don't need a `class` or `aria-labelledby` attributes. Those can be added as needed.