### PR TITLE
Add M5 Mac support to platforms in Gemfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-23
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
Running this app on my macbook automatically adds this line to the Gemfile to enable support for M5s.

Adding this so it's available for others too.