### PR TITLE
Add Prosopite for N+1 query detection

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -20,6 +20,13 @@ Uses [Strong Migrations][] to catch unsafe migrations in development.
 
 [Strong Migrations]: https://github.com/ankane/strong_migrations
 
+### Prosopite
+
+Uses [Prosopite][] to detect N+1 queries in development and test,
+complementing the built-in strict loading protection.
+
+[Prosopite]: https://github.com/charkost/prosopite
+
 ### Seed Data
 
 Follows [our guidance][seed-data-guide] for managing seed data. Use

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -22,8 +22,7 @@ Uses [Strong Migrations][] to catch unsafe migrations in development.
 
 ### Prosopite
 
-Uses [Prosopite][] to detect N+1 queries in development and test,
-complementing the built-in strict loading protection.
+Uses [Prosopite][] to detect N+1 queries in development and test.
 
 [Prosopite]: https://github.com/charkost/prosopite
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@ Unreleased
 
 * Added: AI harness. Downloads `.claude/CLAUDE.md` and `.claude/rules/` from [thoughtbot/guides](https://github.com/thoughtbot/guides/tree/main/rails/ai-rules).
 * Added: [letter_opener](https://github.com/ryanb/letter_opener) for email previews in development
+* Added: [prosopite](https://github.com/charkost/prosopite) for N+1 query detection in development and test
 * Updated: Run the development seeder from `bin/setup`.
 * Updated: Consolidate duplicate gem groups in the generated Gemfile.
 

--- a/lib/templates/config/initializers/sidekiq.rb
+++ b/lib/templates/config/initializers/sidekiq.rb
@@ -7,6 +7,13 @@ SIDEKIQ_REDIS_CONFIGURATION = {
 
 Sidekiq.configure_server do |config|
   config.redis = SIDEKIQ_REDIS_CONFIGURATION
+
+  unless Rails.env.production?
+    config.server_middleware do |chain|
+      require "prosopite/middleware/sidekiq"
+      chain.add(Prosopite::Middleware::Sidekiq)
+    end
+  end
 end
 
 Sidekiq.configure_client do |config|

--- a/lib/templates/web.rb
+++ b/lib/templates/web.rb
@@ -37,6 +37,8 @@ def install_gems
 
   gem_group :development, :test do
     gem "factory_bot_rails"
+    gem "pg_query"
+    gem "prosopite"
     gem "rspec-rails", "~> 8.0.0"
   end
 end
@@ -54,6 +56,7 @@ after_bundle do
   configure_sidekiq
   configure_action_cable
   configure_strong_migrations
+  configure_prosopite
   configure_mailer_interceptor
   configure_inline_svg
   configure_development_seeder
@@ -219,6 +222,28 @@ def configure_strong_migrations
   rails_command "generate strong_migrations:install"
 end
 
+def configure_prosopite
+  initializer "prosopite.rb", <<~RUBY
+    unless Rails.env.production?
+      require "prosopite/middleware/rack"
+      Rails.configuration.middleware.use(Prosopite::Middleware::Rack)
+    end
+  RUBY
+
+  environment <<~RUBY, env: "development"
+    config.after_initialize do
+      Prosopite.rails_logger = true
+    end
+  RUBY
+
+  environment <<~RUBY, env: "test"
+    config.after_initialize do
+      Prosopite.rails_logger = true
+      Prosopite.raise = true
+    end
+  RUBY
+end
+
 def configure_mailer_interceptor
   lib "email_interceptor.rb", <<~RUBY
     class EmailInterceptor
@@ -357,6 +382,13 @@ def update_readme
       Uses [Strong Migrations][] to catch unsafe migrations in development.
 
       [Strong Migrations]: https://github.com/ankane/strong_migrations
+
+      ### N+1 Query Detection
+
+      Uses [Prosopite][] to detect N+1 queries, complementing the built-in
+      strict loading protection.
+
+      [Prosopite]: https://github.com/charkost/prosopite
 
       ### Seed Data
 

--- a/lib/templates/web.rb
+++ b/lib/templates/web.rb
@@ -305,8 +305,6 @@ def setup_production_environment
 end
 
 def setup_application
-  environment "config.active_record.strict_loading_by_default = true"
-  environment "config.active_record.strict_loading_mode = :n_plus_one_only"
   environment "config.require_master_key = true"
 end
 
@@ -385,8 +383,7 @@ def update_readme
 
       ### N+1 Query Detection
 
-      Uses [Prosopite][] to detect N+1 queries, complementing the built-in
-      strict loading protection.
+      Uses [Prosopite][] to detect N+1 queries.
 
       [Prosopite]: https://github.com/charkost/prosopite
 


### PR DESCRIPTION
Before, generated apps relied on `strict_loading_by_default` with the `:n_plus_one_only` mode for N+1 protection, which raises when an association is lazily loaded from a collection-loaded record. However, strict loading does not detect [all] N+1s.

Now, [Prosopite] scans web requests & Sidekiq jobs in development and test via its middleware. Detections are logged in development and raise `Prosopite::NPlusOneQueriesError` in test, so new apps fail their test suite on N+1 queries that strict loading can't see.

[all]: https://github.com/rails/rails/issues/56094
[Prosopite]: https://github.com/charkost/prosopite

Closes: https://github.com/thoughtbot/suspenders/discussions/1325