### PR TITLE
Consolidate duplicate groups in Gemfile

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ Unreleased
 * Added: AI harness. Downloads `.claude/CLAUDE.md` and `.claude/rules/` from [thoughtbot/guides](https://github.com/thoughtbot/guides/tree/main/rails/ai-rules).
 * Added: [letter_opener](https://github.com/ryanb/letter_opener) for email previews in development
 * Updated: Run the development seeder from `bin/setup`.
+* Updated: Consolidate duplicate gem groups in the generated Gemfile.
 
 20260325.0 (March 25, 2026)
 

--- a/lib/suspenders.rb
+++ b/lib/suspenders.rb
@@ -2,6 +2,7 @@
 
 require_relative "suspenders/version"
 require_relative "suspenders/cli"
+require_relative "suspenders/gemfile_consolidator"
 
 module Suspenders
   class Error < StandardError; end

--- a/lib/suspenders/gemfile_consolidator.rb
+++ b/lib/suspenders/gemfile_consolidator.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Suspenders
+  class GemfileConsolidator
+    GROUP_BLOCK = /^group\s+(.+?)\s+do\n(.*?)\nend\n/m
+
+    def self.call(content)
+      new(content).call
+    end
+
+    def initialize(content)
+      @content = content
+    end
+
+    def call
+      tidy(top_level) + grouped.map { |key, bodies| render(key, bodies) }.join
+    end
+
+    private
+
+    attr_reader :content
+
+    def top_level
+      content.gsub(GROUP_BLOCK, "")
+    end
+
+    def grouped
+      content.scan(GROUP_BLOCK).each_with_object({}) do |(key, body), groups|
+        (groups[key.strip] ||= []) << body
+      end
+    end
+
+    def tidy(text)
+      collapse_blank_lines(ensure_single_trailing_newline(text))
+    end
+
+    def collapse_blank_lines(text)
+      text.gsub(/\n{3,}/, "\n\n")
+    end
+
+    def ensure_single_trailing_newline(text)
+      text.sub(/\n+\z/, "\n")
+    end
+
+    def render(key, bodies)
+      "\ngroup #{key} do\n#{bodies.join("\n\n")}\nend\n"
+    end
+  end
+end

--- a/lib/templates/web.rb
+++ b/lib/templates/web.rb
@@ -1,4 +1,5 @@
 require "suspenders/version"
+require "suspenders/gemfile_consolidator"
 require "net/http"
 require "json"
 
@@ -43,6 +44,7 @@ end
 install_gems
 
 after_bundle do
+  consolidate_gemfile_groups
   commit_initial_application_state
 
   # Initializers & Configuration
@@ -81,6 +83,10 @@ end
 
 def commit_initial_application_state
   git add: ".", commit: %(-m 'Initial commit from rails new') unless ENV["CI"]
+end
+
+def consolidate_gemfile_groups
+  File.write("Gemfile", Suspenders::GemfileConsolidator.call(File.read("Gemfile")))
 end
 
 def configure_database

--- a/spec/suspenders/gemfile_consolidator_spec.rb
+++ b/spec/suspenders/gemfile_consolidator_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+RSpec.describe Suspenders::GemfileConsolidator do
+  describe ".call" do
+    it "merges duplicate group blocks and preserves top-level gems" do
+      input = <<~GEMFILE
+        source "https://rubygems.org"
+
+        gem "rails"
+
+        group :development, :test do
+          gem "debug"
+        end
+
+        group :development do
+          gem "web-console"
+        end
+        gem "sidekiq"
+
+        group :test do
+          gem "capybara"
+        end
+
+        group :development do
+          gem "hotwire-spark"
+        end
+
+        group :development, :test do
+          gem "rspec-rails"
+        end
+      GEMFILE
+
+      expected = <<~GEMFILE
+        source "https://rubygems.org"
+
+        gem "rails"
+
+        gem "sidekiq"
+
+        group :development, :test do
+          gem "debug"
+
+          gem "rspec-rails"
+        end
+
+        group :development do
+          gem "web-console"
+
+          gem "hotwire-spark"
+        end
+
+        group :test do
+          gem "capybara"
+        end
+      GEMFILE
+
+      expect(described_class.call(input)).to eq(expected)
+    end
+  end
+end


### PR DESCRIPTION
Closes #1345

Prior to this commit, the generated `Gemfile` would create duplicate `group`
blocks, rather than append existing ones.
