### PR TITLE
Configure Action Cable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 Unreleased
 
+* Updated: Configure Action Cable
+
 20260127.0 (January 27, 2026)
 
 * Updated: `shoulda-matchers` to `v7.0`.


### PR DESCRIPTION
Closes #1327.

This commit fixes two problems.

First, it improves the developer experience by changing the [subscription
adapter][sa] from `async` to `redis`. Doing this accounts for the
following pain point:

> The async adapter only works within the same process, so for manually
triggering cable updates from a console and seeing results in the
browser, you must do so from the web console (running inside the dev
process), not a terminal started via `bin/rails console`! Add `console` to
any action or any ERB template view to make the web console appear.

Next, we update the [Redis adapter][ra] in `production` to account for
Heroku's [requirements][req].

We don't need to uncomment the Redis related lines in
`.github/workflows/ci.yml` since we're not using Redis in our `test`
environment.

[sa]: https://guides.rubyonrails.org/action_cable_overview.html#subscription-adapter
[ra]: https://guides.rubyonrails.org/action_cable_overview.html#redis-adapter
[req]: https://devcenter.heroku.com/articles/connecting-heroku-redis#connecting-in-rails
