### PR TITLE
Add Letter Opener

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -8,6 +8,12 @@ Uses [Hotwire Spark][] for live reloading during development.
 
 [Hotwire Spark]: https://github.com/hotwired/spark
 
+### Letter Opener
+
+Uses [Letter Opener][] to preview emails in the browser instead of sending them.
+
+[Letter Opener]: https://github.com/ryanb/letter_opener
+
 ### Strong Migrations
 
 Uses [Strong Migrations][] to catch unsafe migrations in development.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 Unreleased
 
 * Added: AI harness. Downloads `.claude/CLAUDE.md` and `.claude/rules/` from [thoughtbot/guides](https://github.com/thoughtbot/guides/tree/main/rails/ai-rules).
+* Added: [letter_opener](https://github.com/ryanb/letter_opener) for email previews in development
 
 20260325.0 (March 25, 2026)
 

--- a/lib/templates/web.rb
+++ b/lib/templates/web.rb
@@ -31,6 +31,7 @@ def install_gems
 
   gem_group :development do
     gem "hotwire-spark"
+    gem "letter_opener"
   end
 
   gem_group :development, :test do
@@ -252,6 +253,9 @@ def setup_development_environment
   environment "config.active_model.i18n_customize_full_message = true", env: "development"
   uncomment_lines "config/environments/development.rb", /config\.i18n\.raise_on_missing_translations/
   uncomment_lines "config/environments/development.rb", /config\.generators\.apply_rubocop_autocorrect_after_generate!/
+  insert_into_file "config/environments/development.rb",
+    "  config.action_mailer.delivery_method = :letter_opener\n  config.action_mailer.perform_deliveries = true\n",
+    after: /config\.action_mailer\.default_url_options.*\n/
 end
 
 def setup_production_environment
@@ -475,6 +479,8 @@ def update_readme
 
       ## Mailers
 
+      Uses [Letter Opener][] to preview emails in the browser during development instead of sending them.
+
       [Intercept][] emails in non-production environments by setting `INTERCEPTOR_ADDRESSES`.
 
       ```sh
@@ -485,6 +491,7 @@ def update_readme
 
       Interceptor can be found at `lib/email_interceptor.rb`.
 
+      [Letter Opener]: https://github.com/ryanb/letter_opener
       [Intercept]: https://guides.rubyonrails.org/action_mailer_basics.html#intercepting-emails
 
       ## Jobs


### PR DESCRIPTION
It is inevitable that an application will send email. In development, we don't want to actually send emails because a) we might accidentally send to a real person, and b) it's friction in the development flow to ensure you use an email you own, jump across to your email client, wait for it to be received etc.

This change introduces [letter_opener] in development only, so generated emails open automatically in the browser.

[letter_opener]: https://github.com/ryanb/letter_opener

---

I appreciate that Rails comes with [mailer interceptors](https://guides.rubyonrails.org/action_mailer_basics.html#intercepting-and-observing-emails) now but these need to be configured and the emails don't open in the browser which is a nice DX.