### PR TITLE
Seed development seeds during bin/setup

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@ Unreleased
 
 * Added: AI harness. Downloads `.claude/CLAUDE.md` and `.claude/rules/` from [thoughtbot/guides](https://github.com/thoughtbot/guides/tree/main/rails/ai-rules).
 * Added: [letter_opener](https://github.com/ryanb/letter_opener) for email previews in development
+* Updated: Run the development seeder from `bin/setup`.
 
 20260325.0 (March 25, 2026)
 

--- a/lib/templates/web.rb
+++ b/lib/templates/web.rb
@@ -242,6 +242,14 @@ end
 def configure_development_seeder
   copy_file "lib/development/seeder.rb"
   copy_file "lib/tasks/development.rake"
+  inject_into_file "bin/setup", after: /system!.*db:reset.*\n/ do
+    "\n" + <<~RUBY.gsub(/^/, "  ")
+      if ENV.fetch("RAILS_ENV", "development") == "development"
+        puts "\\n== Loading development seed data =="
+        system! "bin/rails development:db:seed"
+      end
+    RUBY
+  end
 end
 
 def setup_test_environment

--- a/lib/templates/web.rb
+++ b/lib/templates/web.rb
@@ -244,7 +244,7 @@ def configure_development_seeder
   copy_file "lib/tasks/development.rake"
   inject_into_file "bin/setup", after: /system!.*db:reset.*\n/ do
     "\n" + <<~RUBY.gsub(/^/, "  ")
-      if ENV("RAILS_ENV") == "development"
+      if ENV["RAILS_ENV"] == "development"
         puts "\\n== Loading development seed data =="
         system! "bin/rails development:db:seed"
       end

--- a/lib/templates/web.rb
+++ b/lib/templates/web.rb
@@ -244,7 +244,7 @@ def configure_development_seeder
   copy_file "lib/tasks/development.rake"
   inject_into_file "bin/setup", after: /system!.*db:reset.*\n/ do
     "\n" + <<~RUBY.gsub(/^/, "  ")
-      if ENV["RAILS_ENV"] == "development"
+      if ENV.fetch("RAILS_ENV", "development") == "development"
         puts "\\n== Loading development seed data =="
         system! "bin/rails development:db:seed"
       end

--- a/lib/templates/web.rb
+++ b/lib/templates/web.rb
@@ -244,7 +244,7 @@ def configure_development_seeder
   copy_file "lib/tasks/development.rake"
   inject_into_file "bin/setup", after: /system!.*db:reset.*\n/ do
     "\n" + <<~RUBY.gsub(/^/, "  ")
-      if ENV.fetch("RAILS_ENV", "development") == "development"
+      if ENV("RAILS_ENV") == "development"
         puts "\\n== Loading development seed data =="
         system! "bin/rails development:db:seed"
       end


### PR DESCRIPTION
Before, the development seeder was only reachable by manually running `bin/rails development:db:seed` after setup. Developers had to know to run this separately.

Now, bin/setup calls `development:db:seed` automatically after preparing the database. An environment guard skips the call in non-development environments.

---

As I was playing with a new suspenders app, I added development seeds to the seeder and then ran bin/setup expecting that the seeds would be populated for me. I didn't realise I needed to run the development seed command directly. I think this could be a nice quality of life improvement. Given data in the development seeder is expected to be seeded in development, then running bin/setup can help do this for us.

Let me know what you think.