### PR TITLE
Introduce issue template, and update contributing guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,14 @@
 # Contributing
 
+[Bug reports][bugs] and [pull requests][prs] are welcome on GitHub at https://github.com/thoughtbot/suspenders.
+
+[bugs]: https://github.com/thoughtbot/suspenders/issues/new?template=bug_report.md
+[prs]: https://github.com/thoughtbot/top_secret/pulls
+
+Please create a [new discussion][discussion] if you want to share ideas for new features.
+
+[discussion]: https://github.com/thoughtbot/suspenders/discussions/new?category=ideas
+
 We love contributions from everyone.
 By participating in this project,
 you agree to abide by the thoughtbot [code of conduct].

--- a/ISSUE_TEMPLATE/bug_report.md
+++ b/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Library Information**
+ - Ruby Version [e.g. 3.4.5]
+ - Version [e.g. 0.1.1]
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
Moving forward, I'd like to keep issues scoped to bugs. Anything else
should be treated as a discussion, since those accounted for nearly all
of our previous issues.
