### PR TITLE
Update status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Suspenders
 
-[![CI](https://github.com/thoughtbot/suspenders/actions/workflows/main.yml/badge.svg)](https://github.com/thoughtbot/suspenders/actions/workflows/main.yml)
+[![CI](https://github.com/thoughtbot/suspenders/actions/workflows/test-template.yml/badge.svg)](https://github.com/thoughtbot/suspenders/actions/workflows/test-template.yml)
 
 Suspenders is intended to create a new Rails applications with these
 [features][], and is optimized for deployment on Heroku.


### PR DESCRIPTION
Now that we've updated our CI to account for the new build, we update
the badge in the README to reflect that.

We're getting a failure for `update-templates`, but that's not related
to the library.
