### PR TITLE
Require MFA for gem pushes

### DIFF
--- a/suspenders.gemspec
+++ b/suspenders.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["changelog_uri"] = "https://github.com/thoughtbot/suspenders/blob/main/NEWS.md"
+  spec.metadata["rubygems_mfa_required"] = "true"
 
   gemspec = File.basename(__FILE__)
   spec.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|


### PR DESCRIPTION
This adds the `rubygems_mfa_required` metadata to the gemspec, requiring multi-factor authentication for privileged operations on RubyGems.org.

This is a protection against supply chain attacks like the recent NPM Axios compromise: https://socket.dev/blog/axios-npm-package-compromised

Reference: https://guides.rubygems.org/mfa-requirement-opt-in/