### PR TITLE
Introduce `development:db:seed` and `development:db:seed:replant` tasks

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -2,9 +2,36 @@
 
 ## Local Development
 
+### Strong Migrations
+
 Uses [Strong Migrations][] to catch unsafe migrations in development.
 
 [Strong Migrations]: https://github.com/ankane/strong_migrations
+
+### Seed Data
+
+Follows [our guidance][seed-data-guide] for managing seed data. Use
+`db/seeds.rb` for data required in **all** environments, and
+`development:db:seed` for data specific to development environments.
+
+Place idempotent seed data in `Development::Seeder`.
+
+To load development seed data:
+
+```bash
+bin/rails development:db:seed
+```
+
+To reset your database and reload seed data:
+
+```bash
+bin/rails development:db:seed:replant
+```
+
+The `replant` command truncates all tables and reloads the seed data, providing
+a clean slate for development.
+
+[seed-data-guide]: https://github.com/thoughtbot/guides/blob/main/rails/how-to/seed-data.md
 
 ## Environment Variables
 

--- a/lib/templates/lib/development/seeder.rb
+++ b/lib/templates/lib/development/seeder.rb
@@ -1,0 +1,21 @@
+# This file should ensure the existence of records required to run the application in development.
+# The code here should be idempotent so that it can be executed at any point in development.
+# The data can then be loaded with the bin/rails development:db:seed command.
+
+module Development
+  class Seeder
+    def self.load_seeds
+      if Rails.env.development?
+        new.load_seeds
+      else
+        raise "Development::Seeder can only be run in a development environment."
+      end
+    end
+
+    def load_seeds
+      #   ["Ruby", "Ralph"].each do |name|
+      #     User.find_or_create_by!(name:)
+      #   end
+    end
+  end
+end

--- a/lib/templates/lib/tasks/development.rake
+++ b/lib/templates/lib/tasks/development.rake
@@ -1,0 +1,15 @@
+if Rails.env.development?
+  namespace :development do
+    namespace :db do
+      desc "Loads seed data into development."
+      task seed: ["environment", "db:seed"] do
+        Development::Seeder.load_seeds
+      end
+
+      namespace :seed do
+        desc "Truncate tables of each database for development and loads seed data."
+        task replant: ["environment", "db:truncate_all", "development:db:seed"]
+      end
+    end
+  end
+end

--- a/lib/templates/web.rb
+++ b/lib/templates/web.rb
@@ -42,6 +42,7 @@ after_bundle do
   configure_strong_migrations
   configure_mailer_intercepter
   configure_inline_svg
+  configure_development_seeder
 
   # Environments
   setup_test_environment
@@ -214,6 +215,12 @@ def configure_inline_svg
   RUBY
 end
 
+def configure_development_seeder
+  copy_file "lib/development/seeder.rb"
+  copy_file "lib/tasks/development.rake"
+  gsub_file "config/application.rb", /config\.autoload_lib\(ignore: %w\[assets tasks\]\)/, "config.autoload_lib(ignore: %w[assets tasks development])"
+end
+
 def setup_test_environment
   gsub_file "config/environments/test.rb", /config\.action_dispatch\.show_exceptions = :rescuable/, "config.action_dispatch.show_exceptions = :none"
   uncomment_lines "config/environments/test.rb", /config\.i18n\.raise_on_missing_translations/
@@ -299,17 +306,42 @@ def update_readme
 
       [Suspenders]: https://github.com/thoughtbot/suspenders
  
-      ## Local Server
+      ## Local Development
 
       Run `bin/dev` to start the web server and Sidekiq worker. Then, navigate to [http://localhost:3000][local]
 
       [local]: http://localhost:3000
 
-      ## Local Development
+      ### Strong Migrations
 
       Uses [Strong Migrations][] to catch unsafe migrations in development.
 
       [Strong Migrations]: https://github.com/ankane/strong_migrations
+
+      ### Seed Data
+
+      Follows [our guidance][seed-data-guide] for managing seed data.
+
+      Use `db/seeds.rb` for data required in **all** environments, and `development:db:seed` for data specific to development environments.
+
+      Place idempotent seed data in `Development::Seeder`.
+
+      To load development seed data:
+
+      ```bash
+      bin/rails development:db:seed
+      ```
+
+      To reset your database and reload seed data:
+
+      ```bash
+      bin/rails development:db:seed:replant
+      ```
+
+      The `replant` command truncates all tables and reloads the seed data, providing
+      a clean slate for development.
+
+      [seed-data-guide]: https://github.com/thoughtbot/guides/blob/main/rails/how-to/seed-data.md
 
       ## Environment Variables
 


### PR DESCRIPTION
This closes #1251.

Since `db:seeds.rb` is intended to ensure

> ... the existence of records required to run the application in every
environment (production, development, test)

we have relied on [`dev:prime`][1] for loading data necessary for users to view most of the features of the app in development.

However, there were a few areas of improvement.

First, rename `dev` namespace to `development`, and rename [`prime`][1] task to `seed` for improved clarity.

Then, introduces `development:db:seed:replant` take to create parity with the existing `db:seed:replant` task.

Introduces `Development::Seeder` class to encapsulate seed data, which is called in the `development:db:seed` and `development:db:seed:replant` tasks. The advantage to this is that the class can be called independently from the task, and can also be [unit tested][2].

Finally, we ignore this class from being auto-loaded, since it's intended for development use.

[1]: https://thoughtbot.com/blog/priming-the-pump
[2]: https://thoughtbot.com/blog/seeds-of-destruction