### PR TITLE
Add `libvips` package to generated `ci.yml`

### DIFF
--- a/lib/templates/web.rb
+++ b/lib/templates/web.rb
@@ -139,7 +139,7 @@ def configure_ci
 
       steps:
         - name: Install packages
-          run: sudo apt-get update && sudo apt-get install --no-install-recommends -y libpq-dev
+          run: sudo apt-get update && sudo apt-get install --no-install-recommends -y libpq-dev libvips
 
         - name: Checkout code
           uses: actions/checkout@v5


### PR DESCRIPTION
Relates to https://github.com/rails/rails/pull/56523

Since we call `--skip-test`, changes to `ci.yml` will never be picked
up. So, we add the `libvips` package to the generated `ci.yml` since that
package is necessary for Active Storage.
